### PR TITLE
add basic CLI and config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,13 @@ and then visit `http://localhost:8000`, and sign in with your unix credentials.
 If you want multiple users to be able to sign into the server, you will need to run the
 `jupyterhub` command as a privileged user, such as root.
 
+### Some examples
+
+generate a default config file:
+
+    jupyterhub --generate-config
+
+spawn the server on 10.0.1.2:443 with https:
+
+    jupyterhub --ip 10.0.1.2 --port 443 --ssl-key my_ssl.key --ssl-cert my_ssl.cert
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -49,11 +49,9 @@ class Spawner(LoggingConfigurable):
         self._env_key(env, 'API_TOKEN', self.api_token)
         return env
     
-    cmd = List(Unicode, config=True,
+    cmd = List(Unicode, default_value=['jupyterhub-singleuser'], config=True,
         help="""The command used for starting notebooks."""
     )
-    def _cmd_default(self):
-        return ['jupyterhub-singleuser']
     
     @classmethod
     def fromJSON(cls, state, **kwargs):
@@ -183,8 +181,8 @@ class LocalProcessSpawner(Spawner):
     set_user = Enum(['sudo', 'setuid'], default_value='setuid', config=True,
         help="""scheme for setting the user of the spawned process
 
-        sudo can be more prudently restricted,
-        but setuid is simpler for a server run as root
+        'sudo' can be more prudently restricted,
+        but 'setuid' is simpler for a server run as root
         """
     )
     def _set_user_changed(self, name, old, new):

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -1,0 +1,11 @@
+"""Test the JupyterHubApp entry point"""
+
+import sys
+from subprocess import check_output
+
+def test_help_all():
+    out = check_output([sys.executable, '-m', 'jupyterhub', '--help-all']).decode('utf8', 'replace')
+    assert u'--ip' in out
+    assert u'--JupyterHubApp.ip' in out
+
+    


### PR DESCRIPTION
See `jupyterhub -h` for common shortcuts
- default config file: `jupyter_hub_config.py`
- generate config file with: `jupyterhub --generate-config`
- non-default config file: `jupyterhub -f myconfig.py`
