### PR TITLE
handle failure to check authorization

### DIFF
--- a/jupyterhub/singleuserapp.py
+++ b/jupyterhub/singleuserapp.py
@@ -44,8 +44,10 @@ def verify_token(self, token):
     )
     if r.status_code == 404:
         data = {'user' : ''}
+    elif r.status_code >= 400:
+        self.log.warn("Failed to check authorization: [%i] %s", r.status_code, r.reason)
+        data = None
     else:
-        r.raise_for_status()
         data = r.json()
     token_cache[token] = data
     return data
@@ -123,8 +125,8 @@ class SingleUserNotebookApp(NotebookApp):
         )
         s['token_cache'] = {}
         s['user'] = self.user
-        s['hub_api_key'] = env.pop('JPY_API_TOKEN', '')
-        s['cookie_secret'] = env.pop('JPY_COOKIE_SECRET', '')
+        s['hub_api_key'] = env['JPY_API_TOKEN']
+        s['cookie_secret'] = env['JPY_COOKIE_SECRET']
         s['cookie_name'] = self.cookie_name
         s['login_url'] = url_path_join(self.hub_prefix, 'login')
         s['hub_api_url'] = self.hub_api_url


### PR DESCRIPTION
in single-user app.

JPY_\* auth env variables are non-optional for single-user server. Refuse to start if they are undefined.
