### PR TITLE
more hooks for authenticators

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -9,6 +9,8 @@ import simplepam
 from IPython.config import LoggingConfigurable
 from IPython.utils.traitlets import Unicode, Set
 
+from .utils import url_path_join
+
 class Authenticator(LoggingConfigurable):
     """A class for authentication.
     
@@ -22,6 +24,7 @@ class Authenticator(LoggingConfigurable):
         If empty, allow any user to attempt login.
         """
     )
+    custom_html = Unicode('')
     
     @gen.coroutine
     def authenticate(self, handler, data):
@@ -31,6 +34,22 @@ class Authenticator(LoggingConfigurable):
         It must return the username on successful authentication,
         and return None on failed authentication.
         """
+    
+    def login_url(self, base_url):
+        """Override to register a custom login handler"""
+        return url_path_join(base_url, 'login')
+    
+    def logout_url(self, base_url):
+        """Override to register a custom logout handler"""
+        return url_path_join(base_url, 'logout')
+    
+    def get_handlers(self, app):
+        """Return any custom handlers the authenticator needs to register
+        
+        (e.g. for OAuth)
+        """
+        return []
+
 
 class PAMAuthenticator(Authenticator):
     encoding = Unicode('utf8', config=True,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -206,6 +206,7 @@ class BaseHandler(RequestHandler):
             base_url=self.hub.server.base_url,
             user=user,
             login_url=self.settings['login_url'],
+            logout_url=self.settings['logout_url'],
             static_url=self.static_url,
         )
 

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -25,6 +25,7 @@ class LoginHandler(BaseHandler):
                 next=url_escape(self.get_argument('next', default='')),
                 username=username,
                 message=message,
+                custom_html=self.authenticator.custom_html,
         )
     
     def get(self):

--- a/share/jupyter/templates/login.html
+++ b/share/jupyter/templates/login.html
@@ -6,6 +6,9 @@
 {% block main %}
 
 <div id="login-main" class="container">
+{% if custom_html %}
+{{custom_html}}
+{% else %}
   <form action="{{login_url}}?next={{next}}" method="post" role="form">
         <div class="input-group">
           <span class="input-group-addon">Username:</span>
@@ -24,6 +27,7 @@
     </div>
   </div>
   {% endif %}
+{% endif %}
 <div/>
 
 {% endblock %}

--- a/share/jupyter/templates/page.html
+++ b/share/jupyter/templates/page.html
@@ -83,9 +83,9 @@
 
     <span id="login_widget">
       {% if user %}
-        <a id="logout" class="btn navbar-btn btn-default pull-right" href="{{base_url}}logout">Logout</a>
+        <a id="logout" class="btn navbar-btn btn-default pull-right" href="{{logout_url}}">Logout</a>
       {% else %}
-        <a id="login" class="btn navbar-btn btn-default pull-right" href="{{base_url}}login">Login</a>
+        <a id="login" class="btn navbar-btn btn-default pull-right" href="{{login_url}}">Login</a>
       {% endif %}
     </span>
 


### PR DESCRIPTION
Allow authenticators to:
- register custom handlers
- change login and logout URLs
- replace the entire login form

This is enough to get oauth working with [this custom authenticator](https://gist.github.com/minrk/b823f6d0465c9a00fede) derived from [Kyle's example](https://github.com/rgbkrk/gitorn).

The weird thing about an OAuth authenticator is that `Authenticator.authenticate` is never called, it's all done with URL handlers.
