### PR TITLE
whitelist env to pass to spawned subprocesses

### DIFF
--- a/jupyterhub/singleuserapp.py
+++ b/jupyterhub/singleuserapp.py
@@ -125,8 +125,8 @@ class SingleUserNotebookApp(NotebookApp):
         )
         s['token_cache'] = {}
         s['user'] = self.user
-        s['hub_api_key'] = env['JPY_API_TOKEN']
-        s['cookie_secret'] = env['JPY_COOKIE_SECRET']
+        s['hub_api_key'] = env.pop('JPY_API_TOKEN')
+        s['cookie_secret'] = env.pop('JPY_COOKIE_SECRET')
         s['cookie_name'] = self.cookie_name
         s['login_url'] = url_path_join(self.hub_prefix, 'login')
         s['hub_api_url'] = self.hub_api_url

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -55,17 +55,25 @@ class Spawner(LoggingConfigurable):
         if new:
             self.cmd.append('--debug')
     
-    env_prefix = Unicode('JPY_')
-    def _env_key(self, d, key, value):
-        d['%s%s' % (self.env_prefix, key)] = value
-    
+    env_keep = List([
+        'PATH',
+        'PYTHONPATH',
+        'CONDA_ROOT',
+        'CONDA_DEFAULT_ENV',
+        'VIRTUAL_ENV',
+        'LANG',
+        'LC_ALL',
+    ], config=True,
+        help="Whitelist of environment variables for the subprocess to inherit"
+    )
     env = Dict()
     def _env_default(self):
-        env = os.environ.copy()
-        for key in ['HOME', 'USER', 'USERNAME', 'LOGNAME', 'LNAME']:
-            env.pop(key, None)
-        self._env_key(env, 'COOKIE_SECRET', self.user.server.cookie_secret)
-        self._env_key(env, 'API_TOKEN', self.api_token)
+        env = {}
+        for key in self.env_keep:
+            if key in os.environ:
+                env[key] = os.environ[key]
+        env['JPY_COOKIE_SECRET'] = self.user.server.cookie_secret
+        env['JPY_API_TOKEN'] = self.api_token
         return env
     
     cmd = List(Unicode, default_value=['jupyterhub-singleuser'], config=True,


### PR DESCRIPTION
rather than starting with everything.
Reduces risk of leaking security-related environment variables to kernels.
