### PR TITLE
Add Authenticator.add_user hook

### DIFF
--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -14,7 +14,7 @@ from IPython.utils.py3compat import unicode_type
 
 from ..spawner import LocalProcessSpawner
 from ..app import JupyterHubApp
-from ..auth import PAMAuthenticator
+from ..auth import PAMAuthenticator, Authenticator
 from .. import orm
 
 def mock_authenticate(username, password, service='login'):
@@ -46,6 +46,10 @@ class MockSpawner(LocalProcessSpawner):
 
 
 class MockPAMAuthenticator(PAMAuthenticator):
+    def system_user_exists(self, user):
+        # skip the add-system-user bit
+        return True
+    
     def authenticate(self, *args, **kwargs):
         with mock.patch('simplepam.authenticate', mock_authenticate):
             return super(MockPAMAuthenticator, self).authenticate(*args, **kwargs)


### PR DESCRIPTION
and .delete_user

This hook can be used to trigger events such as user validation or creating of system users.

Adds a LocalAuthenticator class that implements checking for and rudimentary creation of system users. PAMAuthenticator is a subclass of this, so it can create system users. Creation of system users is disabled by default, though.
