### PR TITLE
BUG: Fix unicode/str error when generating config file.

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -9,6 +9,7 @@ import io
 import logging
 import os
 from datetime import datetime
+from six import text_type
 from subprocess import Popen
 
 try:
@@ -654,8 +655,8 @@ class JupyterHubApp(Application):
                 answer = ask()
             if answer.startswith('n'):
                 return
-        
-        config_text = self.generate_config_file()
+
+        config_text = text_type(self.generate_config_file(), 'utf8')
         print("Writing default config to: %s" % self.config_file)
         with io.open(self.config_file, encoding='utf8', mode='w') as f:
             f.write(config_text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jinja2
 simplepam
 sqlalchemy
 requests
+six


### PR DESCRIPTION
Fixes a bug where doing `jupyterhub --generate-config` would generate the following stacktrace:

```
(jupyterhub)[~/clones/jupyterhub]@(master:b24df4f104)$ jupyterhub --generate-config
Overwrite jupyter_hub_config.py with default config? [y/N]y
Writing default config to: jupyter_hub_config.py
Traceback (most recent call last):
  File "/Users/ssanderson/.virtualenvs/jupyterhub/bin/jupyterhub", line 10, in <module>
    execfile(__file__)
  File "/Users/ssanderson/clones/jupyterhub/scripts/jupyterhub", line 4, in <module>
    main()
  File "/Users/ssanderson/clones/ipython/IPython/config/application.py", line 559, in launch_instance
    app.start()
  File "/Users/ssanderson/clones/jupyterhub/jupyterhub/app.py", line 686, in start
    self.write_config_file()
  File "/Users/ssanderson/clones/jupyterhub/jupyterhub/app.py", line 661, in write_config_file
    f.write(config_text)
TypeError: must be unicode, not str
```

It's possible that the real bug here is in `IPython.config.Application.generate_config`, which is not returning unicode when that appears to be the expectation here.  If so, feel free to disregard this PR.
