### PR TITLE
BUG: Only pass check_same_thread when using sqlite.

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -384,7 +384,8 @@ class CookieToken(Token, Base):
 
 def new_session(url="sqlite:///:memory:", reset=False, **kwargs):
     """Create a new session at url"""
-    kwargs.setdefault('connect_args', {'check_same_thread': False})
+    if url.startswith('sqlite'):
+        kwargs.setdefault('connect_args', {'check_same_thread': False})
     kwargs.setdefault('poolclass', StaticPool)
     engine = create_engine(url, **kwargs)
     Session = sessionmaker(bind=engine)


### PR DESCRIPTION
Suggested fix for https://github.com/jupyter/jupyterhub/issues/74.  I'd rather this use some sort of SQLAlchemy-blessed parsing function for determining the database engine from the url, but a quick perusal of the docs didn't turn up such a function.
