### PR TITLE
[WIP] Scope database sessions to API requests.

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -381,17 +381,16 @@ class CookieToken(Token, Base):
     __tablename__ = 'cookie_tokens'
 
 
-def new_session(url="sqlite:///:memory:", reset=False, **kwargs):
+def new_session_factory(url="sqlite:///:memory:", reset=False, **kwargs):
     """Create a new session at url"""
     if url.startswith('sqlite'):
         kwargs.setdefault('connect_args', {'check_same_thread': False})
     kwargs.setdefault('poolclass', StaticPool)
+
     engine = create_engine(url, **kwargs)
-    Session = sessionmaker(bind=engine)
-    session = Session()
     if reset:
         Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
-    return session
 
-
+    session_factory = sessionmaker(bind=engine)
+    return session_factory

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -15,14 +15,19 @@ from .mocking import MockHubApp
 
 
 # global db session object
-_db = None
+_session_factory = None
 
 @fixture
 def db():
     """Get a db session"""
-    global _db
-    if _db is None:
-        _db = orm.new_session('sqlite:///:memory:', echo=True)
+
+    global _session_factory
+    if _session_factory is None:
+        session = _session_factory()
+        _session_factory = orm.new_session_factory(
+            'sqlite:///:memory:',
+            echo=True,
+        )
         user = orm.User(
             name=getuser_unicode(),
             server=orm.Server(),
@@ -30,10 +35,13 @@ def db():
         hub = orm.Hub(
             server=orm.Server(),
         )
-        _db.add(user)
-        _db.add(hub)
-        _db.commit()
-    return _db
+        session.add(user)
+        session.add(hub)
+        session.commit()
+        session.close()
+
+    session = _session_factory()
+    return session
 
 
 @fixture

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -79,10 +79,12 @@ class MockHubApp(JupyterHubApp):
             # put initialize in start for SQLAlchemy threading reasons
             super(MockHubApp, self).initialize(argv=argv)
 
-            # add an initial user
-            user = orm.User(name='user')
-            self.db.add(user)
-            self.db.commit()
+            with self.new_db_session() as db:
+                # add an initial user
+                user = orm.User(name='user')
+                db.add(user)
+                db.commit()
+
             self.io_loop.add_callback(evt.set)
             super(MockHubApp, self).start()
         


### PR DESCRIPTION
WIP fix for #84.  The basic idea is to lazily create session objects for each HTTP Request, cleaning them up during the request's `finish` method, with some extra wrinkles thrown in because some of the Hub's management routines also make database queries, and these have less obvious natural scopes than HTTP Requests.

There are a few issues with this strategy that I'm not sure how to solve:
1. When a database object is queried in a new session, it loses any Python-only attributes that have been tacked onto it.  This means, in particular, that the spawner column on User doesn't persist between requests (the lone remaining test failure is caused by this).  I'm not sure whether it's important to persist the Python-level spawner.  If it is important, I'm not sure whether it could be straightforwardly persisted in the database.
2. Making this work with the Hub's management routines is pretty awkward.  In particular, there's a lot of manual moving of the Proxy between database sessions, and there's at least one location where I'm nesting calls to `new_db_session`.  I could probably deal with the latter by making `new_db_session` idempotent.
