### PR TITLE
remove incorrect link to favicon

### DIFF
--- a/share/jupyter/templates/page.html
+++ b/share/jupyter/templates/page.html
@@ -26,7 +26,6 @@
     <meta charset="utf-8">
 
     <title>{% block title %}Jupyter Hub{% endblock %}</title>
-    <link rel="shortcut icon" type="image/x-icon" href="{{static_url("images/favicon.ico") }}">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     


### PR DESCRIPTION
the favicon is already in the correct default location

closes #113
