### PR TITLE
polish cookie-secret PR

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -205,7 +205,7 @@ as follows:
 c.JupyterHub.cookie_secret_file = '/srv/jupyterhub/cookie_secret'
 ```
 
-The content of this file should be a long random string encoded in MIME Base64. An example would be to generate thisfile as:
+The content of this file should be a long random string encoded in MIME Base64. An example would be to generate this file as:
 
 ```bash
 openssl rand -base64 2048 > /srv/jupyterhub/cookie_secret
@@ -215,7 +215,7 @@ In most deployments of JupyterHub, you should point this to a secure location on
 system, such as `/srv/jupyterhub/cookie_secret`. If the cookie secret file doesn't exist when
 the Hub starts, a new cookie secret is generated and stored in the file. The
 file must not be readable by group or other or the server won't start.
-The recommended -permissions for the cookie secret file should be 600 (owner-only rw).
+The recommended permissions for the cookie secret file are 600 (owner-only rw).
 
 
 If you would like to avoid the need for files, the value can be loaded in the Hub process from

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -620,17 +620,17 @@ class JupyterHub(Application):
             self.log.info("Loading %s from %s", trait_name, secret_file)
             try:
                 perm = os.stat(secret_file).st_mode
-                assert not perm & 0o07, \
-                    "cookie_secret_file can be read or written by anybody"
+                if perm & 0o07:
+                    raise ValueError("cookie_secret_file can be read or written by anybody")
                 with open(secret_file) as f:
                     b64_secret = f.read()
                 secret = binascii.a2b_base64(b64_secret)
             except Exception as e:
                 self.log.error(
-                    "Refusing to run JuptyterHub with invalid cookie_secret_file. "
+                    "Refusing to run JupyterHub with invalid cookie_secret_file. "
                     "%s error was: %s",
                     secret_file, e)
-                sys.exit(1)
+                self.exit(1)
         if not secret:
             secret_from = 'new'
             self.log.debug("Generating new %s", trait_name)


### PR DESCRIPTION
- fix a couple of typos
- use ValueError instead of assert to ensure error is raised even when Python optimizes-out asserts