### PR TITLE
add ignored -e arg to docker login

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,5 +15,5 @@ deployment:
   hub:
     branch: master
     commands:
-      - docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - docker login -u $DOCKER_USER -p $DOCKER_PASS -e unused@example.com
       - docker push jupyterhub/jupyterhub-onbuild:${CIRCLE_TAG:-latest}


### PR DESCRIPTION
doesn't appear to be needed on more recent docker, but needed on circle-ci.

Verified that it works [on my branch](https://circleci.com/gh/minrk/jupyterhub/86), so merging right away.