### PR TITLE
check referer only if there is a valid user cookie

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -42,9 +42,13 @@ class APIHandler(BaseHandler):
     
     def get_current_user_cookie(self):
         """Override get_user_cookie to check Referer header"""
-        if not self.check_referer():
+        cookie_user = super().get_current_user_cookie()
+        # check referer only if there is a cookie user,
+        # avoiding misleading "Blocking Cross Origin" messages
+        # when there's no cookie set anyway.
+        if cookie_user and not self.check_referer():
             return None
-        return super().get_current_user_cookie()
+        return cookie_user
 
     def get_json_body(self):
         """Return the body of the request as JSON data."""


### PR DESCRIPTION
avoids misleading "Blocking Cross Origin..." message when there's no logged-in user for API requests.