### PR TITLE
disable codecov PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+# Disable coverage reports in PR comments
+comment:
+  branches: neverdothis


### PR DESCRIPTION
They've removed web app config, in favor of codecov.yml, discarding our existing config, which means huge, annoying coverage reports are showing up in most Jupyter PRs now.