### PR TITLE
Serve proxy error pages from the Hub

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -937,6 +937,7 @@ class JupyterHub(Application):
             '--api-ip', self.proxy.api_server.ip,
             '--api-port', str(self.proxy.api_server.port),
             '--default-target', self.hub.server.host,
+            '--error-target', url_path_join(self.hub.server.url, 'error'),
         ]
         if self.subdomain_host:
             cmd.append('--host-routing')

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -410,6 +410,7 @@ class BaseHandler(RequestHandler):
         """render custom error pages"""
         exc_info = kwargs.get('exc_info')
         message = ''
+        exception = None
         status_message = responses.get(status_code, 'Unknown HTTP Error')
         if exc_info:
             exception = exc_info[1]

--- a/share/jupyter/hub/templates/error.html
+++ b/share/jupyter/hub/templates/error.html
@@ -17,6 +17,11 @@
     {{message}}
   </p>
   {% endif %}
+  {% if message_html %}
+  <p>
+    {{message_html | safe}}
+  </p>
+  {% endif %}
   {% endblock error_detail %}
 </div>
 

--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -82,7 +82,7 @@
 
 <div id="header" class="navbar navbar-static-top">
   <div class="container">
-  <span id="jupyterhub-logo" class="pull-left"><a href="{{base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
+  <span id="jupyterhub-logo" class="pull-left"><a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
 
   {% block login_widget %}
 


### PR DESCRIPTION
Allows us to have better 503 error pages, for instance.

cc @ellisonbg