### PR TITLE
doc: Add section about API tokens

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -344,11 +344,11 @@ which is the place to put configuration that you want to affect all of your user
 
 ## External services
 
-JupyterHub has a REST API that can be used to run external services like the
+JupyterHub has a REST API that can be used by external services like the
 [cull_idle_servers](https://github.com/jupyterhub/jupyterhub/blob/master/examples/cull-idle/cull_idle_servers.py)
 script which monitors and kills idle single-user servers periodically. In order to run such an
-external service, you need to provide it an API token that - for the above example - is passed
-through an environment variable called `JPY_API_TOKEN`.
+external service, you need to provide it an API token. In the case of `cull_idle_servers`, it is passed
+as the environment variable called `JPY_API_TOKEN`.
 
 Currently there are two ways of registering that token with JupyterHub. The first on is to use
 the `jupyterhub` command to generate a token for a specific hub user:
@@ -370,7 +370,7 @@ and then write it to your JupyterHub configuration file (note that the **key** i
 c.JupyterHub.api_tokens = {'token' : 'username'}
 ```
 
-Upon restarting the daemon, you should see a message like below in the logs:
+Upon restarting JupyterHub, you should see a message like below in the logs:
 
 ```
 Adding API token for <username>

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -344,8 +344,40 @@ which is the place to put configuration that you want to affect all of your user
 
 ## External services
 
-JupyterHub has a REST API that can be used to run external services.
-More detail on this API will be added in the future.
+JupyterHub has a REST API that can be used to run external services like the
+[cull_idle_servers](https://github.com/jupyterhub/jupyterhub/blob/master/examples/cull-idle/cull_idle_servers.py)
+script which monitors and kills idle single-user servers periodically. In order to run such an
+external service, you need to provide it an API token that - for the above example - is passed
+through an environment variable called `JPY_API_TOKEN`.
+
+Currently there are two ways of registering that token with JupyterHub. The first on is to use
+the `jupyterhub` command to generate a token for a specific hub user:
+
+```
+$ jupyterhub token <username>
+```
+
+As of [version 0.6.0](./changelog.html), the preferred way of doing this is to first generate an API token:
+
+```
+$ openssl rand -hex 32
+```
+
+
+and then write it to your JupyterHub configuration file (note that the **key** is the token while the **value** is the username):
+
+```
+c.JupyterHub.api_tokens = {'token' : 'username'}
+```
+
+Upon restarting the daemon, you should see a message like below in the logs:
+
+```
+Adding API token for <username>
+```
+
+Now you can run your script by providing it the API token and it will authenticate through
+the REST API to interact with it.
 
 ## File locations
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -350,7 +350,7 @@ script which monitors and kills idle single-user servers periodically. In order 
 external service, you need to provide it an API token. In the case of `cull_idle_servers`, it is passed
 as the environment variable called `JPY_API_TOKEN`.
 
-Currently there are two ways of registering that token with JupyterHub. The first on is to use
+Currently there are two ways of registering that token with JupyterHub. The first one is to use
 the `jupyterhub` command to generate a token for a specific hub user:
 
 ```
@@ -376,7 +376,7 @@ Upon restarting JupyterHub, you should see a message like below in the logs:
 Adding API token for <username>
 ```
 
-Now you can run your script by providing it the API token and it will authenticate through
+Now you can run your script, i.e. `cull_idle_servers`, by providing it the API token and it will authenticate through
 the REST API to interact with it.
 
 ## File locations


### PR DESCRIPTION
This PR adds a small section about pregenerating API tokens and giving an example external service namely the cull_idle_servers.

#557 