### PR TITLE
Minor typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Notes on the `pip` command used in the installation directions below:
 
 JupyterHub can be installed with pip, and the proxy with npm:
 
-    npm install -g configurable-http-proxy
     pip3 install jupyterhub
 
 If you plan to run notebook servers locally, you may also need to install the


### PR DESCRIPTION
"npm install -g configurable-http-proxy" was written twice : in the dependecies section and in the Installation section