### PR TITLE
Run tests with an encoded base_url

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -902,6 +902,7 @@ class JupyterHub(Application):
         self.proxy.log = self.log
         self.proxy.public_server.ip = self.ip
         self.proxy.public_server.port = self.port
+        self.proxy.public_server.base_url = self.base_url
         self.proxy.api_server.ip = self.proxy_api_ip
         self.proxy.api_server.port = self.proxy_api_port
         self.proxy.api_server.base_url = '/api/routes/'

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -117,6 +117,8 @@ class MockHub(JupyterHub):
     
     last_activity_interval = 2
     
+    base_url = '/@/space%20word/'
+    
     @default('subdomain_host')
     def _subdomain_host_default(self):
         return os.environ.get('JUPYTERHUB_TEST_SUBDOMAIN_HOST', '')

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -13,7 +13,7 @@ from .. import orm
 from ..user import User
 from ..utils import url_path_join as ujoin
 from . import mocking
-from .mocking import public_url, user_url
+from .mocking import public_host, public_url, user_url
 
 
 def check_db_locks(func):
@@ -105,7 +105,7 @@ def test_auth_api(app):
 
 
 def test_referer_check(app, io_loop):
-    url = ujoin(public_url(app), app.hub.server.base_url)
+    url = ujoin(public_host(app), app.hub.server.base_url)
     host = urlparse(url).netloc
     user = find_user(app.db, 'admin')
     if user is None:
@@ -351,7 +351,7 @@ def test_spawn(app, io_loop):
     status = io_loop.run_sync(app_user.spawner.poll)
     assert status is None
 
-    assert user.server.base_url == '/user/%s' % name
+    assert user.server.base_url == ujoin(app.base_url, 'user/%s' % name)
     url = user_url(user, app)
     print(url)
     r = requests.get(url)


### PR DESCRIPTION
to ensure we get our escaping right

Mostly revealed fixes needed in tests so far, not code, but should catch regressions.