### PR TITLE
[WIP][services] add Authenticators.api_only_admins

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -158,6 +158,103 @@ paths:
       responses:
         '200':
           description: Sets a cookie granting the requesting admin access to the user's server
+  /groups:
+    get:
+      summary: List groups
+      responses:
+        '200':
+          description: The list of groups
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Group'
+  /groups/{name}:
+    get:
+      summary: Get a group by name
+      parameters:
+        - name: name
+          description: group name
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The group model
+          schema:
+            $ref: '#/definitions/Group'
+    post:
+      summary: Create a group
+      parameters:
+        - name: name
+          description: group name
+          in: path
+          required: true
+          type: string
+      responses:
+        '201':
+          description: The group has been created
+          schema:
+            $ref: '#/definitions/Group'
+    delete:
+      summary: Delete a group
+      parameters:
+        - name: name
+          description: group name
+          in: path
+          required: true
+          type: string
+      responses:
+        '204':
+          description: The group has been deleted
+  /groups/{name}/users:
+    post:
+      summary: add users to a group
+      parameters:
+        - name: name
+          description: group name
+          in: path
+          required: true
+          type: string
+        - name: data
+          in: body
+          required: true
+          description: The users to add to the group
+          schema:
+            type: object
+            properties:
+              users:
+                type: array
+                description: List of usernames to add to the group
+                items:
+                  type: string
+      responses:
+        '200':
+          description: The users have been added to the group
+          schema:
+            $ref: '#/definitions/Group'
+    delete:
+      summary: Remove users from a group
+      parameters:
+        - name: name
+          description: group name
+          in: path
+          required: true
+          type: string
+        - name: data
+          in: body
+          required: true
+          description: The users to add to the group
+          schema:
+            type: object
+            properties:
+              users:
+                type: array
+                description: List of usernames to add to the group
+                items:
+                  type: string
+      responses:
+        '200':
+          description: The users have been removed from the group
   /proxy:
     get:
       summary: Get the proxy's routing table
@@ -246,6 +343,11 @@ definitions:
       admin:
         type: boolean
         description: Whether the user is an admin
+      groups:
+        type: array
+        description: The names of groups of which this user is a member
+        items:
+          type: string
       server:
         type: string
         description: The user's server's base URL, if running; null if not.
@@ -257,3 +359,14 @@ definitions:
         type: string
         format: ISO8601 Timestamp
         description: Timestamp of last-seen activity from the user
+  Group:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The group's name
+      users:
+        type: array
+        description: The names of users who are members of this group
+        items:
+          type: string

--- a/jupyterhub/alembic/versions/99eca004846c_api_only.py
+++ b/jupyterhub/alembic/versions/99eca004846c_api_only.py
@@ -1,0 +1,27 @@
+"""api_only
+
+Add api_only column to users table.
+
+Revision ID: 99eca004846c
+Revises: eeb276e51423
+Create Date: 2016-06-03 14:49:54.451090
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '99eca004846c'
+down_revision = 'eeb276e51423'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('users', sa.Column('api_only', sa.Boolean))
+
+
+def downgrade():
+    # sqlite cannot downgrade because of limited ALTER TABLE support (no DROP COLUMN)
+    op.drop_column('users', 'api_only')

--- a/jupyterhub/apihandlers/__init__.py
+++ b/jupyterhub/apihandlers/__init__.py
@@ -3,9 +3,9 @@ from .auth import *
 from .hub import *
 from .proxy import *
 from .users import *
-
+from .groups import *
 from . import auth, hub, proxy, users
 
 default_handlers = []
-for mod in (auth, hub, proxy, users):
+for mod in (auth, hub, proxy, users, groups):
     default_handlers.extend(mod.default_handlers)

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -90,6 +90,7 @@ class APIHandler(BaseHandler):
         model = {
             'name': user.name,
             'admin': user.admin,
+            'groups': [ g.name for g in user.groups ],
             'server': user.url if user.running else None,
             'pending': None,
             'last_activity': user.last_activity.isoformat(),

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -87,6 +87,7 @@ class APIHandler(BaseHandler):
         }))
 
     def user_model(self, user):
+        """Get the JSON model for a User object"""
         model = {
             'name': user.name,
             'admin': user.admin,
@@ -100,22 +101,56 @@ class APIHandler(BaseHandler):
         elif user.stop_pending:
             model['pending'] = 'stop'
         return model
-    
-    _model_types = {
+
+    def group_model(self, group):
+        """Get the JSON model for a Group object"""
+        return {
+            'name': group.name,
+            'users': [ u.name for u in group.users ]
+        }
+
+    _user_model_types = {
         'name': str,
         'admin': bool,
+        'groups': list,
     }
-    
-    def _check_user_model(self, model):
+
+    _group_model_types = {
+        'name': str,
+        'users': list,
+    }
+
+    def _check_model(self, model, model_types, name):
+        """Check a model provided by a REST API request
+        
+        Args:
+            model (dict): user-provided model
+            model_types (dict): dict of key:type used to validate types and keys
+            name (str): name of the model, used in error messages
+        """
         if not isinstance(model, dict):
             raise web.HTTPError(400, "Invalid JSON data: %r" % model)
-        if not set(model).issubset(set(self._model_types)):
+        if not set(model).issubset(set(model_types)):
             raise web.HTTPError(400, "Invalid JSON keys: %r" % model)
         for key, value in model.items():
-            if not isinstance(value, self._model_types[key]):
-                raise web.HTTPError(400, "user.%s must be %s, not: %r" % (
-                    key, self._model_types[key], type(value)
+            if not isinstance(value, model_types[key]):
+                raise web.HTTPError(400, "%s.%s must be %s, not: %r" % (
+                    name, key, model_types[key], type(value)
                 ))
+
+    def _check_user_model(self, model):
+        """Check a request-provided user model from a REST API"""
+        return self._check_model(model, self._user_model_types, 'user')
+        for groupname in model.get('groups', []):
+            if not isinstance(groupname, str):
+                raise web.HTTPError(400, "group names must be str, not %r" % type(groupname))
+
+    def _check_group_model(self, model):
+        """Check a request-provided user model from a REST API"""
+        self._check_model(model, self._group_model_types, 'group')
+        for username in model.get('users', []):
+            if not isinstance(username, str):
+                raise web.HTTPError(400, "usernames must be str, not %r" % type(groupname))
 
     def options(self, *args, **kwargs):
         self.set_header('Access-Control-Allow-Headers', 'accept, content-type')

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -1,0 +1,136 @@
+"""Group handlers"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+
+from tornado import gen, web
+
+from .. import orm
+from ..utils import admin_only
+from .base import APIHandler
+
+
+class _GroupAPIHandler(APIHandler):
+    def _usernames_to_users(self, usernames):
+        """Turn a list of usernames into user objects"""
+        users = []
+        for username in usernames:
+            username = self.authenticator.normalize_username(username)
+            user = self.find_user(username)
+            if user is None:
+                raise web.HTTPError(400, "No such user: %s" % username)
+            users.append(user.orm_user)
+        return users
+
+    def find_group(self, name):
+        """Find and return a group by name.
+
+        Raise 404 if not found.
+        """
+        group = orm.Group.find(self.db, name=name)
+        if group is None:
+            raise web.HTTPError(404, "No such group: %s", name)
+        return group
+
+class GroupListAPIHandler(_GroupAPIHandler):
+    @admin_only
+    def get(self):
+        """List groups"""
+        data = [ self.group_model(g) for g in self.db.query(orm.Group) ]
+        self.write(json.dumps(data))
+
+
+class GroupAPIHandler(_GroupAPIHandler):
+    """View and modify groups by name"""
+
+    @admin_only
+    def get(self, name):
+        group = self.find_group(name)
+        self.write(json.dumps(self.group_model(group)))
+
+    @admin_only
+    @gen.coroutine
+    def post(self, name):
+        """POST creates a group by name"""
+        model = self.get_json_body()
+        if model is None:
+            model = {}
+        else:
+            self._check_group_model(model)
+
+        existing = orm.Group.find(self.db, name=name)
+        if existing is not None:
+            raise web.HTTPError(400, "Group %s already exists" % name)
+
+        usernames = model.get('users', [])
+        # check that users exist
+        users = self._usernames_to_users(usernames)
+
+        # create the group
+        self.log.info("Creating new group %s with %i users",
+            name, len(users),
+        )
+        self.log.debug("Users: %s", usernames)
+        group = orm.Group(name=name, users=users)
+        self.db.add(group)
+        self.db.commit()
+        self.write(json.dumps(self.group_model(group)))
+        self.set_status(201)
+
+    @admin_only
+    def delete(self, name):
+        """Delete a group by name"""
+        group = self.find_group(name)
+        self.log.info("Deleting group %s", name)
+        self.db.delete(group)
+        self.db.commit()
+        self.set_status(204)
+
+
+class GroupUsersAPIHandler(_GroupAPIHandler):
+    """Modify a group's user list"""
+    @admin_only
+    def post(self, name):
+        """POST adds users to a group"""
+        group = self.find_group(name)
+        data = self.get_json_body()
+        self._check_group_model(data)
+        if 'users' not in data:
+            raise web.HTTPError(400, "Must specify users to add")
+        self.log.info("Adding %i users to group %s", len(data['users']), name)
+        self.log.debug("Adding: %s", data['users'])
+        for user in self._usernames_to_users(data['users']):
+            if user not in group.users:
+                group.users.append(user)
+            else:
+                self.log.warning("User %s already in group %s", user.name, name)
+        self.db.commit()
+        self.write(json.dumps(self.group_model(group)))
+
+    @gen.coroutine
+    @admin_only
+    def delete(self, name):
+        """DELETE removes users from a group"""
+        group = self.find_group(name)
+        data = self.get_json_body()
+        self._check_group_model(data)
+        if 'users' not in data:
+            raise web.HTTPError(400, "Must specify users to delete")
+        self.log.info("Removing %i users from group %s", len(data['users']), name)
+        self.log.debug("Removing: %s", data['users'])
+        for user in self._usernames_to_users(data['users']):
+            if user in group.users:
+                group.users.remove(user)
+            else:
+                self.log.warning("User %s already not in group %s", user.name, name)
+        self.db.commit()
+        self.write(json.dumps(self.group_model(group)))
+
+
+default_handlers = [
+    (r"/api/groups", GroupListAPIHandler),
+    (r"/api/groups/([^/]+)", GroupAPIHandler),
+    (r"/api/groups/([^/]+)/users", GroupUsersAPIHandler),
+]

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -42,6 +42,15 @@ class Authenticator(LoggingConfigurable):
         If empty, allow any user to attempt login.
         """
     ).tag(config=True)
+    api_only_admins = Set(
+        help="""Set of usernames that are API-only.
+        
+        These are usernames that can only be authenticated via API key,
+        never login forms or OAuth setups.
+        
+        They are always administrators.
+        """
+    ).tag(config=True)
     custom_html = Unicode('',
         help="""HTML login form for custom handlers.
         Override in form-based custom authenticators

--- a/jupyterhub/dbutil.py
+++ b/jupyterhub/dbutil.py
@@ -80,3 +80,14 @@ def upgrade(db_url, revision='head'):
             ['alembic', '-c', alembic_ini, 'upgrade', revision]
         )
 
+def _alembic(*args):
+    """Run an alembic command with a temporary alembic.ini"""
+    with _temp_alembic_ini('sqlite:///jupyterhub.sqlite') as alembic_ini:
+        check_call(
+            ['alembic', '-c', alembic_ini] + list(args)
+        )
+
+
+if __name__ == '__main__':
+    import sys
+    _alembic(*sys.argv[1:])

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -16,7 +16,6 @@ from tornado.web import RequestHandler
 from tornado import gen, web
 
 from .. import orm
-from ..user import User
 from ..spawner import LocalProcessSpawner
 from ..utils import url_path_join
 
@@ -168,6 +167,11 @@ class BaseHandler(RequestHandler):
             self.log.warning("Invalid cookie token")
             # have cookie, but it's not valid. Clear it and start over.
             clear()
+        elif user.api_only:
+            # don't allow API-only users to login via cookie
+            self.log.error("Authenticated as {name} with cookie, but {name} is api-only",
+                extra={'name': user.name})
+            user = None
         return user
 
     def _user_from_orm(self, orm_user):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -307,6 +307,7 @@ class User(Base):
     _server_id = Column(Integer, ForeignKey('servers.id'))
     server = relationship(Server, primaryjoin=_server_id == Server.id)
     admin = Column(Boolean, default=False)
+    api_only = Column(Boolean, default=False)
     last_activity = Column(DateTime, default=datetime.utcnow)
 
     api_tokens = relationship("APIToken", backref="user")

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -21,14 +21,13 @@ def check_db_locks(func):
     Decorator for test functions that verifies no locks are held on the
     application's database upon exit by creating and dropping a dummy table.
 
-    Relies on an instance of JupyterhubApp being the first argument to the
+    Relies on an instance of JupyterHubApp being the first argument to the
     decorated function.
     """
 
-    def new_func(*args, **kwargs):
-        retval = func(*args, **kwargs)
+    def new_func(app, *args, **kwargs):
+        retval = func(app, *args, **kwargs)
 
-        app = args[0]
         temp_session = app.session_factory()
         temp_session.execute('CREATE TABLE dummy (foo INT)')
         temp_session.execute('DROP TABLE dummy')
@@ -159,12 +158,14 @@ def test_get_users(app):
     assert users == [
         {
             'name': 'admin',
+            'groups': [],
             'admin': True,
             'server': None,
             'pending': None,
         },
         {
             'name': 'user',
+            'groups': [],
             'admin': False,
             'server': None,
             'pending': None,
@@ -195,6 +196,7 @@ def test_get_user(app):
     user.pop('last_activity')
     assert user == {
         'name': name,
+        'groups': [],
         'admin': False,
         'server': None,
         'pending': None,

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -140,3 +140,20 @@ def test_cookie_secret_env(tmpdir):
     assert hub.cookie_secret == binascii.a2b_hex('abc123')
     assert not os.path.exists(hub.cookie_secret_file)
 
+
+def test_load_groups(io_loop):
+    to_load = {
+        'blue': ['cyclops', 'rogue', 'wolverine'],
+        'gold': ['storm', 'jean-grey', 'colossus'],
+    }
+    hub = MockHub(load_groups=to_load)
+    hub.init_db()
+    io_loop.run_sync(hub.init_users)
+    hub.init_groups()
+    db = hub.db
+    blue = orm.Group.find(db, name='blue')
+    assert blue is not None
+    assert sorted([ u.name for u in blue.users ]) == sorted(to_load['blue'])
+    gold = orm.Group.find(db, name='gold')
+    assert gold is not None
+    assert sorted([ u.name for u in gold.users ]) == sorted(to_load['gold'])

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -124,3 +124,17 @@ def test_spawn_fails(db, io_loop):
     assert user.server is None
     assert not user.running
 
+
+def test_groups(db):
+    user = orm.User(name='aeofel')
+    db.add(user)
+    
+    group = orm.Group(name='lives')
+    db.add(group)
+    db.commit()
+    assert group.users == []
+    assert user.groups == []
+    group.users.append(user)
+    db.commit()
+    assert group.users == [user]
+    assert user.groups == [group]

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -197,7 +197,8 @@ class User(HasTraits):
     def spawn(self, options=None):
         """Start the user's spawner"""
         db = self.db
-        
+        if self.api_only:
+            raise web.HTTPError(400, "User %s is api-only and not allowed to start a server." % self.name)
         self.server = orm.Server(
             cookie_name=self.cookie_name,
             base_url=self.base_url,


### PR DESCRIPTION
Adds notion of api-only admin users. This is part of services, and enables
services to get an API token that doesn't correspond to a 'real' user.

API-only users:

- are always admins
- cannot have servers
- do not have to exist on the system or whatever service the Authenticator wraps.

Alternately, we could add the notion of dedicated *services*, distinguishing them from users.
I will investigate this prior to committing to api_only users, but it might be a somewhat more complicated database change.