### PR TITLE
add Services to db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - npm install -g configurable-http-proxy
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
 install:
-    - pip install --pre -f travis-wheels/wheelhouse -r dev-requirements.txt .
+    - pip install -v --pre -f travis-wheels/wheelhouse -r dev-requirements.txt .
 script:
     - travis_retry py.test --cov jupyterhub jupyterhub/tests -v
 after_success:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+mock
 codecov
 pytest-cov
 pytest>=2.8

--- a/jupyterhub/alembic/versions/af4cbdb2d13c_services.py
+++ b/jupyterhub/alembic/versions/af4cbdb2d13c_services.py
@@ -1,0 +1,25 @@
+"""services
+
+Revision ID: af4cbdb2d13c
+Revises: eeb276e51423
+Create Date: 2016-07-28 16:16:38.245348
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'af4cbdb2d13c'
+down_revision = 'eeb276e51423'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('api_tokens', sa.Column('service_id', sa.Integer))
+
+
+def downgrade():
+    # sqlite cannot downgrade because of limited ALTER TABLE support (no DROP COLUMN)
+    op.drop_column('api_tokens', 'service_id')

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -144,7 +144,7 @@ class BaseHandler(RequestHandler):
         if orm_token is None:
             return None
         else:
-            return orm_token.user
+            return orm_token.user or orm_token.service
 
     def _user_for_cookie(self, cookie_name, cookie_value=None):
         """Get the User for a given cookie, if there is one"""

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -42,8 +42,13 @@ def find_user(db, name):
     return db.query(orm.User).filter(orm.User.name==name).first()
 
 def add_user(db, app=None, **kwargs):
-    orm_user = orm.User(**kwargs)
-    db.add(orm_user)
+    orm_user = find_user(db, name=kwargs.get('name'))
+    if orm_user is None:
+        orm_user = orm.User(**kwargs)
+        db.add(orm_user)
+    else:
+        for attr, value in kwargs.items():
+            setattr(orm_user, attr, value)
     db.commit()
     if app:
         user = app.users[orm_user.id] = User(orm_user, app.tornado_settings)

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -23,7 +23,7 @@ def test_upgrade(tmpdir):
     print(db_url)
     upgrade(db_url)
 
-def test_upgrade_entrypoint(tmpdir):
+def test_upgrade_entrypoint(tmpdir, io_loop):
     generate_old_db(str(tmpdir))
     tmpdir.chdir()
     tokenapp = NewToken()
@@ -32,7 +32,7 @@ def test_upgrade_entrypoint(tmpdir):
         tokenapp.start()
     
     upgradeapp = UpgradeDB()
-    upgradeapp.initialize([])
+    io_loop.run_sync(lambda : upgradeapp.initialize([]))
     upgradeapp.start()
     
     # run tokenapp again, it should work


### PR DESCRIPTION
Adds the DB state for services, so that API tokens can be associated with users or services.

Services have:

(like users):

- name
- admin (bool)

(unlike users):

- multiple URL endpoints
- pid for managed processes
- no single-user server

Next step is to add a services API for registering services with the Hub.