### PR TITLE
Add a warning on login if page not over ssl.

### DIFF
--- a/share/jupyter/hub/static/less/login.less
+++ b/share/jupyter/hub/static/less/login.less
@@ -1,6 +1,11 @@
 #login-main {
     display: table;
     height: 80vh;
+
+    & #insecure-login-warning{
+        .bg-warning();
+        padding:10px;
+    }
     
     .service-login {
       text-align: center;

--- a/share/jupyter/hub/templates/login.html
+++ b/share/jupyter/hub/templates/login.html
@@ -21,6 +21,12 @@
     Sign in
   </div>
   <div class='auth-form-body'>
+
+    <p id='insecure-login-warning'>
+    Warning: JupyterHub seems to be served over an unsecured HTTP connection.
+    We strongly recommend enabling TLS for JupyterHub.
+    </p>
+
     {% if login_error %}
     <p class="login_error">
       {{login_error}}
@@ -64,5 +70,11 @@
 
 {% block script %}
 {{super()}}
+
+<script>
+if (window.location.protocol === "https:") {
+    var warnings = document.getElementById('insecure-login-warning').remove()
+}
+</script>
 
 {% endblock %}


### PR DESCRIPTION
The --no-ssl option in the backend make sens, but still too many
deployment are not over SSL because they underestimate / do not
understand the risks.

--- 
<img width="413" alt="screen shot 2016-06-12 at 13 20 35" src="https://cloud.githubusercontent.com/assets/335567/15993607/8301bc74-30a0-11e6-9777-0d104a8265b2.png">

On secured connexions there might be a quick flash of the yellow box  before it get removed, the alternative is to hide it by default, and show it on non-https, but seem more complicated.
