### PR TITLE
Add /user-redirect/ endpoint

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -520,6 +520,24 @@ class UserSpawnHandler(BaseHandler):
             ))
 
 
+class UserRedirectHandler(BaseHandler):
+    """Redirect requests to user servers.
+    
+    Allows public linking to "this file on your server".
+    
+    /user-redirect/path/to/foo will redirect to /user/:name/path/to/foo
+    
+    If the user is not logged in, send to login URL, redirecting back here.
+    
+    .. versionadded:: 0.7
+    """
+    @web.authenticated
+    def get(self, path):
+        user = self.get_current_user()
+        url = url_path_join(user.url, path)
+        self.redirect(url)
+
+
 class CSPReportHandler(BaseHandler):
     '''Accepts a content security policy violation report'''
     @web.authenticated
@@ -532,7 +550,9 @@ class CSPReportHandler(BaseHandler):
         # Report it to statsd as well
         self.statsd.incr('csp_report')
 
+
 default_handlers = [
     (r'/user/([^/]+)(/.*)?', UserSpawnHandler),
+    (r'/user-redirect/(.*)?', UserRedirectHandler),
     (r'/security/csp-report', CSPReportHandler),
 ]

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -37,6 +37,9 @@ class RootHandler(BaseHandler):
             # ultimately redirecting to the logged-in user's server.
             without_prefix = next_url[len(self.base_url):]
             next_url = url_path_join(self.hub.server.base_url, without_prefix)
+            self.log.warning("Redirecting %s to %s. For sharing public links, use /user-redirect/",
+                self.request.uri, next_url,
+            )
             self.redirect(next_url)
             return
         user = self.get_current_user()

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -166,6 +166,28 @@ def test_user_redirect(app):
     name = 'wash'
     cookies = app.login_user(name)
 
+    r = get_page('/user-redirect/tree/top/', app)
+    r.raise_for_status()
+    print(urlparse(r.url))
+    path = urlparse(r.url).path
+    assert path == ujoin(app.base_url, '/hub/login')
+    query = urlparse(r.url).query
+    assert query == urlencode({
+        'next': ujoin(app.hub.server.base_url, '/user-redirect/tree/top/')
+    })
+
+    r = get_page('/user-redirect/notebooks/test.ipynb', app, cookies=cookies)
+    r.raise_for_status()
+    print(urlparse(r.url))
+    path = urlparse(r.url).path
+    assert path == ujoin(app.base_url, '/user/%s/notebooks/test.ipynb' % name)
+
+
+def test_user_redirect_deprecated(app):
+    """redirecting from /user/someonelse/ URLs (deprecated)"""
+    name = 'wash'
+    cookies = app.login_user(name)
+
     r = get_page('/user/baduser', app, cookies=cookies, hub=False)
     r.raise_for_status()
     print(urlparse(r.url))


### PR DESCRIPTION
So that explicit links can be made that will open a file in any user's server.

should avoid needing to add user-detection / intent into other endpoints. That functionality isn't removed, but warnings are added indicating that /user-redirect/ should be used instead.

cc @akaihola @daradib