### PR TITLE
Correct Spawner.start typo

### DIFF
--- a/docs/source/spawners.md
+++ b/docs/source/spawners.md
@@ -153,7 +153,7 @@ which would return:
 }
 ```
 
-When `Spawner.spawn` is called, this dictionary is accessible as `self.user_options`.
+When `Spawner.start` is called, this dictionary is accessible as `self.user_options`.
 
 
 


### PR DESCRIPTION
As documented at https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/spawner.py#L103