### PR TITLE
Remove link and reflow text

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -7,9 +7,7 @@
 :Release: |release|
 :Date: |today|
 
-JupyterHub also provides a
-[REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
-for administration of the Hub and users.
+JupyterHub also provides a REST API for administration of the Hub and users.
 
 .. toctree::
 


### PR DESCRIPTION
Removes link below since better addressed in #656.

<img width="824" alt="screen shot 2016-07-25 at 7 41 46 am" src="https://cloud.githubusercontent.com/assets/2680980/17105287/7dc7d650-523b-11e6-9f6f-95934601a928.png">
