### PR TITLE
Fix invalid license object and bad JSON pointers in API spec

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -4,7 +4,8 @@ info:
   title: JupyterHub
   description: The REST API for JupyterHub
   version: 0.7.0
-  license: BSD-3-Clause
+  license:
+    name: BSD-3-Clause
 schemes:
   - http
 securityDefinitions:

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -310,7 +310,7 @@ paths:
         '200':
           description: The user identified by the API token
           schema:
-            $ref: '#!/definitions/User'
+            $ref: '#/definitions/User'
   /authorizations/cookie/{cookie_name}/{cookie_value}:
     get:
       summary: Identify a user from a cookie
@@ -328,7 +328,7 @@ paths:
         '200':
           description: The user identified by the cookie
           schema:
-            $ref: '#!/definitions/User'
+            $ref: '#/definitions/User'
   /shutdown:
     post:
       summary: Shutdown the Hub


### PR DESCRIPTION
Very minor fix. Swagger's validator says it's good now!

[Bravado](https://github.com/Yelp/bravado) is calling it invalid, however, so I'm going to look into that and maybe do some light refactoring while I experiment with it.