### PR TITLE
Add /api/ and /api/info endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 build
 dist
 docs/_build
+docs/source/_static/rest-api
 .ipynb_checkpoints
 # ignore config file at the top-level of the repo
 # but not sub-dirs

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -332,6 +332,15 @@ paths:
   /shutdown:
     post:
       summary: Shutdown the Hub
+      parameters:
+        - name: proxy
+          in: body
+          type: bool
+          description: Whether the proxy should be shutdown as well (default from Hub config)
+        - name: servers
+          in: body
+          type: bool
+          description: Whether users's servers should be shutdown as well (default from Hub config)
       responses:
         '200':
           description: Hub has shutdown

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -21,6 +21,60 @@ produces:
 consumes:
   - application/json
 paths:
+  /:
+    get:
+      summary: See the version of JupyterHub itself
+      description: |
+        This endpoint is not authenticated,
+        so clients can identify the version of JupyterHub before setting up authentication.
+      responses:
+        '200':
+          description: The version of JupyterHub itself
+          schema:
+            type: object
+            properties:
+              version:
+                type: string
+                description: The version of JupyterHub itself
+  /info:
+    get:
+      summary: Get detailed info about JupyterHub
+      description: |
+        Detailed information about JupyterHub,
+        including information about Python, JupyterHub's version,
+        and what Authenticators and Spawners are in use.
+      responses:
+        '200':
+          schema:
+            type: object
+            properties:
+              version:
+                type: string
+                description: The version of JupyterHub itself
+              python:
+                type: string
+                description: The version of Python, as returned by sys.version
+              sys_executable:
+                type: string
+                description: The path to sys.executable running JupyterHub
+              authenticator:
+                type: object
+                properties:
+                  class:
+                    type: string
+                    description: The Python class currently in use
+                  version:
+                    type: string
+                    description: The version of the package providing the Authenticator class
+              spawner:
+                type: object
+                properties:
+                  class:
+                    type: string
+                    description: The Python class currently in use for spawning single-user servers
+                  version:
+                    type: string
+                    description: The version of the package providing the Spawner class
   /users:
     get:
       summary: List users


### PR DESCRIPTION
`/api/` is not authenticated, and just reports JupyterHub's version for now.

`/api/info` is admin-only, and reports more detailed info about Python, authenticators/spawners in use, etc.

Added missing parameters in docs for `/api/shutdown` as well.