### PR TITLE
Swagger spec conformance

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -389,11 +389,11 @@ paths:
       parameters:
         - name: proxy
           in: body
-          type: bool
+          type: boolean
           description: Whether the proxy should be shutdown as well (default from Hub config)
         - name: servers
           in: body
-          type: bool
+          type: boolean
           description: Whether users's servers should be shutdown as well (default from Hub config)
       responses:
         '200':

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -45,6 +45,7 @@ paths:
         and what Authenticators and Spawners are in use.
       responses:
         '200':
+          description: Detailed JupyterHub info
           schema:
             type: object
             properties:


### PR DESCRIPTION
Minor updates again. "bool" wasn't a valid type, and responses need descriptions. Error responses should be added at some point; the spec has an interesting example called and ErrorModel that may be worthwhile to look at.

The shutdown command is broken now, however. Parameters that go in the body need to be schema objects and that's a little over my head. I think the parameters needs to be something like this
```yaml
- name: proxy
  in: body
  description: Whether the proxy should be shutdown as well (default from Hub config)
  schema:
    type: boolean
 - name: servers
  in: body
 description: Whether users' servers should be shutdown as well (default from Hub config)
  schema:
    type: boolean
```
The web interface broke when I tried that, though, and the validator said it was fine, so it must be **really** wrong. The examples in the specification only show how to use arrays and not single values for parameter schemas, so that's just a guess.

For reference, here's the output of the swagger validator after this PR
```json
{"schemaValidationMessages":[
{"level":"error","domain":"validation","keyword":"oneOf","message":"instance failed to match exactly one schema (matched 0 out of 2)","schema":{"loadingURI":"http://swagger.io/v2/schema.json#","pointer":"/definitions/parametersList/items"},"instance":{"pointer":"/paths/~1shutdown/post/parameters/0"}},
{"level":"error","domain":"validation","keyword":"oneOf","message":"instance failed to match exactly one schema (matched 0 out of 2)","schema":{"loadingURI":"http://swagger.io/v2/schema.json#","pointer":"/definitions/parametersList/items"},"instance":{"pointer":"/paths/~1shutdown/post/parameters/1"}}]}
```