### PR TITLE
Update conda env and conf.py for clean build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: jd
+name: jhub_docs
 channels:
   - conda-forge
 dependencies:
@@ -10,6 +10,7 @@ dependencies:
 - sqlalchemy>=1
 - tornado>=4.1
 - traitlets>=4.1
+- sphinx>=1.3.6
+- sphinx_rtd_theme
 - pip:
-    - sphinx>=1.3.6
     - recommonmark==0.4.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,10 +139,7 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    'collapse_navigation': False,
-    'display_version': False,
-}
+#html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
PR #693 added HTML theme options that are breaking build for docs. Remove this from conf.py.

Move sphinx to conda install in `environment.yml`