### PR TITLE
HubAuth login_url changes:

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -40,10 +40,10 @@ class LoginHandler(BaseHandler):
     def get(self):
         self.statsd.incr('login.request')
         next_url = self.get_argument('next', '')
-        if next_url.startswith('%s://%s' % (self.request.protocol, self.request.host)):
+        if (next_url + '/').startswith('%s://%s/' % (self.request.protocol, self.request.host)):
             # treat absolute URLs for our host as absolute paths:
             next_url = urlparse(next_url).path
-        if not next_url.startswith('/'):
+        elif not next_url.startswith('/'):
             # disallow non-absolute next URLs (e.g. full URLs to other hosts)
             next_url = ''
         user = self.get_current_user()

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -3,6 +3,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from urllib.parse import urlparse
+
 from tornado.escape import url_escape
 from tornado import gen
 
@@ -38,8 +40,11 @@ class LoginHandler(BaseHandler):
     def get(self):
         self.statsd.incr('login.request')
         next_url = self.get_argument('next', '')
+        if next_url.startswith('%s://%s' % (self.request.protocol, self.request.host)):
+            # treat absolute URLs for our host as absolute paths:
+            next_url = urlparse(next_url).path
         if not next_url.startswith('/'):
-            # disallow non-absolute next URLs (e.g. full URLs)
+            # disallow non-absolute next URLs (e.g. full URLs to other hosts)
             next_url = ''
         user = self.get_current_user()
         if user:

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -102,17 +102,17 @@ class HubAuth(Configurable):
         """
     ).tag(config=True)
 
-    login_url = Unicode('https://127.0.0.1:8000/hub/login',
+    login_url = Unicode('/hub/login',
         help="""The login URL of the Hub
         
-        Typically https://public-hub-host/hub/login
+        Typically /hub/login
         """
     ).tag(config=True)
 
     api_token = Unicode('',
         help="""API key for accessing Hub API.
 
-        Generate with `jupyterhub token [username]` or add to JupyterHub.api_tokens config.
+        Generate with `jupyterhub token [username]` or add to JupyterHub.services config.
         """
     ).tag(config=True)
 


### PR DESCRIPTION
1. use `/hub/login` instead of full URL in HubAuth.login_url
2. allow absolute URLs if they are for our host (equivalent to absolute path)

cf https://github.com/jupyter/nbgrader/pull/538

cc @jhamrick