### PR TITLE
Add navigation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+**[Technical overview](#technical-overview)** |
+**[Prerequisites](#prerequisites)** |
+**[Installation](#installation)** |
+**[Running the Hub Server](#running-the-hub-server)** |
+**[Configuration](#configuration)** |
+**[Docker](#docker)** |
+**[Contributing](#contributing)** |
+**[License](#license)** |
+**[Getting help](#getting-help)**
+
 # [JupyterHub](https://github.com/jupyterhub/jupyterhub)
 
 [![Build Status](https://travis-ci.org/jupyterhub/jupyterhub.svg?branch=master)](https://travis-ci.org/jupyterhub/jupyterhub)


### PR DESCRIPTION
The README page is getting a bit long. I was over on the zulip repo and saw this navigation for the top of the README which saves the user some scrolling if they know which section they want.

Let me know what you think.  