### PR TITLE
Add --no-ssl to docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ To run the single-user servers, which may be on the same system as the Hub or no
 #### Starting JupyterHub with docker
 The JupyterHub docker image can be started with the following command:
 
-    docker run -d --name jupyterhub jupyterhub/jupyterhub jupyterhub
+    docker run -d --name jupyterhub jupyterhub/jupyterhub jupyterhub --no-ssl
 
 This command will create a container named `jupyterhub` that you can **stop and resume** with `docker stop/start`.
 


### PR DESCRIPTION
Otherwise this doesn't run by default, and someone in gitter ran into this earlier.