### PR TITLE
Set default for ip to 0.0.0.0 than ''

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -268,7 +268,7 @@ class JupyterHub(Application):
         Use with ssl_key
         """
     ).tag(config=True)
-    ip = Unicode('',
+    ip = Unicode('0.0.0.0',
         help="The public facing ip of the whole application (the proxy)"
     ).tag(config=True)
 


### PR DESCRIPTION
0.0.0.0 has same behavior as '' (listen on all interfaces),
and is a standard IP address for this behavior as well.

Ran into this at https://github.com/yuvipanda/jupyterhub-nginx-chp/pull/5