### PR TITLE
Deprecate `%U` username substitution

### DIFF
--- a/docs/source/api/spawner.rst
+++ b/docs/source/api/spawner.rst
@@ -13,6 +13,6 @@ Module: :mod:`jupyterhub.spawner`
 ----------------
 
 .. autoclass:: Spawner
-    :members: options_from_form, poll, start, stop, get_args, get_env, get_state
+    :members: options_from_form, poll, start, stop, get_args, get_env, get_state, template_namespace, format_string
 
 .. autoclass:: LocalProcessSpawner


### PR DESCRIPTION
Use Python format-strings  `{username}` instead.

`%U` will be automatically substituted during the deprecation.

cc @shreddd