### PR TITLE
Add contributor list to the docs and update the contents

### DIFF
--- a/docs/source/contributor-list.md
+++ b/docs/source/contributor-list.md
@@ -1,0 +1,51 @@
+# Contributors
+
+Project Jupyter thanks the following people for their help and
+contribution on JupyterHub:
+
+- anderbubble
+- betatim
+- Carreau
+- ckald
+- cwaldbieser
+- daradib
+- datapolitan
+- dblockow-d2dcrc
+- dietmarw
+- DominicFollettSmith
+- dsblank
+- ellisonbg
+- evanlinde
+- Fokko
+- iamed18
+- JamiesHQ
+- jdavidheiser
+- jhamrick
+- josephtate
+- KrishnaPG
+- ksolan
+- mbmilligan
+- minrk
+- mistercrunch
+- Mistobaan
+- mwmarkland
+- nthiery
+- ObiWahn
+- ozancaglayan
+- PeterDaveHello
+- peterruppel
+- rafael-ladislau
+- rgbkrk
+- robnagler
+- ryanlovett
+- shreddd
+- ssanderson
+- takluyver
+- TimShawver
+- toobaz
+- tsaeger
+- vilhelmen
+- willingc
+- YannBrrd
+- yuvipanda
+- zoltan-fedor

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,6 +57,7 @@ Contents
 
 * :doc:`authenticators`
 * :doc:`spawners`
+* :doc:`services`
 * :doc:`config-examples`
 * :doc:`troubleshooting`
 
@@ -67,6 +68,7 @@ Contents
 
    authenticators
    spawners
+   services
    config-examples
    troubleshooting
 
@@ -86,6 +88,7 @@ Contents
 **About JupyterHub**
 
 * :doc:`changelog`
+* :doc:`contributor-list`
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Contents
    :caption: About JupyterHub
 
    changelog
+   contributor-list
 
 
 Indices and tables


### PR DESCRIPTION
@minrk In preparation of the changelog for 0.7, I've added a contributor list to the docs as a community goodwill item. 

I've also added services to the TOC which I missed in an older PR.