### PR TITLE
Update API docs

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -8,6 +8,19 @@
 :Date: |today|
 
 JupyterHub also provides a REST API for administration of the Hub and users.
+The documentation on `Using JupyterHub's REST API <../rest.html>`_ provides
+information on:
+
+- Creating an API token
+- Adding tokens to the configuration file (optional)
+- Making an API request
+
+The same JupyterHub API spec, as found here, is available in an interactive form
+`here (on swagger's petstore) <http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#!/default>`__.
+The `OpenAPI Initiative`_ (fka Swagger™) is a project used to describe
+and document RESTful APIs.
+
+JupyterHub API Reference:
 
 .. toctree::
 
@@ -16,3 +29,5 @@ JupyterHub also provides a REST API for administration of the Hub and users.
     user
     services.auth
 
+
+.. _OpenAPI Initiative: https://openapis.org/

--- a/docs/source/rest.md
+++ b/docs/source/rest.md
@@ -1,11 +1,17 @@
 # Using JupyterHub's REST API
 
-Using the JupyterHub [REST API](https://en.wikipedia.org/wiki/Representational_state_transfer),
-you can perform actions on the Hub, such as:
+Using the [JupyterHub REST API][], you can perform actions on the Hub,
+such as:
 
 - checking which users are active
 - adding or removing users
 - stopping or starting single user notebook servers
+- authenticating services
+
+A [REST](https://en.wikipedia.org/wiki/Representational_state_transfer)
+API provides a standard way for users to get and send information to the
+Hub.
+ 
 
 ## Creating an API token
 To send requests using JupyterHub API, you must pass an API token with the
@@ -54,8 +60,11 @@ users = r.json()
  
 ## Learning more about the API
 
-You can see the full [REST API Spec](../_static/rest-api/index.html) for details.
-The same REST API Spec can be viewed in a more visually appealing style [on swagger's petstore][].
+You can see the full [JupyterHub REST API][] for details.
+The same REST API Spec can be viewed in a more interactive style [on swagger's petstore][].
 Both resources contain the same information and differ only in its display.
+Note: The Swagger specification is being renamed the [OpenAPI Initiative][].
 
 [on swagger's petstore]: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#!/default
+[OpenAPI Initiative]: https://openapis.org/
+[JupyterHub REST API]: ./api/index.html


### PR DESCRIPTION
- Update so first link in 'Using the JupyterHub API' redirects to the API spec
- Add links and updated text for swagger and its transfer to the OpenAPI Initiative
- Provide link to swagger rendering of API in the 'JupyterHub API Spec' doc.
