### PR TITLE
Work on service authentication

### DIFF
--- a/examples/service-whoami/README.md
+++ b/examples/service-whoami/README.md
@@ -5,7 +5,7 @@ Uses `jupyterhub.services.HubAuthenticated` to authenticate requests with the Hu
 ## Run
 
 1. Launch JupyterHub and the `whoami service` with `source launch.sh`.
-2. Visit http://127.0.0.1:8000/hub/whoami
+2. Visit http://127.0.0.1:8000/services/whoami
 
 After logging in with your local-system credentials, you should see a JSON dump of your user info:
 
@@ -18,3 +18,13 @@ After logging in with your local-system credentials, you should see a JSON dump 
  "server": "/user/queequeg"
 }
 ```
+
+This relies on the Hub starting the whoami services, via config (see [jupyterhub_config.py](./jupyterhub_config.py)).
+
+A similar service could be run externally, by setting the JupyterHub service environment variables:
+
+    JUPYTERHUB_API_TOKEN
+    JUPYTERHUB_API_URL
+    JUPYTERHUB_SERVICE_PREFIX
+
+or instantiating and configuring a HubAuth object yourself, and attaching it as `self.hub_auth` in your HubAuthenticated handlers.

--- a/examples/service-whoami/jupyterhub_config.py
+++ b/examples/service-whoami/jupyterhub_config.py
@@ -1,6 +1,10 @@
-from getpass import getuser
 import os
+import sys
 
-c.JupyterHub.api_tokens = {
-    os.environ['WHOAMI_HUB_API_TOKEN']: getuser(),
-}
+c.JupyterHub.services = [
+    {
+        'name': 'whoami',
+        'url': 'http://127.0.0.1:10101',
+        'command': [sys.executable, './whoami.py'],
+    }
+]

--- a/examples/service-whoami/launch.sh
+++ b/examples/service-whoami/launch.sh
@@ -1,12 +1,5 @@
 # make some API tokens, one for the proxy, one for the service
 export CONFIGPROXY_AUTH_TOKEN=`openssl rand -hex 32`
-export WHOAMI_HUB_API_TOKEN=`openssl rand -hex 32`
 
 # start JupyterHub
-jupyterhub --no-ssl --ip=127.0.0.1 &
-
-# give JupyterHub a moment to start
-sleep 2
-
-# start the whoami service as /hub/whoami
-python whoami.py
+jupyterhub --no-ssl --ip=127.0.0.1

--- a/examples/service-whoami/whoami.py
+++ b/examples/service-whoami/whoami.py
@@ -1,26 +1,21 @@
 """An example service authenticating with the Hub.
 
-This serves `/hub/whoami/`, authenticated with the Hub, showing the user their own info.
+This serves `/services/whoami/`, authenticated with the Hub, showing the user their own info.
 """
 from getpass import getuser
 import json
 import os
-
-import requests
+from urllib.parse import urlparse
 
 from tornado.ioloop import IOLoop
 from tornado.httpserver import HTTPServer
 from tornado.web import RequestHandler, Application, authenticated
 
-from jupyterhub.services.auth import HubAuthenticated, HubAuth
+from jupyterhub.services.auth import HubAuthenticated
 
 
 class WhoAmIHandler(HubAuthenticated, RequestHandler):
     hub_users = {getuser()} # the users allowed to access me
-
-    def initialize(self, hub_auth):
-        super().initialize()
-        self.hub_auth = hub_auth
 
     @authenticated
     def get(self):
@@ -28,33 +23,17 @@ class WhoAmIHandler(HubAuthenticated, RequestHandler):
         self.set_header('content-type', 'application/json')
         self.write(json.dumps(user_model, indent=1, sort_keys=True))
 
-def add_route():
-    # add myself to the proxy
-    # TODO: this will be done by the Hub when the Hub gets service config
-    requests.post('http://127.0.0.1:8001/api/routes/hub/whoami',
-         data=json.dumps({
-             'target': 'http://127.0.0.1:9999',
-         }),
-         headers={
-             'Authorization': 'token %s' % os.environ['CONFIGPROXY_AUTH_TOKEN'],
-         }
-    )
-
 def main():
-    # FIXME: remove when we can declare routes in Hub config
-    add_route()
-    
-    hub_auth = HubAuth(
-        cookie_name='jupyter-hub-token',
-        api_token=os.environ['WHOAMI_HUB_API_TOKEN'],
-        login_url='http://127.0.0.1:8000/hub/login',
-    )
     app = Application([
-        (r"/hub/whoami", WhoAmIHandler, dict(hub_auth=hub_auth)),
-    ], login_url=hub_auth.login_url)
+        (os.environ['JUPYTERHUB_SERVICE_PREFIX'] + '/?', WhoAmIHandler),
+        (r'.*', WhoAmIHandler),
+    ], login_url='/hub/login')
     
     http_server = HTTPServer(app)
-    http_server.listen(9999)
+    url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
+
+    http_server.listen(url.port, url.hostname)
+
     IOLoop.current().start()
 
 if __name__ == '__main__':

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1112,7 +1112,7 @@ class JupyterHub(Application):
         if self.proxy.public_server.is_up() or self.proxy.api_server.is_up():
             # check for *authenticated* access to the proxy (auth token can change)
             try:
-                yield self.proxy.get_routes()
+                routes = yield self.proxy.get_routes()
             except (HTTPError, OSError, socket.error) as e:
                 if isinstance(e, HTTPError) and e.code == 403:
                     msg = "Did CONFIGPROXY_AUTH_TOKEN change?"
@@ -1124,6 +1124,7 @@ class JupyterHub(Application):
                 return
             else:
                 self.log.info("Proxy already running at: %s", self.proxy.public_server.bind_url)
+                yield self.proxy.check_routes(self.users, self._service_map, routes)
             self.proxy_process = None
             return
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -241,7 +241,10 @@ class BaseHandler(RequestHandler):
 
     def set_service_cookie(self, user):
         """set the login cookie for services"""
-        self._set_user_cookie(user, self.service_server)
+        self._set_user_cookie(user, orm.Server(
+            cookie_name='jupyterhub-services',
+            base_url=url_path_join(self.base_url, 'services')
+        ))
 
     def set_server_cookie(self, user):
         """set the login cookie for the single-user server"""
@@ -262,7 +265,7 @@ class BaseHandler(RequestHandler):
             self.set_server_cookie(user)
 
         # set single cookie for services
-        if self.db.query(orm.Service).first():
+        if self.db.query(orm.Service).filter(orm.Service.server != None).first():
             self.set_service_cookie(user)
 
         # create and set a new cookie token for the hub

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 import requests
 from tornado import web, httpserver, ioloop
 
+from jupyterhub.services.auth import  HubAuthenticated
 
 class EchoHandler(web.RequestHandler):
     def get(self):
@@ -36,6 +37,12 @@ class APIHandler(web.RequestHandler):
         self.set_header('Content-Type', 'application/json')
         self.write(r.text)
 
+class WhoAmIHandler(HubAuthenticated, web.RequestHandler):
+
+    @web.authenticated
+    def get(self):
+        self.write(self.get_current_user())
+
 
 def main():
     if os.environ['JUPYTERHUB_SERVICE_URL']:
@@ -43,6 +50,7 @@ def main():
         app = web.Application([
             (r'.*/env', EnvHandler),
             (r'.*/api/(.*)', APIHandler),
+            (r'.*/whoami/?', WhoAmIHandler),
             (r'.*', EchoHandler),
         ])
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -161,9 +161,9 @@ class User(HasTraits):
     @property
     def proxy_path(self):
         if self.settings.get('subdomain_host'):
-            return url_path_join('/' + self.domain, self.server.base_url)
+            return url_path_join('/' + self.domain, self.base_url)
         else:
-            return self.server.base_url
+            return self.base_url
     
     @property
     def domain(self):


### PR DESCRIPTION
- HubAuth loads defaults from service environment variables
- HubAuthenticated mixin populates default HubAuth
- Fix setting service cookie (including test)
- Simplify HubAuthenticated example, now that defaults work

This means that the *only* thing you need to authenticate a tornado-based service with the Hub is:

```python

class MyHandler(HubAuthenticated, RequestHandler):
    @web.authenticated
    def get(self):
        ...
```

for a Hub-managed service. An externally managed service may need to set a few variables,
or (perhaps simplest) set the same environment variables that a managed service would get:

    JUPYTERHUB_API_TOKEN
    JUPYTERHUB_API_URL

cc @jhamrick as this may simplify formgrader integrating HubAuth.