### PR TITLE
Deprecate `--no-ssl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ To run the single-user servers, which may be on the same system as the Hub or no
 #### Starting JupyterHub with docker
 The JupyterHub docker image can be started with the following command:
 
-    docker run -d --name jupyterhub jupyterhub/jupyterhub jupyterhub --no-ssl
+    docker run -d --name jupyterhub jupyterhub/jupyterhub jupyterhub
 
 This command will create a container named `jupyterhub` that you can **stop and resume** with `docker stop/start`.
 
@@ -155,7 +155,7 @@ a new image.
 
 The command `docker exec -it jupyterhub bash` will spawn a root shell in your docker
 container. You can **use the root shell to create system users in the container**. These accounts will be used for authentication
-in JupyterHub's default configuration. In order to run without SSL (for testing purposes only), you'll need to set `--no-ssl` explicitly.
+in JupyterHub's default configuration.
 
 ----
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -52,11 +52,11 @@ using Docker.
 
 ### Default behavior
 
-**IMPORTANT:** In its default configuration, JupyterHub requires SSL encryption (HTTPS) to run.
-**You should not run JupyterHub without SSL encryption on a public network.**
-See [Security documentation](#security) for how to configure JupyterHub to use SSL, and in
-certain cases, e.g. behind SSL termination in nginx, allowing the hub to run with no SSL
-by requiring `--no-ssl` (as of [version 0.5](./changelog.html)).
+**IMPORTANT: You should not run JupyterHub without SSL encryption on a public network.**
+See [Security documentation](#security) for how to configure JupyterHub to use SSL, 
+or put it behind SSL termination in another proxy server, such as nginx.
+JupyterHub 0.5-0.6 require extra confirmation via `--no-ssl` to allow running without SSL,
+but this is not needed anymore in 0.7.
 
 To start JupyterHub in its default configuration, type the following at the command line:
 
@@ -246,8 +246,7 @@ Note on **chain certificates**: If you are using a chain certificate, see also
 [chained certificate for SSL](troubleshooting.md#chained-certificates-for-ssl) in the JupyterHub troubleshooting FAQ).
 
 Note: In certain cases, e.g. **behind SSL termination in nginx**, allowing no SSL
-running on the hub may be desired. To run the Hub without SSL, you must opt
-in by configuring and confirming the `--no-ssl` option, added as of [version 0.5](./changelog.html).
+running on the hub may be desired.
 
 ### Cookie secret
 

--- a/examples/service-whoami/launch.sh
+++ b/examples/service-whoami/launch.sh
@@ -2,4 +2,4 @@
 export CONFIGPROXY_AUTH_TOKEN=`openssl rand -hex 32`
 
 # start JupyterHub
-jupyterhub --no-ssl --ip=127.0.0.1
+jupyterhub --ip=127.0.0.1

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -94,7 +94,7 @@ flags = {
         "disable persisting state database to disk"
     ),
     'no-ssl': ({'JupyterHub': {'confirm_no_ssl': True}},
-        "Allow JupyterHub to run without SSL (SSL termination should be happening elsewhere)."
+        "[DEPRECATED in 0.7: does nothing]"
     ),
 }
 
@@ -252,9 +252,7 @@ class JupyterHub(Application):
         return [os.path.join(self.data_files_path, 'templates')]
 
     confirm_no_ssl = Bool(False,
-        help="""Confirm that JupyterHub should be run without SSL.
-        This is **NOT RECOMMENDED** unless SSL termination is being handled by another layer.
-        """
+        help="""DEPRECATED: does nothing"""
     ).tag(config=True)
     ssl_key = Unicode('',
         help="""Path to SSL key file for the public facing interface of the proxy
@@ -1152,18 +1150,10 @@ class JupyterHub(Application):
                 '--statsd-port', str(self.statsd_port),
                 '--statsd-prefix', self.statsd_prefix + '.chp'
             ])
-        # Require SSL to be used or `--no-ssl` to confirm no SSL on
+        # Warn if SSL is not used
         if ' --ssl' not in ' '.join(cmd):
-            if self.confirm_no_ssl:
-                self.log.warning("Running JupyterHub without SSL."
-                    " There better be SSL termination happening somewhere else...")
-            else:
-                self.log.error(
-                    "Refusing to run JupyterHub without SSL."
-                    " If you are terminating SSL in another layer,"
-                    " pass --no-ssl to tell JupyterHub to allow the proxy to listen on HTTP."
-                )
-                self.exit(1)
+            self.log.warning("Running JupyterHub without SSL."
+                "  I hope there is SSL termination happening somewhere else...")
         self.log.info("Starting proxy @ %s", self.proxy.public_server.bind_url)
         self.log.debug("Proxy cmd: %s", cmd)
         try:

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -122,7 +122,6 @@ class MockHub(JupyterHub):
     """Hub with various mock bits"""
 
     db_file = None
-    confirm_no_ssl = True
     
     last_activity_interval = 2
     


### PR DESCRIPTION
it's unnecessarily pedantic. Just warn instead.