### PR TITLE
spawn_pending set too soon causing redirect loop

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -258,7 +258,6 @@ class User(HasTraits):
         self.state = spawner.get_state()
         self.last_activity = datetime.utcnow()
         db.commit()
-        self.spawn_pending = False
         try:
             yield self.server.wait_up(http=True, timeout=spawner.http_timeout)
         except Exception as e:
@@ -285,6 +284,7 @@ class User(HasTraits):
                 ), exc_info=True)
             # raise original TimeoutError
             raise e
+        self.spawn_pending = False
         return self
 
     @gen.coroutine


### PR DESCRIPTION
Attempts to fix #569 where redirects loop between /hub/user/USERNAME and /user/USERNAME while waiting for jupyterhub-singleuser to become available. I'm using dockerspawner.systemuserspawner along with a custom authenticator.

If you artificially set the spawn_timeout in base.py to something low (2s) it makes it easier to trigger the redirect behaviour. Testing against f8229c9fb6ab5a5135f67ea253e6833cebd761f7 and https://github.com/jupyterhub/dockerspawner/commit/e7e2af631b65bcaad4f205d2f481b2f5b6a4f722 my browser complains about a redirect loop without the patch. The patch moves the spawn_pending to after server.wait_up.