### PR TITLE
add User.waiting_for_response

### DIFF
--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -104,3 +104,12 @@ def mockservice(request, app):
 @yield_fixture
 def mockservice_url(request, app):
     yield _mockservice(request, app, url=True)
+
+@yield_fixture
+def no_patience(app):
+    """Set slow-spawning timeouts to zero"""
+    with mock.patch.dict(app.tornado_application.settings,
+                         {'slow_spawn_timeout': 0,
+                          'slow_stop_timeout': 0}):
+        yield
+

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -258,7 +258,6 @@ class User(HasTraits):
         self.state = spawner.get_state()
         self.last_activity = datetime.utcnow()
         db.commit()
-        self.spawn_pending = False
         try:
             yield self.server.wait_up(http=True, timeout=spawner.http_timeout)
         except Exception as e:
@@ -285,6 +284,7 @@ class User(HasTraits):
                 ), exc_info=True)
             # raise original TimeoutError
             raise e
+        self.spawn_pending = False
         return self
 
     @gen.coroutine


### PR DESCRIPTION
There are two major async stages to spawning:

1. Spawner.start
2. waiting for Spawner to become responsive at its http endpoint

Previously, `.spawn_pending` only covered the `Spawner.start` window, which meant that weird things could happen if servers are slow to start up, because they are not added to the proxy until after they become responsive.


`.waiting_for_response` can only be True while `.spawn_pending` is also True.