### PR TITLE
Fix setting in configuration example

### DIFF
--- a/docs/source/config-examples.md
+++ b/docs/source/config-examples.md
@@ -47,7 +47,7 @@ c.JupyterHub.db_url = pjoin(runtime_dir, 'jupyterhub.sqlite')
 # or `--db=/path/to/jupyterhub.sqlite` on the command-line
 
 # put the log file in /var/log
-c.JupyterHub.log_file = '/var/log/jupyterhub.log'
+c.JupyterHub.extra_log_file = '/var/log/jupyterhub.log'
 
 # use GitHub OAuthenticator for local users
 


### PR DESCRIPTION
### Issue

The valid setting to locate the log file in the configuration file `jupyterhub_config.py` is `extra_log_file`, instead of current `log_file` in the example.

### Tests

I've run the server with `log_file`. It doesn't write to the log file and outputs a warning like this:

```
[W 2016-10-13 10:49:24.021 JupyterHub configurable:168] Config option `log_file` not recognized by `JupyterHub`.  Did you mean one of: `config_file, extra_log_file, logo_file`?
```

I've run the server with `extra_log_file`. It writes to the log file as expected.

### Comments

The default configuration file (`jupyterhub --generate-config`) has the valid `extra_log_file` setting.

The valid argument to pass through command line is `--log-file`.