### PR TITLE
Use warning instead of warn for logs

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -404,7 +404,7 @@ class JupyterHub(Application):
     ).tag(config=True)
     @observe('api_tokens')
     def _deprecate_api_tokens(self, change):
-        self.log.warn("JupyterHub.api_tokens is pending deprecation."
+        self.log.warning("JupyterHub.api_tokens is pending deprecation."
             "  Consider using JupyterHub.service_tokens."
             "  If you have a use case for services that identify as users,"
             " let us know: https://github.com/jupyterhub/jupyterhub/issues"

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -29,7 +29,7 @@ class RootHandler(BaseHandler):
     def get(self):
         next_url = self.get_argument('next', '')
         if not next_url.startswith('/'):
-            self.log.warn("Disallowing redirect outside JupyterHub: %r", next_url)
+            self.log.warning("Disallowing redirect outside JupyterHub: %r", next_url)
             next_url = ''
         if next_url and next_url.startswith(url_path_join(self.base_url, 'user/')):
             # add /hub/ prefix, to ensure we redirect to the right user's server.

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -182,7 +182,7 @@ class HubAuth(Configurable):
             app_log.error("Upstream failure verifying auth token: [%i] %s", r.status_code, r.reason)
             raise HTTPError(502, "Failed to check authorization (upstream problem)")
         elif r.status_code >= 400:
-            app_log.warn("Failed to check authorization: [%i] %s", r.status_code, r.reason)
+            app_log.warning("Failed to check authorization: [%i] %s", r.status_code, r.reason)
             raise HTTPError(500, "Failed to check authorization")
         else:
             data = r.json()

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -168,11 +168,11 @@ class Spawner(LoggingConfigurable):
         print(proposal)
         v = proposal['value']
         if '%U' in v:
-            self.log.warn("%%U for username in %s is deprecated in JupyterHub 0.7, use {username}",
+            self.log.warning("%%U for username in %s is deprecated in JupyterHub 0.7, use {username}",
                 proposal['trait'].name,
             )
             v = v.replace('%U', '{username}')
-            self.log.warn("Converting %r to %r", proposal['value'], v)
+            self.log.warning("Converting %r to %r", proposal['value'], v)
         return v
     
     disable_user_config = Bool(False,


### PR DESCRIPTION
A clean up PR. Following up on something that caught my eye in #830, I've  replaced the handful of remaining log messages that still used 'warn' instead of the more current 'warning'.