### PR TITLE
quotes around single-user CLI args

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -298,15 +298,15 @@ class Spawner(LoggingConfigurable):
     def get_args(self):
         """Return the arguments to be passed after self.cmd"""
         args = [
-            '--user=%s' % self.user.name,
-            '--cookie-name=%s' % self.user.server.cookie_name,
-            '--base-url=%s' % self.user.server.base_url,
-            '--hub-host=%s' % self.hub.host,
-            '--hub-prefix=%s' % self.hub.server.base_url,
-            '--hub-api-url=%s' % self.hub.api_url,
+            '--user="%s"' % self.user.name,
+            '--cookie-name="%s"' % self.user.server.cookie_name,
+            '--base-url="%s"' % self.user.server.base_url,
+            '--hub-host="%s"' % self.hub.host,
+            '--hub-prefix="%s"' % self.hub.server.base_url,
+            '--hub-api-url="%s"' % self.hub.api_url,
             ]
         if self.ip:
-            args.append('--ip=%s' % self.ip)
+            args.append('--ip="%s"' % self.ip)
 
         if self.port:
             args.append('--port=%i' % self.port)
@@ -316,10 +316,10 @@ class Spawner(LoggingConfigurable):
 
         if self.notebook_dir:
             notebook_dir = self.format_string(self.notebook_dir)
-            args.append('--notebook-dir=%s' % notebook_dir)
+            args.append('--notebook-dir="%s"' % notebook_dir)
         if self.default_url:
             default_url = self.format_string(self.default_url)
-            args.append('--NotebookApp.default_url=%s' % default_url)
+            args.append('--NotebookApp.default_url="%s"' % default_url)
 
         if self.debug:
             args.append('--debug')

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -390,10 +390,10 @@ def test_spawn(app, io_loop):
     r = requests.get(ujoin(url, 'args'))
     assert r.status_code == 200
     argv = r.json()
-    for expected in ['--user=%s' % name, '--base-url=%s' % user.server.base_url]:
+    for expected in ['--user="%s"' % name, '--base-url="%s"' % user.server.base_url]:
         assert expected in argv
     if app.subdomain_host:
-        assert '--hub-host=%s' % app.subdomain_host in argv
+        assert '--hub-host="%s"' % app.subdomain_host in argv
 
     r = api_request(app, 'users', name, 'server', method='delete')
     assert r.status_code == 204


### PR DESCRIPTION
avoids mishandling things such as integer-literals

closes #836

I was able to test locally and verify that it works.
