### PR TITLE
Add a high-level release checklist

### DIFF
--- a/CHECKLIST-Release.md
+++ b/CHECKLIST-Release.md
@@ -1,0 +1,26 @@
+# Release checklist
+
+- Upgrade Docs prior to Release
+
+    * Change log
+    * New features documented
+    * Update the contributor list - thank you page
+
+- Upgrade and test Reference Deployments
+
+- Release software
+
+    * Make sure 0 issues in milestone
+    * Follow release process steps
+    * Send builds to PyPI (Warehouse) and Conda Forge
+
+- Blog post and/or release notebook
+
+- Notify users of release
+
+    * Email Jupyter and Jupyter In Education mailing lists
+    * Tweet (optional)
+
+- Increment the version number for the next release
+
+- Update roadmap

--- a/CHECKLIST-Release.md
+++ b/CHECKLIST-Release.md
@@ -14,7 +14,7 @@
     * Follow release process steps
     * Send builds to PyPI (Warehouse) and Conda Forge
 
-- Blog post and/or release notebook
+- Blog post and/or release note
 
 - Notify users of release
 


### PR DESCRIPTION
Since we're busy, this checklist serves as a reminder of key tasks when releasing software to users. Based on discussion at Team meeting with @minrk @parente @yuvipanda @willingc