### PR TITLE
allow `check_whitelist` to be a coroutine

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -132,7 +132,9 @@ class Authenticator(LoggingConfigurable):
         if not self.validate_username(username):
             self.log.warning("Disallowing invalid username %r.", username)
             return
-        if self.check_whitelist(username):
+
+        whitelist_pass = yield gen.maybe_future(self.check_whitelist(username))
+        if whitelist_pass:
             return username
         else:
             self.log.warning("User %r not in whitelist.", username)


### PR DESCRIPTION
Some authenticators may have whitelist checking that requires
async operations, and this should be supported.

Notably [BitBucketOAuthenticator](https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/bitbucket.py#L94) needs this in order for team whitelisting to function correctly
(currently team whitelisting does not actually work).