### PR TITLE
Rename MemorySpecification to ByteSpecification

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -24,7 +24,7 @@ from traitlets import (
     validate,
 )
 
-from .traitlets import Command, MemorySpecification
+from .traitlets import Command, ByteSpecification
 from .utils import random_port
 
 class Spawner(LoggingConfigurable):
@@ -183,7 +183,7 @@ class Spawner(LoggingConfigurable):
         """
     ).tag(config=True)
 
-    mem_limit = MemorySpecification(
+    mem_limit = ByteSpecification(
         None,
         help="""
         Maximum number of bytes a single-user notebook server is allowed to use.
@@ -220,7 +220,7 @@ class Spawner(LoggingConfigurable):
         """
     ).tag(config=True)
 
-    mem_guarantee = MemorySpecification(
+    mem_guarantee = ByteSpecification(
         None,
         help="""
         Minimum number of bytes a single-user notebook server is guaranteed to have available.

--- a/jupyterhub/tests/test_traitlets.py
+++ b/jupyterhub/tests/test_traitlets.py
@@ -1,7 +1,7 @@
 import pytest
 from traitlets import HasTraits, TraitError
 
-from jupyterhub.traitlets import URLPrefix, Command, MemorySpecification
+from jupyterhub.traitlets import URLPrefix, Command, ByteSpecification
 
 
 def test_url_prefix():
@@ -29,7 +29,7 @@ def test_command():
 
 def test_memoryspec():
     class C(HasTraits):
-        mem = MemorySpecification()
+        mem = ByteSpecification()
 
     c = C()
 

--- a/jupyterhub/traitlets.py
+++ b/jupyterhub/traitlets.py
@@ -32,9 +32,9 @@ class Command(List):
         return super().validate(obj, value)
 
 
-class MemorySpecification(Integer):
+class ByteSpecification(Integer):
     """
-    Allow easily specifying memory in units of 1024 with suffixes
+    Allow easily specifying bytes in units of 1024 with suffixes
 
     Suffixes allowed are:
       - K -> Kilobyte
@@ -65,7 +65,7 @@ class MemorySpecification(Integer):
             return value
         num = value[:-1]
         suffix = value[-1]
-        if not num.isdigit() and suffix not in MemorySpecification.UNIT_SUFFIXES:
+        if not num.isdigit() and suffix not in ByteSpecification.UNIT_SUFFIXES:
             raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
         else:
-            return int(num) * MemorySpecification.UNIT_SUFFIXES[suffix]
+            return int(num) * ByteSpecification.UNIT_SUFFIXES[suffix]


### PR DESCRIPTION
Since we might use this in other places (such as storage, which has already come up in KubeSpawner).
