### PR TITLE
disable unused token on singleuser-server

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -138,6 +138,9 @@ class SingleUserNotebookApp(NotebookApp):
     hub_api_url = Unicode().tag(config=True)
     aliases = aliases
     flags = flags
+    
+    # disble some single-user configurables
+    token = ''
     open_browser = False
     trust_xheaders = True
     login_handler_class = JupyterHubLoginHandler


### PR DESCRIPTION
Avoids confusing message about token access in notebook server startup logs (only affects unreleased notebook versions)