### PR TITLE
Allow users to have multiple servers (in db)

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1095,6 +1095,7 @@ class JupyterHub(Application):
                 # if user.server is defined.
                 log = self.log.warning if user.server else self.log.debug
                 log("%s not running.", user.name)
+                # remove all server or servers entry from db related to the user
                 for server in user.servers:
                     db.delete(server)
                 db.commit()

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -146,18 +146,18 @@ class NewToken(Application):
 
 class UpgradeDB(Application):
     """Upgrade the JupyterHub database schema."""
-    
+
     name = 'jupyterhub-upgrade-db'
     version = jupyterhub.__version__
     description = """Upgrade the JupyterHub database to the current schema.
-    
+
     Usage:
 
         jupyterhub upgrade-db
     """
     aliases = common_aliases
     classes = []
-    
+
     def _backup_db_file(self, db_file):
         """Backup a database file"""
         if not os.path.exists(db_file):
@@ -171,7 +171,7 @@ class UpgradeDB(Application):
             backup_db_file = '{}.{}.{}'.format(db_file, timestamp, i)
         if os.path.exists(backup_db_file):
             self.exit("backup db file already exists: %s" % backup_db_file)
-        
+
         self.log.info("Backing up %s => %s", db_file, backup_db_file)
         shutil.copy(db_file, backup_db_file)
 
@@ -222,12 +222,12 @@ class JupyterHub(Application):
         Authenticator,
         PAMAuthenticator,
     ])
-    
+
     load_groups = Dict(List(Unicode()),
         help="""Dict of 'group': ['usernames'] to load at startup.
-        
+
         This strictly *adds* groups and users to groups.
-        
+
         Loading one set of groups, then starting JupyterHub again with a different
         set will not remove users or groups from previous launches.
         That must be done through the API.
@@ -414,7 +414,7 @@ class JupyterHub(Application):
 
     api_tokens = Dict(Unicode(),
         help="""PENDING DEPRECATION: consider using service_tokens
-        
+
         Dict of token:username to be loaded into the database.
 
         Allows ahead-of-time generation of API tokens for use by externally managed services,
@@ -437,14 +437,14 @@ class JupyterHub(Application):
         Allows ahead-of-time generation of API tokens for use by externally managed services.
         """
     ).tag(config=True)
-    
+
     services = List(Dict(),
         help="""List of service specification dictionaries.
-        
+
         A service
-        
+
         For instance::
-        
+
             services = [
                 {
                     'name': 'cull_idle',
@@ -454,7 +454,7 @@ class JupyterHub(Application):
                     'name': 'formgrader',
                     'url': 'http://127.0.0.1:1234',
                     'token': 'super-secret',
-                    'env': 
+                    'env':
                 }
             ]
         """
@@ -608,7 +608,7 @@ class JupyterHub(Application):
         Instance(logging.Handler),
         help="Extra log handlers to set on JupyterHub logger",
     ).tag(config=True)
-    
+
     statsd = Any(allow_none=False, help="The statsd client, if any. A mock will be used if we aren't using statsd")
     @default('statsd')
     def _statsd(self):
@@ -919,7 +919,7 @@ class JupyterHub(Application):
         # The whitelist set and the users in the db are now the same.
         # From this point on, any user changes should be done simultaneously
         # to the whitelist set and user db, unless the whitelist is empty (all users allowed).
-    
+
     @gen.coroutine
     def init_groups(self):
         """Load predefined groups into the database"""
@@ -941,7 +941,7 @@ class JupyterHub(Application):
                     db.add(user)
                 group.users.append(user)
         db.commit()
-    
+
     @gen.coroutine
     def _add_tokens(self, token_dict, kind):
         """Add tokens for users or services to the database"""
@@ -982,13 +982,13 @@ class JupyterHub(Application):
             else:
                 self.log.debug("Not duplicating token %s", orm_token)
         db.commit()
-    
+
     @gen.coroutine
     def init_api_tokens(self):
         """Load predefined API tokens (for services) into database"""
         yield self._add_tokens(self.service_tokens, kind='service')
         yield self._add_tokens(self.api_tokens, kind='user')
-    
+
     def init_services(self):
         self._service_map.clear()
         if self.domain:
@@ -1095,7 +1095,9 @@ class JupyterHub(Application):
                 # if user.server is defined.
                 log = self.log.warning if user.server else self.log.debug
                 log("%s not running.", user.name)
-                user.server = None
+                for server in user.servers:
+                    db.delete(server)
+                db.commit()
 
             user_summaries.append(_user_summary(user))
 
@@ -1458,7 +1460,7 @@ class JupyterHub(Application):
         except Exception as e:
             self.log.critical("Failed to start proxy", exc_info=True)
             self.exit(1)
-        
+
         for service_name, service in self._service_map.items():
             if not service.managed:
                 continue

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -73,10 +73,6 @@ class Server(Base):
     # added to handle multi-server feature
     last_activity = Column(DateTime, default=datetime.utcnow)
 
-    users = association_proxy("server_to_users", "user",
-                              creator=lambda user: UserServer(user=user)
-                              )
-
     def __repr__(self):
         return "<Server(%s:%s)>" % (self.ip, self.port)
 
@@ -368,8 +364,8 @@ class User(Base):
     A `state` column contains a JSON dict,
     used for restoring state of a Spawner.
 
-    `server` returns the first entry for the users' servers.
-    'servers' is a list that contains a reference to the ser's Servers.
+    'server' returns the first entry for the users' servers.
+    'servers' is a list that contains a reference to the user's Servers.
     """
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -351,8 +351,10 @@ class Group(Base):
 class User(Base):
     """The User table
 
-    Each user can have more than a single server,
-    and multiple tokens used for authorization.
+    Each user can have one or more single user notebook servers.
+
+    Each single user notebook server will have a unique token for authorization.
+    Therefore, a user with multiple notebook servers will have multiple tokens.
 
     API tokens grant access to the Hub's REST API.
     These are used by single-user servers to authenticate requests,
@@ -364,8 +366,9 @@ class User(Base):
     A `state` column contains a JSON dict,
     used for restoring state of a Spawner.
 
-    'server' returns the first entry for the users' servers.
-    'servers' is a list that contains a reference to the user's Servers.
+
+    `servers` is a list that contains a reference for each of the user's single user notebook servers.
+    The method `server` returns the first entry in the user's `servers` list.
     """
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -429,12 +432,10 @@ class User(Base):
 
 class UserServer(Base):
     """The UserServer table
-    Each user can have have more than one server,
-    we use this table to mantain the Many-To-One
-    relationship between Users and Servers tables.
 
-    Servers can have only 1 user, this condition is mantained
-    by UniqueConstraint
+    A table storing the One-To-Many relationship between a user and servers.
+    Each user may have one or more servers.
+    A server can have only one (1) user. This condition is maintained by UniqueConstraint.
     """
     __tablename__ = 'users_servers'
 

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -32,8 +32,11 @@ from .utils import (
 
 class JSONDict(TypeDecorator):
     """Represents an immutable structure as a json-encoded string.
+
     Usage::
+
         JSONEncodedDict(255)
+
     """
 
     impl = TEXT
@@ -56,6 +59,7 @@ Base.log = app_log
 
 class Server(Base):
     """The basic state of a server
+
     connection and cookie info
     """
     __tablename__ = 'servers'
@@ -98,6 +102,7 @@ class Server(Base):
     @property
     def bind_url(self):
         """representation of URL used for binding
+
         Never used in APIs, only logging,
         since it can be non-connectable value, such as '', meaning all interfaces.
         """
@@ -120,6 +125,7 @@ class Server(Base):
 
 class Proxy(Base):
     """A configurable-http-proxy instance.
+
     A proxy consists of the API server info and the public-facing server info,
     plus an auth token for configuring the proxy table.
     """
@@ -218,6 +224,7 @@ class Proxy(Base):
     @gen.coroutine
     def add_all_services(self, service_dict):
         """Update the proxy table from the database.
+
         Used when loading up a new proxy.
         """
         db = inspect(self).session
@@ -233,6 +240,7 @@ class Proxy(Base):
     @gen.coroutine
     def add_all_users(self, user_dict):
         """Update the proxy table from the database.
+
         Used when loading up a new proxy.
         """
         db = inspect(self).session
@@ -293,7 +301,9 @@ class Proxy(Base):
 
 class Hub(Base):
     """Bring it all together at the hub.
+
     The Hub is a server, plus its API path suffix
+
     the api_url is the full URL plus the api_path suffix on the end
     of the server base_url.
     """
@@ -344,15 +354,20 @@ class Group(Base):
 
 class User(Base):
     """The User table
+
     Each user can have more than a single server,
     and multiple tokens used for authorization.
+
     API tokens grant access to the Hub's REST API.
     These are used by single-user servers to authenticate requests,
     and external services to manipulate the Hub.
+
     Cookies are set with a single ID.
     Resetting the Cookie ID invalidates all cookies, forcing user to login again.
+
     A `state` column contains a JSON dict,
     used for restoring state of a Spawner.
+
     `server` returns the first entry for the users' servers.
     'servers' is a list that contains a reference to the ser's Servers.
     """
@@ -449,15 +464,20 @@ class UserServer(Base):
 
 class Service(Base):
     """A service run with JupyterHub
+
     A service is similar to a User without a Spawner.
     A service can have API tokens for accessing the Hub's API
+
     It has:
     - name
     - admin
     - api tokens
     - server (if proxied http endpoint)
+
     In addition to what it has in common with users, a Service has extra info:
+
     - pid: the process id (if managed)
+
     """
     __tablename__ = 'services'
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -482,6 +502,7 @@ class Service(Base):
     @classmethod
     def find(cls, db, name):
         """Find a service by name.
+
         Returns None if not found.
         """
         return db.query(cls).filter(cls.name==name).first()
@@ -539,6 +560,7 @@ class APIToken(Base):
     @classmethod
     def find(cls, db, token, *, kind=None):
         """Find a token object by value.
+
         Returns None if not found.
 
         `kind='user'` only returns API tokens for users

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -30,8 +30,8 @@ def db():
         _db = orm.new_session_factory('sqlite:///:memory:', echo=True)()
         user = orm.User(
             name=getuser(),
-            server=orm.Server(),
         )
+        user.servers.append(orm.Server())
         hub = orm.Hub(
             server=orm.Server(),
         )

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -54,7 +54,7 @@ def test_hub(db):
             port = 1234,
             base_url='/hubtest/',
         ),
-
+        
     )
     db.add(hub)
     db.commit()
@@ -129,14 +129,14 @@ def test_service_server(db):
     service = orm.Service(name='has_servers')
     db.add(service)
     db.commit()
-
+    
     assert service.server is None
     server = service.server = orm.Server()
     assert service
     assert server.id is None
     db.commit()
     assert isinstance(server.id, int)
-
+    
 
 def test_token_find(db):
     service = db.query(orm.Service).first()
@@ -172,17 +172,17 @@ def test_spawn_fails(db, io_loop):
     orm_user = orm.User(name='aeofel')
     db.add(orm_user)
     db.commit()
-
+    
     class BadSpawner(MockSpawner):
         @gen.coroutine
         def start(self):
             raise RuntimeError("Split the party")
-
+    
     user = User(orm_user, {
         'spawner_class': BadSpawner,
         'config': None,
     })
-
+    
     with pytest.raises(Exception) as exc:
         io_loop.run_sync(user.spawn)
     assert user.server is None
@@ -192,7 +192,7 @@ def test_spawn_fails(db, io_loop):
 def test_groups(db):
     user = orm.User.find(db, name='aeofel')
     db.add(user)
-
+    
     group = orm.Group(name='lives')
     db.add(group)
     db.commit()

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -54,7 +54,7 @@ def test_hub(db):
             port = 1234,
             base_url='/hubtest/',
         ),
-        
+
     )
     db.add(hub)
     db.commit()
@@ -65,9 +65,10 @@ def test_hub(db):
 
 def test_user(db):
     user = orm.User(name='kaylee',
-        server=orm.Server(),
         state={'pid': 4234},
     )
+    server = orm.Server()
+    user.servers.append(server)
     db.add(user)
     db.commit()
     assert user.name == 'kaylee'
@@ -128,14 +129,14 @@ def test_service_server(db):
     service = orm.Service(name='has_servers')
     db.add(service)
     db.commit()
-    
+
     assert service.server is None
     server = service.server = orm.Server()
     assert service
     assert server.id is None
     db.commit()
     assert isinstance(server.id, int)
-    
+
 
 def test_token_find(db):
     service = db.query(orm.Service).first()
@@ -171,17 +172,17 @@ def test_spawn_fails(db, io_loop):
     orm_user = orm.User(name='aeofel')
     db.add(orm_user)
     db.commit()
-    
+
     class BadSpawner(MockSpawner):
         @gen.coroutine
         def start(self):
             raise RuntimeError("Split the party")
-    
+
     user = User(orm_user, {
         'spawner_class': BadSpawner,
         'config': None,
     })
-    
+
     with pytest.raises(Exception) as exc:
         io_loop.run_sync(user.spawn)
     assert user.server is None
@@ -191,7 +192,7 @@ def test_spawn_fails(db, io_loop):
 def test_groups(db):
     user = orm.User.find(db, name='aeofel')
     db.add(user)
-    
+
     group = orm.Group(name='lives')
     db.add(group)
     db.commit()

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -18,23 +18,23 @@ from .spawner import LocalProcessSpawner
 
 class UserDict(dict):
     """Like defaultdict, but for users
-    
+
     Getting by a user id OR an orm.User instance returns a User wrapper around the orm user.
     """
     def __init__(self, db_factory, settings):
         self.db_factory = db_factory
         self.settings = settings
         super().__init__()
-    
+
     @property
     def db(self):
         return self.db_factory()
-    
+
     def __contains__(self, key):
         if isinstance(key, (User, orm.User)):
             key = key.id
         return dict.__contains__(self, key)
-    
+
     def __getitem__(self, key):
         if isinstance(key, User):
             key = key.id
@@ -63,7 +63,7 @@ class UserDict(dict):
             return dict.__getitem__(self, id)
         else:
             raise KeyError(repr(key))
-    
+
     def __delitem__(self, key):
         user = self[key]
         user_id = user.id
@@ -74,13 +74,13 @@ class UserDict(dict):
 
 
 class User(HasTraits):
-    
+
     @default('log')
     def _log_default(self):
         return app_log
-    
+
     settings = Dict()
-    
+
     db = Any(allow_none=True)
     @default('db')
     def _db_default(self):
@@ -94,32 +94,32 @@ class User(HasTraits):
             id = self.orm_user.id
             self.orm_user = change['new'].query(orm.User).filter(orm.User.id==id).first()
         self.spawner.db = self.db
-    
+
     orm_user = None
     spawner = None
     spawn_pending = False
     stop_pending = False
     waiting_for_response = False
-    
+
     @property
     def authenticator(self):
         return self.settings.get('authenticator', None)
-    
+
     @property
     def spawner_class(self):
         return self.settings.get('spawner_class', LocalProcessSpawner)
-    
+
     def __init__(self, orm_user, settings, **kwargs):
         self.orm_user = orm_user
         self.settings = settings
         super().__init__(**kwargs)
-        
+
         hub = self.db.query(orm.Hub).first()
-        
+
         self.cookie_name = '%s-%s' % (hub.server.cookie_name, quote(self.name, safe=''))
         self.base_url = url_path_join(
             self.settings.get('base_url', '/'), 'user', self.escaped_name)
-        
+
         self.spawner = self.spawner_class(
             user=self,
             db=self.db,
@@ -127,24 +127,24 @@ class User(HasTraits):
             authenticator=self.authenticator,
             config=self.settings.get('config'),
         )
-    
+
     # pass get/setattr to ORM user
-    
+
     def __getattr__(self, attr):
         if hasattr(self.orm_user, attr):
             return getattr(self.orm_user, attr)
         else:
             raise AttributeError(attr)
-    
+
     def __setattr__(self, attr, value):
         if self.orm_user and hasattr(self.orm_user, attr):
             setattr(self.orm_user, attr, value)
         else:
             super().__setattr__(attr, value)
-    
+
     def __repr__(self):
         return repr(self.orm_user)
-    
+
     @property
     def running(self):
         """property for whether a user has a running server"""
@@ -153,25 +153,25 @@ class User(HasTraits):
         if self.server is None:
             return False
         return True
-    
+
     @property
     def escaped_name(self):
         """My name, escaped for use in URLs, cookies, etc."""
         return quote(self.name, safe='@')
-    
+
     @property
     def proxy_path(self):
         if self.settings.get('subdomain_host'):
             return url_path_join('/' + self.domain, self.base_url)
         else:
             return self.base_url
-    
+
     @property
     def domain(self):
         """Get the domain for my server."""
         # FIXME: escaped_name probably isn't escaped enough in general for a domain fragment
         return self.escaped_name + '.' + self.settings['domain']
-    
+
     @property
     def host(self):
         """Get the *host* for my server (proto://domain[:port])"""
@@ -179,11 +179,11 @@ class User(HasTraits):
         parsed = urlparse(self.settings['subdomain_host'])
         h = '%s://%s.%s' % (parsed.scheme, self.escaped_name, parsed.netloc)
         return h
-    
+
     @property
     def url(self):
         """My URL
-        
+
         Full name.domain/path if using subdomains, otherwise just my /base/url
         """
         if self.settings.get('subdomain_host'):
@@ -193,22 +193,22 @@ class User(HasTraits):
             )
         else:
             return self.base_url
-    
+
     @gen.coroutine
     def spawn(self, options=None):
         """Start the user's spawner"""
         db = self.db
-        
-        self.server = orm.Server(
+        server = orm.Server(
             cookie_name=self.cookie_name,
             base_url=self.base_url,
         )
-        db.add(self.server)
+        self.servers.append(server)
+        db.add(self)
         db.commit()
-        
+
         api_token = self.new_api_token()
         db.commit()
-        
+
         spawner = self.spawner
         spawner.user_options = options or {}
         # we are starting a new server, make sure it doesn't restore state
@@ -294,7 +294,7 @@ class User(HasTraits):
     @gen.coroutine
     def stop(self):
         """Stop the user's spawner
-        
+
         and cleanup after it.
         """
         self.spawn_pending = False
@@ -316,7 +316,8 @@ class User(HasTraits):
             orm_token = orm.APIToken.find(self.db, api_token)
             if orm_token:
                 self.db.delete(orm_token)
-            self.server = None
+            for server in self.servers:
+                self.db.delete(server)
             self.db.commit()
         finally:
             self.stop_pending = False
@@ -326,4 +327,3 @@ class User(HasTraits):
                 yield gen.maybe_future(
                     auth.post_spawn_stop(self, spawner)
                 )
-

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -315,9 +315,9 @@ class User(HasTraits):
             spawner.clear_state()
             self.state = spawner.get_state()
             self.last_activity = datetime.utcnow()
-            # cleanup server entry, API token from defunct server
+            # Cleanup defunct servers: delete entry and API token for each server
             for server in self.servers:
-                # cleanup servers entry from db
+                # remove server entry from db
                 self.db.delete(server)
             if not spawner.will_resume:
                 # find and remove the API token if the spawner isn't


### PR DESCRIPTION
I added the UserServer model and corrected the User model.

Now you can access servers from user.servers and Users from server.users.

With user.server is equal to user.servers[0] otherwise is None.

I corrected the test_orm.py but probably there is something more to do.