### PR TITLE
fix rest-api doc building

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "bootprint": "^0.8.5",
+    "bootprint": "^0.10.0",
     "bootprint-openapi": "^0.17.0"
   }
 }

--- a/docs/source/rest.md
+++ b/docs/source/rest.md
@@ -67,4 +67,4 @@ Note: The Swagger specification is being renamed the [OpenAPI Initiative][].
 
 [on swagger's petstore]: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#!/default
 [OpenAPI Initiative]: https://www.openapis.org/
-[JupyterHub REST API]: ./api/index.html
+[JupyterHub REST API]: ./_static/rest-api/index.html


### PR DESCRIPTION
- fix link to rest-api page
- update bootprint to 0.10, since 0.8 has stopped working

@willingc this should fix the RTD builds you saw yesterday