### PR TITLE
Pass query params through with user-redirect

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -571,6 +571,9 @@ class UserRedirectHandler(BaseHandler):
     def get(self, path):
         user = self.get_current_user()
         url = url_path_join(user.url, path)
+        if self.request.query:
+            # FIXME: use urlunparse instead?
+            url += '?' + self.request.query
         self.redirect(url)
 
 


### PR DESCRIPTION
Currently query params are stripped when sent through user-redirect,
which causes problems in many places (including UC Berkeley's interact
service)