### PR TITLE
singleuser-server service example

### DIFF
--- a/examples/service-notebook/README.md
+++ b/examples/service-notebook/README.md
@@ -6,5 +6,20 @@ one as a 'managed' service, and one as an external service with supervisor.
 A single-user notebook server is run as a service,
 and uses groups to authenticate a collection of users with the Hub.
 
+In these examples, a JupyterHub group `'shared'` is created,
+and a notebook server is spawned at `/services/shared-notebook`.
+Any user in the `'shared'` group will be able to access the notebook server at `/services/shared-notebook/`.
+
+In both examples, you will want to select the name of the group,
+and the name of the shared-notebook service.
+
+In the external example, some extra steps are required to set up supervisor:
+
+1. select a system user to run the service. This is  a user on the system, and does not need to be a Hub user. Add this to the user field in `shared-notebook.conf`, replacing `someuser`.
+2. generate a secret token for authentication, and replace the `super-secret` fields in `shared-notebook-service` and `jupyterhub_config.py`
+3. install `shared-notebook-service` somewhere on your system, and update `/path/to/shared-notebook-service` to the absolute path of this destination
+3. copy `shared-notebook.conf` to `/etc/supervisor/conf.d/`
+4. `supervisorctl reload`
+
 These examples require jupyterhub >= 0.7.2.
 

--- a/examples/service-notebook/README.md
+++ b/examples/service-notebook/README.md
@@ -3,6 +3,8 @@
 This directory contains two examples of running a shared notebook server as a service,
 one as a 'managed' service, and one as an external service with supervisor.
 
+These examples require jupyterhub >= 0.7.2.
+
 A single-user notebook server is run as a service,
 and uses groups to authenticate a collection of users with the Hub.
 
@@ -20,6 +22,4 @@ In the external example, some extra steps are required to set up supervisor:
 3. install `shared-notebook-service` somewhere on your system, and update `/path/to/shared-notebook-service` to the absolute path of this destination
 3. copy `shared-notebook.conf` to `/etc/supervisor/conf.d/`
 4. `supervisorctl reload`
-
-These examples require jupyterhub >= 0.7.2.
 

--- a/examples/service-notebook/README.md
+++ b/examples/service-notebook/README.md
@@ -1,0 +1,10 @@
+# Running a shared notebook as a service
+
+This directory contains two examples of running a shared notebook server as a service,
+one as a 'managed' service, and one as an external service with supervisor.
+
+A single-user notebook server is run as a service,
+and uses groups to authenticate a collection of users with the Hub.
+
+These examples require jupyterhub >= 0.7.2.
+

--- a/examples/service-notebook/external/jupyterhub_config.py
+++ b/examples/service-notebook/external/jupyterhub_config.py
@@ -1,0 +1,24 @@
+# our user list
+c.Authenticator.whitelist = [
+    'minrk',
+    'ellisonbg',
+    'willingc',
+]
+
+# ellisonbg and willingc have access to a shared server:
+
+c.JupyterHub.load_groups = {
+    'shared': [
+        'ellisonbg',
+        'willingc',
+    ]
+}
+
+# start the notebook server as a service
+c.JupyterHub.services = [
+    {
+        'name': 'shared-notebook',
+        'url': 'http://127.0.0.1:9999',
+        'api_token': 'super-secret',
+    }
+]

--- a/examples/service-notebook/external/shared-notebook-service
+++ b/examples/service-notebook/external/shared-notebook-service
@@ -1,0 +1,12 @@
+#!/bin/bash -l
+set -e
+
+export JUPYTERHUB_API_TOKEN=super-secret
+
+jupyterhub-singleuser \
+    --cookie-name=jupyterhub-services \
+    --port=9999 \
+    --group='shared' \
+    --base-url=/services/shared-notebook \
+    --hub-prefix=/hub/ \
+    --hub-api-url=http://127.0.0.1:8081/hub/api/

--- a/examples/service-notebook/external/shared-notebook.conf
+++ b/examples/service-notebook/external/shared-notebook.conf
@@ -1,0 +1,14 @@
+[program:jupyterhub-shared-notebook]
+user=someuser
+command=bash -l /path/to/shared-notebook-service
+directory=/home/someuser
+autostart=true
+autorestart=true
+startretries=1
+exitcodes=0,2
+stopsignal=TERM
+redirect_stderr=true
+stdout_logfile=/var/log/jupyterhub-service-shared-notebook.log
+stdout_logfile_maxbytes=1MB
+stdout_logfile_backups=10
+stdout_capture_maxbytes=1MB

--- a/examples/service-notebook/managed/jupyterhub_config.py
+++ b/examples/service-notebook/managed/jupyterhub_config.py
@@ -1,0 +1,38 @@
+# our user list
+c.Authenticator.whitelist = [
+    'minrk',
+    'ellisonbg',
+    'willingc',
+]
+
+# ellisonbg and willingc have access to a shared server:
+
+c.JupyterHub.load_groups = {
+    'shared': [
+        'ellisonbg',
+        'willingc',
+    ]
+}
+
+hub_ip = '127.0.0.1'
+hub_api_port = 8081
+service_name = 'shared-notebook'
+group_name = 'shared'
+service_port = 9999
+
+# start the notebook server as a service
+c.JupyterHub.services = [
+    {
+        'name': service_name,
+        'url': 'http://127.0.0.1:{}'.format(service_port),
+        'command': [
+            'jupyterhub-singleuser',
+            '--cookie-name=jupyterhub-services',
+            '--port={}'.format(service_port),
+            '--group={}'.format(group_name),
+            '--base-url=/services/{}'.format(service_name),
+            '--hub-prefix=/hub/',
+            '--hub-api-url=http://{}:{}/hub/api'.format(hub_ip, hub_api_port),
+        ]
+    }
+]

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -228,11 +228,18 @@ class SingleUserNotebookApp(NotebookApp):
         super(SingleUserNotebookApp, self).start()
 
     def init_hub_auth(self):
-        if not os.environ.get('JPY_API_TOKEN'):
-            self.exit("JPY_API_TOKEN env is required to run jupyterhub-singleuser. Did you launch it manually?")
+        api_token = None
+        if os.getenv('JPY_API_TOKEN'):
+            # Deprecated env variable (as of 0.7.2)
+            api_token = os.environ.pop('JPY_API_TOKEN')
+        if os.getenv('JUPYTERHUB_API_TOKEN'):
+            api_token = os.environ.pop('JUPYTERHUB_API_TOKEN')
+        
+        if not api_token:
+            self.exit("JUPYTERHUB_API_TOKEN env is required to run jupyterhub-singleuser. Did you launch it manually?")
         self.hub_auth = HubAuth(
             parent=self,
-            api_token=os.environ.pop('JPY_API_TOKEN'),
+            api_token=api_token,
             api_url=self.hub_api_url,
         )
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -190,7 +190,7 @@ class Spawner(LoggingConfigurable):
         Environment variables that end up in the single-user server's process come from 3 sources:
           - This `environment` configurable
           - The JupyterHub process' environment variables that are whitelisted in `env_keep`
-          - Variables to establish contact between the single-user notebook and the hub (such as JPY_API_TOKEN)
+          - Variables to establish contact between the single-user notebook and the hub (such as JUPYTERHUB_API_TOKEN)
 
         The `enviornment` configurable should be set by JupyterHub administrators to add
         installation specific environment variables. It is a dict where the key is the name of the environment
@@ -414,7 +414,9 @@ class Spawner(LoggingConfigurable):
                 env[key] = value(self)
             else:
                 env[key] = value
-
+        
+        env['JUPYTERHUB_API_TOKEN'] = self.api_token
+        # deprecated (as of 0.7.2), for old versions of singleuser
         env['JPY_API_TOKEN'] = self.api_token
 
         # Put in limit and guarantee info if they exist.


### PR DESCRIPTION
I discovered along the way that HubAuth with groups wasn't working at all, so this was a nice test case.


TODO:

- [x] managed example
- [x] external example
- [x] fix & test for HubAuth with groups (#925)

In another PR, I'll add more defaults for jupyterhub-singleuser to have better defaults and respect the services env variables, so the commands don't have to be so verbose.