### PR TITLE
support service env vars in singleuser entrypoint

### DIFF
--- a/examples/service-notebook/external/shared-notebook-service
+++ b/examples/service-notebook/external/shared-notebook-service
@@ -2,11 +2,8 @@
 set -e
 
 export JUPYTERHUB_API_TOKEN=super-secret
+export JUPYTERHUB_SERVICE_URL=http://127.0.0.1:9999
+export JUPYTERHUB_SERVICE_NAME=shared-notebook
 
 jupyterhub-singleuser \
-    --cookie-name=jupyterhub-services \
-    --port=9999 \
-    --group='shared' \
-    --base-url=/services/shared-notebook \
-    --hub-prefix=/hub/ \
-    --hub-api-url=http://127.0.0.1:8081/hub/api/
+    --group='shared'

--- a/examples/service-notebook/managed/jupyterhub_config.py
+++ b/examples/service-notebook/managed/jupyterhub_config.py
@@ -14,11 +14,9 @@ c.JupyterHub.load_groups = {
     ]
 }
 
-hub_ip = '127.0.0.1'
-hub_api_port = 8081
 service_name = 'shared-notebook'
-group_name = 'shared'
 service_port = 9999
+group_name = 'shared'
 
 # start the notebook server as a service
 c.JupyterHub.services = [
@@ -27,12 +25,8 @@ c.JupyterHub.services = [
         'url': 'http://127.0.0.1:{}'.format(service_port),
         'command': [
             'jupyterhub-singleuser',
-            '--cookie-name=jupyterhub-services',
-            '--port={}'.format(service_port),
-            '--group={}'.format(group_name),
-            '--base-url=/services/{}'.format(service_name),
-            '--hub-prefix=/hub/',
-            '--hub-api-url=http://{}:{}/hub/api'.format(hub_ip, hub_api_port),
-        ]
+            '--group=shared',
+            '--debug',
+        ],
     }
 ]

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -300,8 +300,12 @@ class HubAuthenticated(object):
         Returns:
             user_model (dict): The user model, if a user is identified, None if authentication fails.
         """
+        if hasattr(self, '_hub_auth_user_cache'):
+            return self._hub_auth_user_cache
         user_model = self.hub_auth.get_user(self)
         if not user_model:
+            self._hub_auth_user_cache = None
             return
-        return self.check_hub_user(user_model)
+        self._hub_auth_user_cache = self.check_hub_user(user_model)
+        return self._hub_auth_user_cache
 

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+from urllib.parse import urlparse
 
 from jinja2 import ChoiceLoader, FunctionLoader
 
@@ -21,6 +22,7 @@ from traitlets import (
     Unicode,
     CUnicode,
     default,
+    observe,
     validate,
     TraitError,
 )
@@ -124,6 +126,7 @@ def _exclude_home(path_list):
         if not p.startswith(home):
             yield p
 
+
 class SingleUserNotebookApp(NotebookApp):
     """A Subclass of the regular NotebookApp that is aware of the parent multiuser context."""
     description = dedent("""
@@ -139,14 +142,49 @@ class SingleUserNotebookApp(NotebookApp):
 
     user = CUnicode().tag(config=True)
     group = CUnicode().tag(config=True)
-    def _user_changed(self, name, old, new):
-        self.log.name = new
-    hub_prefix = Unicode().tag(config=True)
+    @observe('user')
+    def _user_changed(self, change):
+        self.log.name = change.new
+
     hub_host = Unicode().tag(config=True)
+
+    hub_prefix = Unicode('/hub/').tag(config=True)
+    @default('hub_prefix')
+    def _hub_prefix_default(self):
+        base_url = os.environ.get('JUPYTERHUB_BASE_URL') or '/'
+        return base_url + 'hub/'
+
     hub_api_url = Unicode().tag(config=True)
+    @default('hub_api_url')
+    def _hub_api_url_default(self):
+        return os.environ.get('JUPYTERHUB_API_URL') or 'http://127.0.0.1:8081/hub/api'
+
+    # defaults for some configurables that may come from service env variables:
+    @default('base_url')
+    def _base_url_default(self):
+        return os.environ.get('JUPYTERHUB_SERVICE_PREFIX') or '/'
+
+    @default('cookie_name')
+    def _cookie_name_default(self):
+        if os.environ.get('JUPYTERHUB_SERVICE_NAME'):
+            # if I'm a service, use the services cookie name
+            return 'jupyterhub-services'
+
+    @default('port')
+    def _port_default(self):
+        if os.environ.get('JUPYTERHUB_SERVICE_URL'):
+            url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
+            return url.port
+
+    @default('ip')
+    def _ip_default(self):
+        if os.environ.get('JUPYTERHUB_SERVICE_URL'):
+            url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
+            return url.hostname
+
     aliases = aliases
     flags = flags
-    
+
     # disble some single-user configurables
     token = ''
     open_browser = False


### PR DESCRIPTION
simplifies the shared-notebook service examples, where default values don't need to be re-specified.