### PR TITLE
Fixed help and documentation related to service tokens

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -453,7 +453,7 @@ class JupyterHub(Application):
                 {
                     'name': 'formgrader',
                     'url': 'http://127.0.0.1:1234',
-                    'token': 'super-secret',
+                    'api_token': 'super-secret',
                     'environment':
                 }
             ]

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -27,7 +27,7 @@ An externally managed service running on a URL::
         'name': 'my-service',
         'url': 'https://host:8888',
         'admin': True,
-        'token': 'super-secret',
+        'api_token': 'super-secret',
     }
 
 A hub-managed service with no URL:


### PR DESCRIPTION
The documentation stated that the key `token` should be used to specify
the pregenerated token in `JupyterHub.services`. This is wrong as the key
should be `api_token`.

This changes the help on the trait, along with changing the module
docstring in `service.py`.