### PR TITLE
Allow services to request admin-access

### DIFF
--- a/docs/source/services.md
+++ b/docs/source/services.md
@@ -45,6 +45,8 @@ A Service may have the following properties:
 - `url: str (default - None)` - The URL where the service is/should be. If a
   url is specified for where the Service runs its own web server,
   the service will be added to the proxy at `/services/:name`
+- `api_token: str (default - None)` - For Externally-Managed Services you need to specify 
+  an API token to perform API requests to the Hub
 
 If a service is also to be managed by the Hub, it has a few extra options:
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -208,7 +208,10 @@ class UserAdminAccessAPIHandler(APIHandler):
         if not user.running:
             raise web.HTTPError(400, "%s's server is not running" % name)
         self.set_server_cookie(user)
-        current.other_user_cookies.add(name)
+        # a service can also ask for a user cookie
+        # this code prevent to raise an error
+        if getattr(current, 'other_user_cookies', None) is not None:
+            current.other_user_cookies.add(name)
 
 
 default_handlers = [


### PR DESCRIPTION
Currently when you call the api with a service
`
http://127.0.0.1:8000/hub/api/users/<name>/admin-access`

you receive a 500 error because the service doesn't have a `other_user_cookies` defined inside the orm.

With this fix `current.other_user_cookies.add(name)` is only called for users and not for services.

I also added a little bit more info inside the doc about api_token as a property of a service.