### PR TITLE
check name collisions on rename

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -151,8 +151,8 @@ class UserAPIHandler(APIHandler):
         data = self.get_json_body()
         self._check_user_model(data)
         # check if the new name is already taken
-        new_username = self.find_user(data['name']) if 'name' in data else None
-        if new_username is not None:
+        new_name = self.find_user(data['name']) if 'name' in data else None
+        if new_name is not None:
             # check if the provided name inside the json is the same of the url
             if name != data['name']:
                 raise web.HTTPError(400, "User %s already exists, username must be unique" % data['name'])

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -150,11 +150,9 @@ class UserAPIHandler(APIHandler):
             raise web.HTTPError(404)
         data = self.get_json_body()
         self._check_user_model(data)
-        # check if the new name is already taken
-        new_name = self.find_user(data['name']) if 'name' in data else None
-        if new_name is not None:
-            # check if the provided name inside the json is the same of the url
-            if name != data['name']:
+        if 'name' in data and data['name'] != name:
+            # check if the new name is already taken:
+            if self.find_user(data['name']):
                 raise web.HTTPError(400, "User %s already exists, username must be unique" % data['name'])
         for key, value in data.items():
             setattr(user, key, value)

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -150,6 +150,12 @@ class UserAPIHandler(APIHandler):
             raise web.HTTPError(404)
         data = self.get_json_body()
         self._check_user_model(data)
+        # check if the new name is already taken
+        new_username = self.find_user(data['name']) if 'name' in data else None
+        if new_username is not None:
+            # check if the provided name inside the json is the same of the url
+            if name != data['name']:
+                raise web.HTTPError(400, "User %s already exists, username must be unique" % data['name'])
         for key, value in data.items():
             setattr(user, key, value)
         self.db.commit()

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -151,7 +151,7 @@ class UserAPIHandler(APIHandler):
         data = self.get_json_body()
         self._check_user_model(data)
         if 'name' in data and data['name'] != name:
-            # check if the new name is already taken:
+            # check if the new name is already taken inside db
             if self.find_user(data['name']):
                 raise web.HTTPError(400, "User %s already exists, username must be unique" % data['name'])
         for key, value in data.items():
@@ -214,6 +214,7 @@ class UserAdminAccessAPIHandler(APIHandler):
         self.set_server_cookie(user)
         # a service can also ask for a user cookie
         # this code prevents to raise an error
+        # cause service doesn't have 'other_user_cookies'
         if getattr(current, 'other_user_cookies', None) is not None:
             current.other_user_cookies.add(name)
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -209,7 +209,7 @@ class UserAdminAccessAPIHandler(APIHandler):
             raise web.HTTPError(400, "%s's server is not running" % name)
         self.set_server_cookie(user)
         # a service can also ask for a user cookie
-        # this code prevent to raise an error
+        # this code prevents to raise an error
         if getattr(current, 'other_user_cookies', None) is not None:
             current.other_user_cookies.add(name)
 


### PR DESCRIPTION
It checks if the new name provided is unique, if yes it raises an error.

It doesn't raise an error in case names inside json and {name} are the same.

closes #941