### PR TITLE
Refactor test classes used to mock services

### DIFF
--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -1,7 +1,9 @@
-"""Mock service for testing
+"""Helpers for testing a Service
 
-basic HTTP Server that echos URLs back,
-and allow retrieval of sys.argv.
+Each handler functions as a basic HTTP Server that echos URLs back,
+and allows retrieval of sys.argv.
+
+These handlers are useful when testing a mock Service.
 """
 
 import json
@@ -15,20 +17,20 @@ from jupyterhub.services.auth import HubAuthenticated
 
 
 class EchoHandler(web.RequestHandler):
-    """Handler that mocks a request to the tornado webserver"""
+    """Reply to an HTTP request with the path of the request."""
     def get(self):
         self.write(self.request.path)
 
 
 class EnvHandler(web.RequestHandler):
-    """Handler that mocks a request using header and environment settings"""
+    """Reply to an HTTP request with the service's environment as JSON."""
     def get(self):
         self.set_header('Content-Type', 'application/json')
         self.write(json.dumps(dict(os.environ)))
 
 
 class APIHandler(web.RequestHandler):
-    """Handler that mocks a request using an API token"""
+    """Relay API requests to the Hub's API using the service's API token."""
     def get(self, path):
         api_token = os.environ['JUPYTERHUB_API_TOKEN']
         api_url = os.environ['JUPYTERHUB_API_URL']
@@ -41,7 +43,7 @@ class APIHandler(web.RequestHandler):
 
 
 class WhoAmIHandler(HubAuthenticated, web.RequestHandler):
-    """Handler that mocks a request with an authenticated user"""
+    """Reply with the name of the user who made the request."""
     @web.authenticated
     def get(self):
         self.write(self.get_current_user())

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -15,41 +15,33 @@ from jupyterhub.services.auth import HubAuthenticated
 
 
 class EchoHandler(web.RequestHandler):
-    def data_received(self, chunk):
-        pass
-
+    """Handler that mocks a request to the tornado webserver"""
     def get(self):
         self.write(self.request.path)
 
 
 class EnvHandler(web.RequestHandler):
-    def data_received(self, chunk):
-        pass
-
+    """Handler that mocks a request using header and environment settings"""
     def get(self):
         self.set_header('Content-Type', 'application/json')
         self.write(json.dumps(dict(os.environ)))
 
 
 class APIHandler(web.RequestHandler):
-    def data_received(self, chunk):
-        pass
-
+    """Handler that mocks a request using an API token"""
     def get(self, path):
         api_token = os.environ['JUPYTERHUB_API_TOKEN']
         api_url = os.environ['JUPYTERHUB_API_URL']
-        r = requests.get(api_url + path, headers={
-            'Authorization': 'token %s' % api_token
-        })
+        r = requests.get(api_url + path,
+            headers={'Authorization': 'token %s' % api_token},
+        )
         r.raise_for_status()
         self.set_header('Content-Type', 'application/json')
         self.write(r.text)
 
 
 class WhoAmIHandler(HubAuthenticated, web.RequestHandler):
-    def data_received(self, chunk):
-        pass
-
+    """Handler that mocks a request with an authenticated user"""
     @web.authenticated
     def get(self):
         self.write(self.get_current_user())

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -1,9 +1,13 @@
-"""Helpers for testing a Service
+"""Mock service for testing Service integration
 
-Each handler functions as a basic HTTP Server that echos URLs back,
-and allows retrieval of sys.argv.
+A JupyterHub service running a basic HTTP server.
+Used by the mockservice fixtures.
 
-These handlers are useful when testing a mock Service.
+Handlers allow:
+
+- echoing proxied URLs back
+- retrieving service's environment variables
+- testing service's API access to the Hub retrieval of sys.argv.
 """
 
 import json

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -4,29 +4,37 @@ basic HTTP Server that echos URLs back,
 and allow retrieval of sys.argv.
 """
 
-import argparse
 import json
 import os
-import sys
 from urllib.parse import urlparse
 
 import requests
 from tornado import web, httpserver, ioloop
 
-from jupyterhub.services.auth import  HubAuthenticated
+from jupyterhub.services.auth import HubAuthenticated
+
 
 class EchoHandler(web.RequestHandler):
+    def data_received(self, chunk):
+        pass
+
     def get(self):
         self.write(self.request.path)
 
 
 class EnvHandler(web.RequestHandler):
+    def data_received(self, chunk):
+        pass
+
     def get(self):
         self.set_header('Content-Type', 'application/json')
         self.write(json.dumps(dict(os.environ)))
 
 
 class APIHandler(web.RequestHandler):
+    def data_received(self, chunk):
+        pass
+
     def get(self, path):
         api_token = os.environ['JUPYTERHUB_API_TOKEN']
         api_url = os.environ['JUPYTERHUB_API_URL']
@@ -37,7 +45,10 @@ class APIHandler(web.RequestHandler):
         self.set_header('Content-Type', 'application/json')
         self.write(r.text)
 
+
 class WhoAmIHandler(HubAuthenticated, web.RequestHandler):
+    def data_received(self, chunk):
+        pass
 
     @web.authenticated
     def get(self):


### PR DESCRIPTION
- For classes that inherit from the abstract base class, `web.RequestHandler`, add methods that were previously not implemented.

- Remove unused imports
