### PR TITLE
Rename test class to stub class to allow pytest collection

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
 ignore_errors = True
 omit =
     jupyterhub/tests/*
+    jupyterhub/alembic/*
     */site-packages/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,5 @@ exclude_lines =
     if __name__ == .__main__.:
 ignore_errors = True
 omit =
-    tests/*
+    jupyterhub/tests/*
+    */site-packages/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,15 @@
 [run]
+branch = False
 omit =
     jupyterhub/tests/*
     jupyterhub/alembic/*
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
     - pip install --pre -f travis-wheels/wheelhouse -r dev-requirements.txt .
 script:
-    - travis_retry py.test --cov jupyterhub jupyterhub/tests -v
+    - travis_retry py.test --cov=jupyterhub jupyterhub/tests -v
 after_success:
     - codecov
 matrix:

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -234,7 +234,7 @@ class MockSingleUserServer(SingleUserNotebookApp):
         pass
 
 
-class TestSingleUserSpawner(MockSpawner):
+class StubSingleUserSpawner(MockSpawner):
     """Spawner that starts a MockSingleUserServer in a thread."""
     _thread = None
     @gen.coroutine

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -6,14 +6,14 @@ import sys
 import requests
 
 import jupyterhub
-from .mocking import TestSingleUserSpawner, public_url
+from .mocking import StubSingleUserSpawner, public_url
 from ..utils import url_path_join
 
 
 def test_singleuser_auth(app, io_loop):
-    # use TestSingleUserSpawner to launch a single-user app in a thread
-    app.spawner_class = TestSingleUserSpawner
-    app.tornado_settings['spawner_class'] = TestSingleUserSpawner
+    # use StubSingleUserSpawner to launch a single-user app in a thread
+    app.spawner_class = StubSingleUserSpawner
+    app.tornado_settings['spawner_class'] = StubSingleUserSpawner
     
     # login, start the server
     cookies = app.login_user('nandy')
@@ -39,9 +39,9 @@ def test_singleuser_auth(app, io_loop):
 
 
 def test_disable_user_config(app, io_loop):
-    # use TestSingleUserSpawner to launch a single-user app in a thread
-    app.spawner_class = TestSingleUserSpawner
-    app.tornado_settings['spawner_class'] = TestSingleUserSpawner
+    # use StubSingleUserSpawner to launch a single-user app in a thread
+    app.spawner_class = StubSingleUserSpawner
+    app.tornado_settings['spawner_class'] = StubSingleUserSpawner
     # login, start the server
     cookies = app.login_user('nandy')
     user = app.users['nandy']


### PR DESCRIPTION
Fixes #952 

pytest throws a warning to indicate it will not collect test classes with an inherited `__init__` method. 

This PR renames a test class from TestSingleUserSpawner to StubSingleUserSpawner to satisfy pytest that the mocked class is not being tested but instead simply sets up the test case. [See reference re: fix by pytest core dev](http://hackebrot.github.io/pytest-tricks/show_pytest_warnings/).

Individual tests are renamed to reflect the class name change.