### PR TITLE
Added user_for_token method, moved r check into its own function

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -156,8 +156,9 @@ class HubAuth(Configurable):
             app_log.warning("Failed to check authorization: [%i] %s", r.status_code, r.reason)
             raise HTTPError(500, "Failed to check authorization")
         else:
+            data = r.json()
             app_log.debug("Received request from Hub user %s", data)
-            return r.json()
+            return data
 
     def user_for_cookie(self, encrypted_cookie, use_cache=True):
         """Ask the Hub to identify the user for a given cookie.

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -147,7 +147,7 @@ class HubAuth(Configurable):
             app_log.warning("No Hub user identified for request")
             data = None
         elif r.status_code == 403:
-            app_log.error("I don't have permission to verify cookies, my auth token may have expired: [%i] %s", r.status_code, r.reason)
+            app_log.error("I don't have permission to check authorization with JupyterHub, my auth token may have expired: [%i] %s", r.status_code, r.reason)
             raise HTTPError(500, "Permission failure checking authorization, I may need a new token")
         elif r.status_code >= 500:
             app_log.error("Upstream failure verifying auth token: [%i] %s", r.status_code, r.reason)


### PR DESCRIPTION
This pull request adds the `user_for_token` method to the HubAuth class. This enables easy access to authenticate and get a user by their token.

The response check was moved into its own function to remove duplicating code.