### PR TITLE
Enable token authentication in HubAuth

### DIFF
--- a/examples/service-whoami-flask/whoami.py
+++ b/examples/service-whoami-flask/whoami.py
@@ -29,7 +29,7 @@ def main():
     app = Application([
         (os.environ['JUPYTERHUB_SERVICE_PREFIX'] + '/?', WhoAmIHandler),
         (r'.*', WhoAmIHandler),
-    ], login_url='/hub/login')
+    ])
     
     http_server = HTTPServer(app)
     url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -312,6 +312,10 @@ class HubAuthenticated(object):
     def hub_auth(self, auth):
         self._hub_auth = auth
 
+    def get_login_url(self):
+        """Return the Hub's login URL"""
+        return self.hub_auth.login_url
+
     def check_hub_user(self, user_model):
         """Check whether Hub-authenticated user should be allowed.
 

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -63,6 +63,14 @@ class JupyterHubLoginHandler(LoginHandler):
         return True
 
     @staticmethod
+    def is_token_authenticated(handler):
+        """Is the request token-authenticated?"""
+        if getattr(handler, '_cached_hub_user', None) is None:
+            # ensure get_user has been called, so we know if we're token-authenticated
+            handler.get_current_user()
+        return getattr(handler, '_token_authenticated', False)
+
+    @staticmethod
     def get_user(handler):
         """alternative get_current_user to query the Hub"""
         # patch in HubAuthenticated class for querying the Hub for cookie authentication

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -298,7 +298,7 @@ class SingleUserNotebookApp(NotebookApp):
         s['hub_prefix'] = self.hub_prefix
         s['hub_host'] = self.hub_host
         s['hub_auth'] = self.hub_auth
-        s['login_url'] = self.hub_host + self.hub_prefix
+        self.hub_auth.login_url = self.hub_host + self.hub_prefix
         s['csp_report_uri'] = self.hub_host + url_path_join(self.hub_prefix, 'security/csp-report')
         super(SingleUserNotebookApp, self).init_webapp()
         self.patch_templates()


### PR DESCRIPTION
follow-up to #960
closes #891

- further consolidate some duplicate code asking the Hub to identify a user
- enable token authentication in `.get_user()`
- fully support notebook-4.3 API in single-user for token auth
- add missing `.get_login_url` that tornado needs for redirecting to the Hub for login