### PR TITLE
support service tokens in HubAuth

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -18,7 +18,11 @@ class TokenAPIHandler(APIHandler):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             raise web.HTTPError(404)
-        self.write(json.dumps(self.user_model(self.users[orm_token.user])))
+        if orm_token.user:
+            model = self.user_model(self.users[orm_token.user])
+        elif orm_token.service:
+            model = self.service_model(orm_token.service)
+        self.write(json.dumps(model))
 
     @gen.coroutine
     def post(self):

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -89,6 +89,7 @@ class APIHandler(BaseHandler):
     def user_model(self, user):
         """Get the JSON model for a User object"""
         model = {
+            'kind': 'user',
             'name': user.name,
             'admin': user.admin,
             'groups': [ g.name for g in user.groups ],
@@ -105,6 +106,7 @@ class APIHandler(BaseHandler):
     def group_model(self, group):
         """Get the JSON model for a Group object"""
         return {
+            'kind': 'group',
             'name': group.name,
             'users': [ u.name for u in group.users ],
         }

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -106,7 +106,15 @@ class APIHandler(BaseHandler):
         """Get the JSON model for a Group object"""
         return {
             'name': group.name,
-            'users': [ u.name for u in group.users ]
+            'users': [ u.name for u in group.users ],
+        }
+
+    def service_model(self, service):
+        """Get the JSON model for a Service object"""
+        return {
+            'kind': 'service',
+            'name': service.name,
+            'admin': service.admin,
         }
 
     _user_model_types = {
@@ -151,6 +159,7 @@ class APIHandler(BaseHandler):
         for groupname in model.get('groups', []):
             if not isinstance(groupname, str):
                 raise web.HTTPError(400, ("group names must be str, not %r", type(groupname)))
+
 
     def options(self, *args, **kwargs):
         self.set_header('Access-Control-Allow-Headers', 'accept, content-type')

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -127,6 +127,8 @@ class MockHub(JupyterHub):
     
     base_url = '/@/space%20word/'
     
+    log_datefmt = '%M:%S'
+    
     @default('subdomain_host')
     def _subdomain_host_default(self):
         return os.environ.get('JUPYTERHUB_TEST_SUBDOMAIN_HOST', '')

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -168,6 +168,7 @@ def test_get_users(app):
         u.pop('last_activity')
     assert users == [
         {
+            'kind': 'user',
             'name': 'admin',
             'groups': [],
             'admin': True,
@@ -175,6 +176,7 @@ def test_get_users(app):
             'pending': None,
         },
         {
+            'kind': 'user',
             'name': 'user',
             'groups': [],
             'admin': False,
@@ -209,6 +211,7 @@ def test_get_user(app):
     user = r.json()
     user.pop('last_activity')
     assert user == {
+        'kind': 'user',
         'name': name,
         'groups': [],
         'admin': False,
@@ -570,6 +573,7 @@ def test_groups_list(app):
     r.raise_for_status()
     reply = r.json()
     assert reply == [{
+        'kind': 'group',
         'name': 'alphaflight',
         'users': []
     }]
@@ -589,6 +593,7 @@ def test_group_get(app):
     r.raise_for_status()
     reply = r.json()
     assert reply == {
+        'kind': 'group',
         'name': 'alphaflight',
         'users': ['sasquatch']
     }


### PR DESCRIPTION
- support service tokens in /api/authorizations
- add hub_services to HubAuth
- add 'kind' field to models, which is needed to easily distinguish between users and servers

closes #954