### PR TITLE
redirect to `/hub/login` to avoid automatically starting login process

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from tornado.escape import url_escape
 from tornado import gen
 
+from ..utils import url_path_join
 from .base import BaseHandler
 
 
@@ -22,7 +23,8 @@ class LogoutHandler(BaseHandler):
                 self.clear_login_cookie(name)
             user.other_user_cookies = set([])
             self.statsd.incr('logout')
-        self.redirect(self.hub.server.base_url, permanent=False)
+
+        self.redirect(url_path_join(self.hub.server.base_url, 'login'), permanent=False)
 
 
 class LoginHandler(BaseHandler):

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -52,7 +52,7 @@ class RootHandler(BaseHandler):
                 url = url_path_join(self.hub.server.base_url, 'home')
                 self.log.debug("User is not running: %s", url)
         else:
-            url = self.authenticator.login_url(self.base_url)
+            url = url_path_join(self.hub.server.base_url, 'login')
         self.redirect(url)
 
 


### PR DESCRIPTION
- from root
- from logout

Login should start with the "Login with..." button, not occur automatically, even when using OAuth.

closes #967