### PR TITLE
Update traitlets dependency to 4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic
-traitlets>=4.1
+traitlets>=4.3
 tornado>=4.1
 jinja2
 pamela


### PR DESCRIPTION
Fixes #972. Currently, Jupyterhub actually has a hard requirement on the 4.3 traitlets API, otherwise you'll run into the crash described in that issue for any traitlets version older than that.