### PR TITLE
Remove deprecated yield_fixture

### DIFF
--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -8,7 +8,7 @@ from getpass import getuser
 from subprocess import TimeoutExpired
 import time
 from unittest import mock
-from pytest import fixture, yield_fixture, raises
+from pytest import fixture, raises
 from tornado import ioloop
 
 from .. import orm
@@ -51,6 +51,7 @@ def io_loop():
 
 @fixture(scope='module')
 def app(request):
+    """Mock a jupyterhub app for testing"""
     app = MockHub.instance(log_level=logging.DEBUG)
     app.start([])
     def fin():
@@ -97,19 +98,23 @@ def _mockservice(request, app, url=False):
             service.proc.wait(1)
     return service
 
-@yield_fixture
+
+@fixture
 def mockservice(request, app):
+    """Mock a service with no external service url"""
     yield _mockservice(request, app, url=False)
 
-@yield_fixture
+
+@fixture
 def mockservice_url(request, app):
+    """Mock a service with its own url to test external services"""
     yield _mockservice(request, app, url=True)
 
-@yield_fixture
+
+@fixture
 def no_patience(app):
     """Set slow-spawning timeouts to zero"""
     with mock.patch.dict(app.tornado_application.settings,
                          {'slow_spawn_timeout': 0,
                           'slow_stop_timeout': 0}):
         yield
-


### PR DESCRIPTION
- Remove deprecated `yield_fixture` which was deprecated in pytest 3.0. Yield may now be used instead of return and fixtures may be simply decorated with `@pytest.fixture`
- Added docstrings for custom fixtures so that they will provide description when running `pytest --fixtures`