### PR TITLE
Don't pop token env in single-user servers

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -277,9 +277,9 @@ class SingleUserNotebookApp(NotebookApp):
         api_token = None
         if os.getenv('JPY_API_TOKEN'):
             # Deprecated env variable (as of 0.7.2)
-            api_token = os.environ.pop('JPY_API_TOKEN')
+            api_token = os.environ['JPY_API_TOKEN']
         if os.getenv('JUPYTERHUB_API_TOKEN'):
-            api_token = os.environ.pop('JUPYTERHUB_API_TOKEN')
+            api_token = os.environ['JUPYTERHUB_API_TOKEN']
         
         if not api_token:
             self.exit("JUPYTERHUB_API_TOKEN env is required to run jupyterhub-singleuser. Did you launch it manually?")


### PR DESCRIPTION
Users should be allowed to access their own tokens to talk to the Hub API.

I popped the token for vague 'security reasons', but users are allowed to allocate new tokens, so it doesn't make a huge amount of sense to deprive the user's kernels from using the API token set up for their single-user server.

cc @jhamrick this might be the quickest and easiest fix for your nbgrader needs.