### PR TITLE
[WIP] Document tests and try to isolate intermittent test failures

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,9 @@
 [MASTER]
 # Ignore git and virtualenv-related folders.
-ignore=.git,lib
+ignore=
+    .git,
+    lib,
+    jupyterhub/tests/
 
 [MESSAGES CONTROL]
 disable=all

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,9 +17,3 @@ enable=
 [REPORTS]
 # Do not print a summary report
 reports=no
-
-[FORMAT]
-# One of the few stylistic things we try to check.
-# Modules shouldn't be *too large* - should be broken up
-# Feel free to bump this number if you disagree
-max-module-lines=2000

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,22 @@
+[MASTER]
+# Ignore git and virtualenv-related folders.
+ignore=.git,lib
+
+[MESSAGES CONTROL]
+disable=all
+
+# Explicitly whitelist the lint checks we want to have
+# Prefer things that catch errors and what not, and not stylistic choices
+enable=
+    missing-docstring,
+    empty-docstring
+
+[REPORTS]
+# Do not print a summary report
+reports=no
+
+[FORMAT]
+# One of the few stylistic things we try to check.
+# Modules shouldn't be *too large* - should be broken up
+# Feel free to bump this number if you disagree
+max-module-lines=2000

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -448,7 +448,7 @@ class PAMAuthenticator(LocalAuthenticator):
         help="""
         Whether to open a new PAM session when spawners are started.
 
-        This may trigger things like mounting shared filsystems,
+        This may trigger things like mounting shared filesystems,
         loading credentials, etc. depending on system configuration,
         but it does not always work.
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -70,8 +70,7 @@ def app(request):
     return app
 
 
-
-class MockServiceSpawner(jupyterhub.services.service.ServiceSpawner):
+class MockServiceSpawner(jupyterhub.services.service._ServiceSpawner):
     """Mock services for testing. For example, shorter poll intervals."""
     poll_interval = 1
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -54,16 +54,20 @@ def io_loop():
 
 @fixture(scope='module')
 def app(request):
-    """Mock a jupyterhub app for testing"""
-    mocked_app = MockHub.instance(log_level=logging.DEBUG)
-    mocked_app.start([])
+    """Start a Hub.
+
+    The mock multi-user hub, `MockHub`, is a `traitlets.config.Application`
+    singleton object.
+    """
+    app = MockHub.instance(log_level=logging.DEBUG)
+    app.start([])
 
     def fin():
         """Clean up steps for hub at termination"""
         MockHub.clear_instance()
-        mocked_app.stop()
+        app.stop()
     request.addfinalizer(fin)
-    return mocked_app
+    return app
 
 
 

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -24,7 +24,9 @@ from ..utils import random_port
 
 from pamela import PAMError
 
+
 def mock_authenticate(username, password, service='login'):
+    """Mock simple login authentication"""
     # just use equality for testing
     if password == username:
         return True
@@ -33,6 +35,7 @@ def mock_authenticate(username, password, service='login'):
 
 
 def mock_open_session(username, service):
+    """Mock a session"""
     pass
 
 
@@ -101,6 +104,7 @@ class FormSpawner(MockSpawner):
 
 
 class MockPAMAuthenticator(PAMAuthenticator):
+    """Mock JupyterHub PAM Authenticator"""
     @default('admin_users')
     def _admin_users_default(self):
         return {'admin'}

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -280,4 +280,3 @@ class StubSingleUserSpawner(MockSpawner):
             return None
         else:
             return 0
-

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -68,9 +68,8 @@ class OWhoAmIHandler(HubOAuthenticated, web.RequestHandler):
 
 
 def main():
-    pprint.pprint(dict(os.environ), stream=sys.stderr)
-
-    if os.getenv('JUPYTERHUB_SERVICE_URL'):
+    """Mock service and start a tornado IOLoop"""
+    if os.environ['JUPYTERHUB_SERVICE_URL']:
         url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
         app = web.Application([
             (r'.*/env', EnvHandler),

--- a/jupyterhub/tests/mocksu.py
+++ b/jupyterhub/tests/mocksu.py
@@ -12,15 +12,18 @@ from tornado import web, httpserver, ioloop
 from .mockservice import EnvHandler
 
 class EchoHandler(web.RequestHandler):
+    """Handle echoing URLs back"""
     def get(self):
         self.write(self.request.path)
 
+
 class ArgsHandler(web.RequestHandler):
+    """Handle returning sys.argv"""
     def get(self):
         self.write(json.dumps(sys.argv))
 
 def main(args):
-    
+    """Create a server and start tornado IOLoop"""
     app = web.Application([
         (r'.*/args', ArgsHandler),
         (r'.*/env', EnvHandler),

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -105,6 +105,7 @@ def api_request(app, *api_path, **kwargs):
 
 
 def test_auth_api(app):
+    """Test authentication with a valid token"""
     db = app.db
     r = api_request(app, 'authorizations', 'gobbledygook')
     assert r.status_code == 404
@@ -132,6 +133,7 @@ def test_auth_api(app):
 
 
 def test_referer_check(app, io_loop):
+    """Check if referer in request header is valid"""
     url = ujoin(public_host(app), app.hub.server.base_url)
     host = urlparse(url).netloc
     user = find_user(app.db, 'admin')
@@ -185,6 +187,7 @@ def test_referer_check(app, io_loop):
 
 @mark.user
 def test_get_users(app):
+    """Check if API returns users when requested"""
     db = app.db
     r = api_request(app, 'users')
     assert r.status_code == 200
@@ -219,6 +222,7 @@ def test_get_users(app):
 
 @mark.user
 def test_add_user(app):
+    """Check if user can be successfully added by API"""
     db = app.db
     name = 'newuser'
     r = api_request(app, 'users', name, method='post')
@@ -231,6 +235,7 @@ def test_add_user(app):
 
 @mark.user
 def test_get_user(app):
+    """Check if API request returns the user successfully"""
     name = 'user'
     r = api_request(app, 'users', name)
     assert r.status_code == 200
@@ -248,6 +253,7 @@ def test_get_user(app):
 
 @mark.user
 def test_add_multi_user_bad(app):
+    """Check if adding multiple users fails as expected"""
     r = api_request(app, 'users', method='post')
     assert r.status_code == 400
     r = api_request(app, 'users', method='post', data='{}')
@@ -258,6 +264,7 @@ def test_add_multi_user_bad(app):
 
 @mark.user
 def test_add_multi_user_invalid(app):
+    """Test that a change in authenticator username pattern fails"""
     app.authenticator.username_pattern = r'w.*'
     r = api_request(app, 'users', method='post',
         data=json.dumps({'usernames': ['Willow', 'Andrew', 'Tara']})
@@ -269,6 +276,7 @@ def test_add_multi_user_invalid(app):
 
 @mark.user
 def test_add_multi_user(app):
+    """Test requests to add multiple users"""
     db = app.db
     names = ['a', 'b']
     r = api_request(app, 'users', method='post',
@@ -305,6 +313,7 @@ def test_add_multi_user(app):
 
 @mark.user
 def test_add_multi_user_admin(app):
+    """Test if multiple admins are added by a request"""
     db = app.db
     names = ['c', 'd']
     r = api_request(app, 'users', method='post',
@@ -324,6 +333,7 @@ def test_add_multi_user_admin(app):
 
 @mark.user
 def test_add_user_bad(app):
+    """Test if request will not add a user that does not exist in user list"""
     db = app.db
     name = 'dne_newuser'
     r = api_request(app, 'users', name, method='post')
@@ -334,6 +344,7 @@ def test_add_user_bad(app):
 
 @mark.user
 def test_add_admin(app):
+    """Test if request to add a new admin is successful"""
     db = app.db
     name = 'newadmin'
     r = api_request(app, 'users', name, method='post',
@@ -348,6 +359,7 @@ def test_add_admin(app):
 
 @mark.user
 def test_delete_user(app):
+    """Test if request to delete a user is successful"""
     db = app.db
     mal = add_user(db, name='mal')
     r = api_request(app, 'users', 'mal', method='delete')
@@ -356,6 +368,7 @@ def test_delete_user(app):
 
 @mark.user
 def test_make_admin(app):
+    """Test the request to grant a user administrative privileges"""
     db = app.db
     name = 'admin2'
     r = api_request(app, 'users', name, method='post')
@@ -393,6 +406,7 @@ def get_app_user(app, name):
 
 
 def test_spawn(app, io_loop):
+    """Test if API request spawns a single user server"""
     db = app.db
     name = 'wash'
     user = add_user(db, app=app, name=name)
@@ -444,6 +458,7 @@ def test_spawn(app, io_loop):
 
 
 def test_slow_spawn(app, io_loop, no_patience, request):
+    """Test if an API request spawns a single user server slowly"""
     patch = mock.patch.dict(app.tornado_settings, {'spawner_class': mocking.SlowSpawner})
     patch.start()
     request.addfinalizer(patch.stop)
@@ -493,6 +508,7 @@ def test_slow_spawn(app, io_loop, no_patience, request):
 
 
 def test_never_spawn(app, io_loop, no_patience, request):
+    """"Test if a request never spawns a single user server"""
     patch = mock.patch.dict(app.tornado_settings, {'spawner_class': mocking.NeverSpawner})
     patch.start()
     request.addfinalizer(patch.stop)
@@ -517,6 +533,7 @@ def test_never_spawn(app, io_loop, no_patience, request):
 
 
 def test_get_proxy(app, io_loop):
+    """Test the API request for proxy information"""
     r = api_request(app, 'proxy')
     r.raise_for_status()
     reply = r.json()
@@ -524,6 +541,7 @@ def test_get_proxy(app, io_loop):
 
 
 def test_cookie(app):
+    """Test if a valid cookie is passed in a request"""
     db = app.db
     name = 'patience'
     user = add_user(db, app=app, name=name)
@@ -558,6 +576,7 @@ def test_cookie(app):
 
 
 def test_token(app):
+    """Test if token is authorized"""
     name = 'book'
     user = add_user(app.db, app=app, name=name)
     token = user.new_api_token()
@@ -575,6 +594,7 @@ def test_token(app):
     ({}, {'username': 'fake', 'password': 'fake'}, 200),
 ])
 def test_get_new_token(app, headers, data, status):
+    """Test the request to get a new token"""
     if data:
         data = json.dumps(data)
     # request a new token
@@ -596,6 +616,7 @@ def test_get_new_token(app, headers, data, status):
 
 @mark.group
 def test_groups_list(app):
+    """Test the request to list all the available groups"""
     r = api_request(app, 'groups')
     r.raise_for_status()
     reply = r.json()
@@ -618,6 +639,7 @@ def test_groups_list(app):
 
 @mark.group
 def test_group_get(app):
+    """Test that request returns a group of users"""
     group = orm.Group.find(app.db, name='alphaflight')
     user = add_user(app.db, app=app, name='sasquatch')
     group.users.append(user)
@@ -638,6 +660,7 @@ def test_group_get(app):
 
 @mark.group
 def test_group_create_delete(app):
+    """Tests the requests to create and later delete a group successfully"""
     db = app.db
     r = api_request(app, 'groups/runaways', method='delete')
     assert r.status_code == 404
@@ -674,6 +697,7 @@ def test_group_create_delete(app):
 
 @mark.group
 def test_group_add_users(app):
+    """Test the request to add a group of users"""
     db = app.db
     # must specify users
     r = api_request(app, 'groups/alphaflight/users', method='post', data='{}')
@@ -696,6 +720,7 @@ def test_group_add_users(app):
 
 @mark.group
 def test_group_delete_users(app):
+    """Test the request to delete a group of users"""
     db = app.db
     # must specify users
     r = api_request(app, 'groups/alphaflight/users', method='delete', data='{}')
@@ -723,8 +748,8 @@ def test_group_delete_users(app):
 
 
 @mark.services
-def test_get_services(app, mockservice_url):
-    mockservice = mockservice_url
+def test_get_services(app, mockservice):
+    """Test request to get information on all services"""
     db = app.db
     r = api_request(app, 'services')
     r.raise_for_status()
@@ -749,8 +774,8 @@ def test_get_services(app, mockservice_url):
 
 
 @mark.services
-def test_get_service(app, mockservice_url):
-    mockservice = mockservice_url
+def test_get_service(app, mockservice):
+    """Test requests for a specific service"""
     db = app.db
     r = api_request(app, 'services/%s' % mockservice.name)
     r.raise_for_status()
@@ -779,6 +804,7 @@ def test_get_service(app, mockservice_url):
 
 
 def test_root_api(app):
+    """Test that the expected version of the API is returned"""
     base_url = app.hub.server.url
     url = ujoin(base_url, 'api')
     r = requests.get(url)
@@ -790,6 +816,7 @@ def test_root_api(app):
 
 
 def test_info(app):
+    """Test an API request for information returns data for settings"""
     r = api_request(app, 'info')
     r.raise_for_status()
     data = r.json()
@@ -819,12 +846,14 @@ def test_info(app):
 
 
 def test_options(app):
+    """Test API request for available options in headers"""
     r = api_request(app, 'users', method='options')
     r.raise_for_status()
     assert 'Access-Control-Allow-Headers' in r.headers
 
 
 def test_bad_json_body(app):
+    """Test that a request including data that is not json fails"""
     r = api_request(app, 'users', method='post', data='notjson')
     assert r.status_code == 400
 
@@ -835,6 +864,7 @@ def test_bad_json_body(app):
 
 
 def test_shutdown(app):
+    """Test API shutdown hub request"""
     r = api_request(app, 'shutdown', method='post',
         data=json.dumps({'servers': True, 'proxy': True,}),
     )

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -14,12 +14,16 @@ from .mocking import MockHub
 from .. import orm
 from ..app import COOKIE_SECRET_BYTES
 
+
 def test_help_all():
+    """Test JupyterHub --help-all command"""
     out = check_output([sys.executable, '-m', 'jupyterhub', '--help-all']).decode('utf8', 'replace')
     assert '--ip' in out
     assert '--JupyterHub.ip' in out
 
+
 def test_token_app():
+    """Test jupyterhub token command"""
     cmd = [sys.executable, '-m', 'jupyterhub', 'token']
     out = check_output(cmd + ['--help-all']).decode('utf8', 'replace')
     with TemporaryDirectory() as td:
@@ -28,7 +32,9 @@ def test_token_app():
         out = check_output(cmd + ['user'], cwd=td).decode('utf8', 'replace').strip()
     assert re.match(r'^[a-z0-9]+$', out)
 
+
 def test_generate_config():
+    """Test jupyterhub --generate-config command"""
     with NamedTemporaryFile(prefix='jupyterhub_config', suffix='.py') as tf:
         cfg_file = tf.name
     with open(cfg_file, 'w') as f:
@@ -56,7 +62,9 @@ def test_generate_config():
     assert 'Spawner.cmd' in cfg_text
     assert 'Authenticator.whitelist' in cfg_text
 
+
 def test_init_tokens(io_loop):
+    """Test initialization of api tokens"""
     with TemporaryDirectory() as td:
         db_file = os.path.join(td, 'jupyterhub.sqlite')
         tokens = {
@@ -92,6 +100,7 @@ def test_init_tokens(io_loop):
 
 
 def test_write_cookie_secret(tmpdir):
+    """Test that cookie secret is written to hub"""
     secret_path = str(tmpdir.join('cookie_secret'))
     hub = MockHub(cookie_secret_file=secret_path)
     hub.init_secrets()
@@ -101,6 +110,7 @@ def test_write_cookie_secret(tmpdir):
 
 
 def test_cookie_secret_permissions(tmpdir):
+    """Test cookie secret permission is not set to public"""
     secret_file = tmpdir.join('cookie_secret')
     secret_path = str(secret_file)
     secret = os.urandom(COOKIE_SECRET_BYTES)
@@ -119,6 +129,7 @@ def test_cookie_secret_permissions(tmpdir):
 
 
 def test_cookie_secret_content(tmpdir):
+    """Test cookie secret refers to valid content"""
     secret_file = tmpdir.join('cookie_secret')
     secret_file.write('not base 64: uñiço∂e')
     secret_path = str(secret_file)
@@ -129,6 +140,7 @@ def test_cookie_secret_content(tmpdir):
 
 
 def test_cookie_secret_env(tmpdir):
+    """Test that cookie secret exists in the system environment"""
     hub = MockHub(cookie_secret_file=str(tmpdir.join('cookie_secret')))
 
     with patch.dict(os.environ, {'JPY_COOKIE_SECRET': 'not hex'}):
@@ -142,6 +154,7 @@ def test_cookie_secret_env(tmpdir):
 
 
 def test_load_groups(io_loop):
+    """Test if user groups are loaded from db"""
     to_load = {
         'blue': ['cyclops', 'rogue', 'wolverine'],
         'gold': ['storm', 'jean-grey', 'colossus'],

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -10,7 +10,9 @@ from .mocking import MockPAMAuthenticator
 
 from jupyterhub import auth, orm
 
+
 def test_pam_auth(io_loop):
+    """Test if user can be PAM Authenticated"""
     authenticator = MockPAMAuthenticator()
     authorized = io_loop.run_sync(lambda : authenticator.get_authenticated_user(None, {
         'username': 'match',
@@ -24,7 +26,9 @@ def test_pam_auth(io_loop):
     }))
     assert authorized is None
 
+
 def test_pam_auth_whitelist(io_loop):
+    """Test that whitelisted users are PAM Authenticated"""
     authenticator = MockPAMAuthenticator(whitelist={'wash', 'kaylee'})
     authorized = io_loop.run_sync(lambda : authenticator.get_authenticated_user(None, {
         'username': 'kaylee',
@@ -46,11 +50,14 @@ def test_pam_auth_whitelist(io_loop):
 
 
 class MockGroup:
+    """A mock group of users for testing authentication"""
     def __init__(self, *names):
+        """Initialize the group of users in memory"""
         self.gr_mem = names
 
 
 def test_pam_auth_group_whitelist(io_loop):
+    """Test user in a group whitelist can be authenticated"""
     g = MockGroup('kaylee')
     def getgrnam(name):
         return g
@@ -73,6 +80,7 @@ def test_pam_auth_group_whitelist(io_loop):
 
 
 def test_pam_auth_no_such_group(io_loop):
+    """Test if unrecognized whitelist group is not authenticated"""
     authenticator = MockPAMAuthenticator(group_whitelist={'nosuchcrazygroup'})
     authorized = io_loop.run_sync(lambda : authenticator.get_authenticated_user(None, {
         'username': 'kaylee',
@@ -82,6 +90,7 @@ def test_pam_auth_no_such_group(io_loop):
 
 
 def test_wont_add_system_user(io_loop):
+    """Test that a user will not be added unless the user is on whitelist"""
     user = orm.User(name='lioness4321')
     authenticator = auth.PAMAuthenticator(whitelist={'mal'})
     authenticator.create_system_users = False
@@ -90,6 +99,7 @@ def test_wont_add_system_user(io_loop):
 
 
 def test_cant_add_system_user(io_loop):
+    """Test that user that is not on whitelist can not be added to system"""
     user = orm.User(name='lioness4321')
     authenticator = auth.PAMAuthenticator(whitelist={'mal'})
     authenticator.add_user_cmd = ['jupyterhub-fake-command']
@@ -116,6 +126,7 @@ def test_cant_add_system_user(io_loop):
 
 
 def test_add_system_user(io_loop):
+    """Test if user can be added to system even if user is not on whitelist"""
     user = orm.User(name='lioness4321')
     authenticator = auth.PAMAuthenticator(whitelist={'mal'})
     authenticator.create_system_users = True
@@ -136,6 +147,7 @@ def test_add_system_user(io_loop):
 
 
 def test_delete_user(io_loop):
+    """Test that user not in whitelist can be deleted"""
     user = orm.User(name='zoe')
     a = MockPAMAuthenticator(whitelist={'mal'})
     
@@ -147,6 +159,7 @@ def test_delete_user(io_loop):
 
 
 def test_urls():
+    """Test if urls for login/logout are correct"""
     a = auth.PAMAuthenticator()
     logout = a.logout_url('/base/url/')
     login = a.login_url('/base/url')
@@ -155,12 +168,14 @@ def test_urls():
 
 
 def test_handlers(app):
+    """Test that a handler exists for login"""
     a = auth.PAMAuthenticator()
     handlers = a.get_handlers(app)
     assert handlers[0][0] == '/login'
 
 
 def test_normalize_names(io_loop):
+    """Test names are normalized"""
     a = MockPAMAuthenticator()
     authorized = io_loop.run_sync(lambda : a.get_authenticated_user(None, {
         'username': 'ZOE',
@@ -186,7 +201,9 @@ def test_normalize_names(io_loop):
     }))
     assert authorized == 'test'
 
+
 def test_username_map(io_loop):
+    """Test if normalized authenticator username is mapped to JupyterHub user"""
     a = MockPAMAuthenticator(username_map={'wash': 'alpha'})
     authorized = io_loop.run_sync(lambda : a.get_authenticated_user(None, {
         'username': 'WASH',
@@ -203,6 +220,7 @@ def test_username_map(io_loop):
 
 
 def test_validate_names(io_loop):
+    """Test validation of usernames by authenticator"""
     a = auth.PAMAuthenticator()
     assert a.validate_username('willow')
     assert a.validate_username('giles')
@@ -212,5 +230,3 @@ def test_validate_names(io_loop):
     a = auth.PAMAuthenticator(username_pattern='w.*')
     assert not a.validate_username('xander')
     assert a.validate_username('willow')
-
-

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -1,3 +1,4 @@
+"""Database tests"""
 from glob import glob
 import os
 import shutil
@@ -12,37 +13,42 @@ from ..app import NewToken, UpgradeDB, JupyterHub
 here = os.path.dirname(__file__)
 old_db = os.path.join(here, 'old-jupyterhub.sqlite')
 
+
 def generate_old_db(path):
+    """Return url for old SQLite test database"""
     db_path = os.path.join(path, "jupyterhub.sqlite")
     print(old_db, db_path)
     shutil.copy(old_db, db_path)
-    return 'sqlite:///%s' % db_path
+    return 'sqlite:///{}'.format(db_path)
+
 
 def test_upgrade(tmpdir):
+    """Try to upgrade an old SQLite test database"""
     print(tmpdir)
     db_url = generate_old_db(str(tmpdir))
     print(db_url)
     upgrade(db_url)
 
+
 def test_upgrade_entrypoint(tmpdir, io_loop):
+    """Test upgrade of a database creates a backup"""
     generate_old_db(str(tmpdir))
     tmpdir.chdir()
-    tokenapp = NewToken()
-    tokenapp.initialize(['kaylee'])
+    token_app = NewToken()
+    token_app.initialize(['kaylee'])
     with raises(OperationalError):
-        tokenapp.start()
+        token_app.start()
 
     sqlite_files = glob(os.path.join(str(tmpdir), 'jupyterhub.sqlite*'))
     assert len(sqlite_files) == 1
 
-    upgradeapp = UpgradeDB()
-    io_loop.run_sync(lambda : upgradeapp.initialize([]))
-    upgradeapp.start()
+    upgrade_app = UpgradeDB()
+    io_loop.run_sync(lambda: upgrade_app.initialize([]))
+    upgrade_app.start()
 
     # check that backup was created:
     sqlite_files = glob(os.path.join(str(tmpdir), 'jupyterhub.sqlite*'))
     assert len(sqlite_files) == 2
 
-    # run tokenapp again, it should work
-    tokenapp.start()
-    
+    # run token_app again, it should work
+    token_app.start()

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -12,6 +12,7 @@ from .mocking import MockSpawner
 
 
 def test_server(db):
+    """Test that a server is correctly added to the db"""
     server = orm.Server()
     db.add(server)
     db.commit()
@@ -20,25 +21,20 @@ def test_server(db):
     assert server.proto == 'http'
     assert isinstance(server.port, int)
     assert isinstance(server.cookie_name, str)
-    assert server.host == 'http://127.0.0.1:%i' % server.port
+    assert server.host == 'http://127.0.0.1:{}'.format(server.port)
     assert server.url == server.host + '/'
-    assert server.bind_url == 'http://*:%i/' % server.port
+    assert server.bind_url == 'http://*:{}/'.format(server.port)
+
     server.ip = '127.0.0.1'
-    assert server.host == 'http://127.0.0.1:%i' % server.port
+    assert server.host == 'http://127.0.0.1:{}'.format(server.port)
     assert server.url == server.host + '/'
 
 
 def test_proxy(db):
     proxy = orm.Proxy(
         auth_token='abc-123',
-        public_server=orm.Server(
-            ip='192.168.1.1',
-            port=8000,
-        ),
-        api_server=orm.Server(
-            ip='127.0.0.1',
-            port=8001,
-        ),
+        public_server=orm.Server(ip='192.168.1.1', port=8000,),
+        api_server=orm.Server(ip='127.0.0.1',port=8001,),
     )
     db.add(proxy)
     db.commit()
@@ -190,14 +186,15 @@ def test_spawn_fails(db, io_loop):
 
 
 def test_groups(db):
+    """Test user added to a group succeeds"""
     user = orm.User.find(db, name='aeofel')
     db.add(user)
-    
     group = orm.Group(name='lives')
     db.add(group)
     db.commit()
     assert group.users == []
     assert user.groups == []
+
     group.users.append(user)
     db.commit()
     assert group.users == [user]

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -148,7 +148,7 @@ def test_service_server(db):
 
 
 def test_token_find(db):
-    """Test if token is in db"""
+    """Test APIToken.find"""
     service = db.query(orm.Service).first()
     user = db.query(orm.User).first()
     service_token = service.new_api_token()

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -133,9 +133,9 @@ def test_spawn_form(app, io_loop):
         })
         r.raise_for_status()
         assert r.history
-        print(u.spawner)
-        print(u.spawner.user_options)
-        assert u.spawner.user_options == {
+        print(wrapped_user.spawner)
+        print(wrapped_user.spawner.user_options)
+        assert wrapped_user.spawner.user_options == {
             'energy': '511keV',
             'bounds': [-1, 1],
             'notspecified': 5,

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -119,13 +119,14 @@ def test_spawn_page(app):
         assert FormSpawner.options_form in r.text
 
 def test_spawn_form(app, io_loop):
+    """Test server spawns a form successfully"""
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.server.base_url)
         cookies = app.login_user('jones')
-        orm_u = orm.User.find(app.db, 'jones')
-        u = app.users[orm_u]
-        io_loop.run_sync(u.stop)
-    
+        orm_user_data = orm.User.find(app.db, 'jones')
+        wrapped_user = app.users[orm_user_data]
+        io_loop.run_sync(wrapped_user.stop)
+
         r = requests.post(ujoin(base_url, 'spawn?next=/user/jones/tree'), cookies=cookies, data={
             'bounds': ['-1', '1'],
             'energy': '511keV',
@@ -139,6 +140,22 @@ def test_spawn_form(app, io_loop):
             'bounds': [-1, 1],
             'notspecified': 5,
         }
+
+        r = requests.post(
+            ujoin(base_url, 'spawn'),
+            cookies=cookies,
+            data={
+                'bounds': ['-1', '1'],
+                'energy': '511keV',
+            }
+        )
+        r.raise_for_status()
+
+        print(wrapped_user.spawner)
+        print(wrapped_user.spawner.user_options)
+        assert wrapped_user.spawner.user_options == {'energy': '511keV',
+                                                     'bounds': [-1, 1],
+                                                     'notspecified': 5,}
 
 def test_spawn_form_with_file(app, io_loop):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -11,6 +11,7 @@ from ..utils import url_path_join
 
 
 def test_singleuser_auth(app, io_loop):
+    """Checks login authorization with and without cookies and logout"""
     # use StubSingleUserSpawner to launch a single-user app in a thread
     app.spawner_class = StubSingleUserSpawner
     app.tornado_settings['spawner_class'] = StubSingleUserSpawner
@@ -22,38 +23,49 @@ def test_singleuser_auth(app, io_loop):
         io_loop.run_sync(user.spawn)
     url = public_url(app, user)
     
-    # no cookies, redirects to login page
+    # check if no cookies, redirects to login page
     r = requests.get(url)
     r.raise_for_status()
     assert '/hub/login' in r.url
     
-    # with cookies, login successful
+    # check with cookies, login successful
     r = requests.get(url, cookies=cookies)
     r.raise_for_status()
     assert r.url.rstrip('/').endswith('/user/nandy/tree')
     assert r.status_code == 200
     
-    # logout
+    # check that logout request removes user's cookie
     r = requests.get(url_path_join(url, 'logout'), cookies=cookies)
     assert len(r.cookies) == 0
 
 
 def test_disable_user_config(app, io_loop):
+    """Test updating a user's config spawns a new single user server
+
+    - Using a mocked StubSingleUserSpawner launch a single user app in a thread
+    - Login 'nandy' and grab associated cookie and user from db
+    - If there is an existing single user server running for 'nandy', stop it
+    - Start a new single user server with 'nandy's' updated configuration
+    - Get the public url for nandy's new single user server
+    - Check that nandy's new single user server is working and accessible
+    """
     # use StubSingleUserSpawner to launch a single-user app in a thread
     app.spawner_class = StubSingleUserSpawner
     app.tornado_settings['spawner_class'] = StubSingleUserSpawner
+
     # login, start the server
     cookies = app.login_user('nandy')
     user = app.users['nandy']
-    # stop spawner, if running:
     if user.running:
         print("stopping")
         io_loop.run_sync(user.stop)
-    # start with new config:
-    user.spawner.debug = True
+
+    # start a single user server with new config
+    user.spawner.debug = True  # Enable debug log
+    # use config from db not any config that my be in user's $HOME directory
     user.spawner.disable_user_config = True
     io_loop.run_sync(user.spawn)
-    io_loop.run_sync(lambda : app.proxy.add_user(user))
+    io_loop.run_sync(lambda: app.proxy.add_user(user))
     
     url = public_url(app, user)
     
@@ -65,10 +77,12 @@ def test_disable_user_config(app, io_loop):
 
 
 def test_help_output():
+    """Test command line option --help-all"""
     out = check_output([sys.executable, '-m', 'jupyterhub.singleuser', '--help-all']).decode('utf8', 'replace')
     assert 'JupyterHub' in out
 
+
 def test_version():
+    """Test command line option --version"""
     out = check_output([sys.executable, '-m', 'jupyterhub.singleuser', '--version']).decode('utf8', 'replace')
     assert jupyterhub.__version__ in out
-

--- a/jupyterhub/tests/test_traitlets.py
+++ b/jupyterhub/tests/test_traitlets.py
@@ -1,3 +1,4 @@
+"""Test traitlets"""
 import pytest
 from traitlets import HasTraits, TraitError
 
@@ -5,7 +6,9 @@ from jupyterhub.traitlets import URLPrefix, Command, ByteSpecification
 
 
 def test_url_prefix():
+    """Test url prefix configures correctly"""
     class C(HasTraits):
+        """Test class for URLPrefix trait"""
         url = URLPrefix()
     c = C()
     c.url = '/a/b/c/'
@@ -17,7 +20,9 @@ def test_url_prefix():
 
 
 def test_command():
+    """Test command trait"""
     class C(HasTraits):
+        """Test class for Command trait"""
         cmd = Command('default command')
         cmd2 = Command(['default_cmd'])
     c = C()
@@ -28,7 +33,9 @@ def test_command():
 
 
 def test_memoryspec():
+    """Test memory trait and converting string to numerical value"""
     class C(HasTraits):
+        """Test class for ByteSpecification trait"""
         mem = ByteSpecification()
 
     c = C()

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -109,7 +109,6 @@ def auth_decorator(check_auth):
     def decorator(method):
         """Make a method decorator."""
         def decorated(self, *args, **kwargs):
-            """Make a decorator to check authentication."""
             check_auth(self)
             return method(self, *args, **kwargs)
         decorated.__name__ = method.__name__

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -107,7 +107,9 @@ def auth_decorator(check_auth):
     in your decorator, so you can decorate while you decorate.
     """
     def decorator(method):
+        """Make a method decorator."""
         def decorated(self, *args, **kwargs):
+            """Make a decorator to check authentication."""
             check_auth(self)
             return method(self, *args, **kwargs)
         decorated.__name__ = method.__name__


### PR DESCRIPTION
- Adds pylint config to error on no docstrings
- As I have run the tests a bunch on travis, I've seen frequent, though intermittent failures, on a few of the tests (esp. `test_spawn_form` and `test_groups`). It looks like the failures are when there is no connection to the socket and a socket.gaierror is thrown. `socket.getsockname` is involved.
- The errors seem to happen more frequently when testing the subdomain environment variable.

Going to continue to document and trace through the code base while running tests to see where it leads.