### PR TITLE
Pin Python to 3.5 for RTD build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - nodejs
-- python=3
+- python=3.5
 - jinja2
 - pamela
 - requests


### PR DESCRIPTION
Recent changes were made in RTD upstream builds for conda. Currently, conflicting builds when Python 3.6 is used.