### PR TITLE
Hide the logout icon from screen readers

### DIFF
--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -109,7 +109,7 @@
             {% block login_widget %}
               <span id="login_widget">
                 {% if user %}
-                  <a id="logout" class="navbar-btn btn-sm btn btn-default" href="{{logout_url}}"> <i class="fa fa-sign-out"></i> Logout</a>
+                  <a id="logout" class="navbar-btn btn-sm btn btn-default" href="{{logout_url}}"> <i aria-hidden="true" class="fa fa-sign-out"></i> Logout</a>
                 {% else %}
                   <a id="login" class="btn-sm btn navbar-btn btn-default" href="{{login_url}}">Login</a>
                 {% endif %}


### PR DESCRIPTION
This makes the logout link more discoverable by screen readers,
which sort links based on what they say. Since our icon was
in front of and not behind 'Logout', someone looking for Logout
will not find this