### PR TITLE
Teach FormSpawner to handle query next=/path/to/landing

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -529,7 +529,8 @@ class UserSpawnHandler(BaseHandler):
                 status = yield current_user.spawner.poll()
                 if status is not None:
                     if current_user.spawner.options_form:
-                        self.redirect(url_path_join(self.hub.server.base_url, 'spawn'))
+                        self.redirect(url_concat(url_path_join(self.hub.server.base_url, 'spawn'),
+                                                 {'next': self.request.uri}))
                         return
                     else:
                         yield self.spawn_single_user(current_user)

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -7,6 +7,7 @@ from http.client import responses
 
 from jinja2 import TemplateNotFound
 from tornado import web, gen
+from tornado.httputil import url_concat
 
 from .. import orm
 from ..utils import admin_only, url_path_join
@@ -66,8 +67,13 @@ class HomeHandler(BaseHandler):
         if user.running:
             # trigger poll_and_notify event in case of a server that died
             yield user.spawner.poll_and_notify()
+            url = user.url
+        else:
+            url = url_concat(url_path_join(self.base_url, 'spawn'),
+                             {'next': self.request.uri})
         html = self.render_template('home.html',
             user=user,
+            url=url,
         )
         self.finish(html)
 
@@ -85,6 +91,7 @@ class SpawnHandler(BaseHandler):
             user=user,
             spawner_options_form=user.spawner.options_form,
             error_message=message,
+            url=self.request.uri,
         )
 
     @web.authenticated
@@ -126,6 +133,13 @@ class SpawnHandler(BaseHandler):
             return
         self.set_login_cookie(user)
         url = user.url
+
+        next_url = self.get_argument('next', '')
+        if next_url and not next_url.startswith('/'):
+            self.log.warning("Disallowing redirect outside JupyterHub: %r", next_url)
+        elif next_url:
+            url = next_url
+
         self.redirect(url)
 
 class AdminHandler(BaseHandler):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -114,6 +114,10 @@ def test_spawn_page(app):
         assert r.url.endswith('/spawn')
         assert FormSpawner.options_form in r.text
 
+        r = get_page('spawn?next=foo', app, cookies=cookies)
+        assert r.url.endswith('/spawn?next=foo')
+        assert FormSpawner.options_form in r.text
+
 def test_spawn_form(app, io_loop):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.server.base_url)
@@ -122,11 +126,12 @@ def test_spawn_form(app, io_loop):
         u = app.users[orm_u]
         io_loop.run_sync(u.stop)
     
-        r = requests.post(ujoin(base_url, 'spawn'), cookies=cookies, data={
+        r = requests.post(ujoin(base_url, 'spawn?next=/user/jones/tree'), cookies=cookies, data={
             'bounds': ['-1', '1'],
             'energy': '511keV',
         })
         r.raise_for_status()
+        assert r.history
         print(u.spawner)
         print(u.spawner.user_options)
         assert u.spawner.user_options == {

--- a/share/jupyter/hub/templates/home.html
+++ b/share/jupyter/hub/templates/home.html
@@ -8,13 +8,7 @@
       {% if user.running %}
       <a id="stop" class="btn btn-lg btn-danger">Stop My Server</a>
       {% endif %}
-      <a id="start" class="btn btn-lg btn-success"
-      {% if user.running %}
-        href="{{ user.url }}"
-      {% else %}
-        href="{{base_url}}spawn"
-      {% endif %}
-      >
+      <a id="start" class="btn btn-lg btn-success" href="{{ url }}">
       {% if not user.running %}
       Start
       {% endif %}

--- a/share/jupyter/hub/templates/spawn.html
+++ b/share/jupyter/hub/templates/spawn.html
@@ -12,7 +12,7 @@
           Error: {{error_message}}
         </p>
       {% endif %}
-    <form enctype="multipart/form-data" id="spawn_form" action="{{base_url}}spawn" method="post" role="form">
+    <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
       {{spawner_options_form | safe}}
       <br>
       <input type="submit" value="Spawn" class="btn btn-jupyter">


### PR DESCRIPTION
* before, if /user-redirect/ was used, or if ?next=/path/
  and there was a FormSpawner, the query param would be lost