### PR TITLE
Tag c.Spawner.port as configurable

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -77,6 +77,10 @@ class Spawner(LoggingConfigurable):
 
         Defaults to `0`, which uses a randomly allocated port number each time.
 
+        If set to a non-zero value, all Spawners will use the same port,
+        which only makes sense if each server is on a different address,
+        e.g. in containers.
+
         New in version 0.7.
         """
     ).tag(config=True)

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -79,7 +79,7 @@ class Spawner(LoggingConfigurable):
 
         New in version 0.7.
         """
-    )
+    ).tag(config=True)
 
     start_timeout = Integer(60,
         help="""


### PR DESCRIPTION
Fixes #1029 

I'd also like to backport this to a 0.7 point release, since it is required for https://github.com/jupyterhub/kubespawner/issues/31 to work properly. 