### PR TITLE
Allow setting spawner.cmd to None

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -204,6 +204,7 @@ class Spawner(LoggingConfigurable):
     ).tag(config=True)
 
     cmd = Command(['jupyterhub-singleuser'],
+        allow_none=True,
         help="""
         The command used for starting the single-user server.
 


### PR DESCRIPTION
In some spawners you want to unset .cmd - for example, in
KubeSpawner setting it to None will use the CMD metadata that
is set in the Docker Image. Currently there's no way to set a
None value - you can't set it to [] either. Treating None and
empty values as separate is a useful thing to have.