### PR TITLE
prevent warnings about security in single-user servers

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -83,6 +83,11 @@ class JupyterHubLoginHandler(LoginHandler):
             handler.__class__ = type(name, (HubAuthenticatedHandler, handler.__class__), {})
         return handler.get_current_user()
 
+    @classmethod
+    def validate_security(cls, app, ssl_options=None):
+        """Prevent warnings about security from base class"""
+        return
+
 
 class JupyterHubLogoutHandler(LogoutHandler):
     def get(self):


### PR DESCRIPTION
single-user warns if no token or password is set unless validate_security is overridden

these checks are not relevant when using JupyterHub