### PR TITLE
run subdomain test with localhost.jovyan.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ matrix:
   fast_finish: true
   include:
     - python: 3.6
-      env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://127.0.0.1.xip.io:8000
+      env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000


### PR DESCRIPTION
instead of relying on xip.io, which seems to be flaky sometimes

Ultimately, it's the same thing: a wildcard domain that always resolves to 127.0.0.1,
but since we don't need xip's fancy domain-for-any-ip, we can use a static IP on a domain we control.