### PR TITLE
match the whole content when checking if cookie secret is hex

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -103,7 +103,7 @@ flags = {
 
 COOKIE_SECRET_BYTES = 32  # the number of bytes to use when generating new cookie secrets
 
-HEX_RE = re.compile('([a-f0-9]{2})+', re.IGNORECASE)
+HEX_RE = re.compile('^([a-f0-9]{2})+$', re.IGNORECASE)
 
 class NewToken(Application):
     """Generate and print a new API token"""

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -12,6 +12,7 @@ import pytest
 
 from .mocking import MockHub
 from .. import orm
+from ..app import COOKIE_SECRET_BYTES
 
 def test_help_all():
     out = check_output([sys.executable, '-m', 'jupyterhub', '--help-all']).decode('utf8', 'replace')
@@ -102,8 +103,8 @@ def test_write_cookie_secret(tmpdir):
 def test_cookie_secret_permissions(tmpdir):
     secret_file = tmpdir.join('cookie_secret')
     secret_path = str(secret_file)
-    secret = os.urandom(1024)
-    secret_file.write(binascii.b2a_base64(secret))
+    secret = os.urandom(COOKIE_SECRET_BYTES)
+    secret_file.write(binascii.b2a_hex(secret))
     hub = MockHub(cookie_secret_file=secret_path)
 
     # raise with public secret file


### PR DESCRIPTION
fixes spurious message with base64 cookie secrets that start with hex subset.

Also fix the fact that the tests were still using a base64 cookie secret, which was the source of the messages.