### PR TITLE
Prevent crashes due to deleted system users

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1151,7 +1151,14 @@ class JupyterHub(Application):
             self.users[orm_user.id] = user = User(orm_user, self.tornado_settings)
             self.log.debug("Loading state for %s from db", user.name)
             spawner = user.spawner
-            status = yield spawner.poll()
+            status = 0
+            if user.server:
+                try:
+                    status = yield spawner.poll()
+                except Exception:
+                    self.log.exception("Failed to poll Spawner for %s, assuming it is not running.", user.name)
+                    status = -1
+
             if status is None:
                 self.log.info("%s still running", user.name)
                 spawner.add_poll_callback(user_stopped, user)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -954,11 +954,18 @@ class JupyterHub(Application):
             try:
                 yield gen.maybe_future(self.authenticator.add_user(user))
             except Exception:
-                # TODO: Review approach to synchronize whitelist with db
-                # known cause of the exception is a user who has already been removed from the system
-                # but the user still exists in the hub's user db
                 self.log.exception("Error adding user %r already in db", user.name)
-        db.commit()  # can add_user touch the db?
+                if self.authenticator.delete_invalid_users:
+                    self.log.warning("Deleting invalid user %r", user.name)
+                    db.delete(user)
+                else:
+                    self.log.warning(dedent("""
+                    You can set
+                        c.Authenticator.delete_invalid_users = True
+                    to automatically delete users that have been invalidated,
+                    e.g. by deleting them from the external system without notifying JupyterHub.
+                    """))
+        db.commit()
 
         # The whitelist set and the users in the db are now the same.
         # From this point on, any user changes should be done simultaneously
@@ -1156,7 +1163,7 @@ class JupyterHub(Application):
                 try:
                     status = yield spawner.poll()
                 except Exception:
-                    self.log.exception("Failed to poll Spawner for %s, assuming it is not running.", user.name)
+                    self.log.exception("Failed to poll spawner for %s, assuming the spawner is not running.", user.name)
                     status = -1
 
             if status is None:

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -956,14 +956,16 @@ class JupyterHub(Application):
             except Exception:
                 self.log.exception("Error adding user %r already in db", user.name)
                 if self.authenticator.delete_invalid_users:
-                    self.log.warning("Deleting invalid user %r", user.name)
+                    self.log.warning("Deleting invalid user %r from the Hub database", user.name)
                     db.delete(user)
                 else:
                     self.log.warning(dedent("""
                     You can set
                         c.Authenticator.delete_invalid_users = True
-                    to automatically delete users that have been invalidated,
-                    e.g. by deleting them from the external system without notifying JupyterHub.
+                    to automatically delete users from the Hub database that no longer pass
+                    Authenticator validation,
+                    such as when user accounts are deleted from the external system
+                    without notifying JupyterHub.
                     """))
         db.commit()
 

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -126,11 +126,19 @@ class Authenticator(LoggingConfigurable):
     ).tag(config=True)
 
     delete_invalid_users = Bool(False,
-        help="""Delete any invalid users from the database
+        help="""Delete any users from the database that do not pass validation
 
-        When JupyterHub starts, if any users are found in the database
-        that do not pass a `validate_users` check, they will be deleted.
-        Default is False to avoid data loss due to config changes, etc.
+        When JupyterHub starts, `.add_user` will be called
+        on each user in the database to verify that all users are still valid.
+
+        If `delete_invalid_users` is True,
+        any users that do not pass validation will be deleted from the database.
+        Use this if users might be deleted from an external system,
+        such as local user accounts.
+
+        If False (default), invalid users remain in the Hub's database
+        and a warning will be issued.
+        This is the default to avoid data loss due to config changes.
         """
     )
 

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -125,6 +125,15 @@ class Authenticator(LoggingConfigurable):
         """
     ).tag(config=True)
 
+    delete_invalid_users = Bool(False,
+        help="""Delete any invalid users from the database
+
+        When JupyterHub starts, if any users are found in the database
+        that do not pass a `validate_users` check, they will be deleted.
+        Default is False to avoid data loss due to config changes, etc.
+        """
+    )
+
     def normalize_username(self, username):
         """Normalize the given username and return it
 


### PR DESCRIPTION
In three ways:

1. add opt-in `Authenticator.delete_invalid_users`, which will remove any users that fail to be added. Since it's opt-in, the config to enable it is logged when the situation is encountered and the option is not enabled.
2. only poll a server on startup if it could be running (User.server is defined). If a Spawner appears to be running and User.server is not defined, there's not enough information to recover anyway.
3. Catch and log exceptions in pre-flight Spawner.poll, so that Spawner bugs cannot prevent the app from launching.

Each of these individually would fix the specific crash in #1060, but all together, JupyterHub should be better protected from Spawners and the option to keep the userlist in sync should be useful.

closes #1060