### PR TITLE
Allow services to store other user cookies

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -392,7 +392,7 @@ class User(Base):
     auth_state = Column(JSONDict)
     # group mapping
     groups = relationship('Group', secondary='user_group_map', back_populates='users')
-
+    # Cookies granted to access other user servers
     other_user_cookies = set([])
 
     @property
@@ -486,6 +486,7 @@ class Service(Base):
     # common user interface:
     name = Column(Unicode(1023), unique=True)
     admin = Column(Boolean, default=False)
+    other_user_cookies = set([])
 
     api_tokens = relationship("APIToken", backref="service")
 


### PR DESCRIPTION
When a service is run with an admin token and the hub is configured to allow admin access, a POST /users/{name}/admin-access fails with a 500 error because other_user_cookies is not part of the Service ORM.

```
[E 2017-04-15 23:13:06.180 JupyterHub web:1548] Uncaught exception POST /hub/api/users/parente/admin-access (127.0.0.1)
    HTTPServerRequest(protocol='http', host='127.0.0.1:8081', method='POST', uri='/hub/api/users/parente/admin-access', version='HTTP/1.1', remote_ip='127.0.0.1', headers={'Host': '127.0.0.1:8081', 'User-Agent': 'python-requests/2.13.0', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive', 'Authorization': 'token a0529e8638fd40deb1045e2b84bc8a6b', 'Content-Length': '0'})
    Traceback (most recent call last):
      File "/Users/parente/miniconda3/envs/jupyterhub/lib/python3.6/site-packages/tornado/web.py", line 1467, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/Users/parente/projects/jupyterhub/jupyterhub/utils.py", line 109, in decorated
        return method(self, *args, **kwargs)
      File "/Users/parente/projects/jupyterhub/jupyterhub/apihandlers/users.py", line 211, in post
        current.other_user_cookies.add(name)
    AttributeError: 'Service' object has no attribute 'other_user_cookies'
```