### PR TITLE
remove references to unused other_user_cookies

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -19,9 +19,6 @@ class LogoutHandler(BaseHandler):
         if user:
             self.log.info("User logged out: %s", user.name)
             self.clear_login_cookie()
-            for name in user.other_user_cookies:
-                self.clear_login_cookie(name)
-            user.other_user_cookies = set([])
             self.statsd.incr('logout')
 
         self.redirect(url_path_join(self.hub.server.base_url, 'login'), permanent=False)

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -393,8 +393,6 @@ class User(Base):
     # group mapping
     groups = relationship('Group', secondary='user_group_map', back_populates='users')
 
-    other_user_cookies = set([])
-
     @property
     def server(self):
         """Returns the first element of servers.


### PR DESCRIPTION
OAuth gets rid of the concept of the Hub managing cookies on behalf of sub-servers