### PR TITLE
Don't give OAuth access tokens access to the REST API

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -19,6 +19,8 @@ class TokenAPIHandler(APIHandler):
     def get(self, token):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
+            orm_token = orm.OAuthAccessToken.find(self.db, token)
+        if orm_token is None:
             raise web.HTTPError(404)
         if orm_token.user:
             model = self.user_model(self.users[orm_token.user])

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -20,6 +20,11 @@ class SelfAPIHandler(APIHandler):
     @web.authenticated
     def get(self):
         user = self.get_current_user()
+        if user is None:
+            # whoami can be accessed via oauth token
+            user = self.get_current_user_oauth_token()
+        if user is None:
+            raise web.HTTPError(403)
         self.write(json.dumps(self.user_model(user)))
 
 

--- a/jupyterhub/oauth/store.py
+++ b/jupyterhub/oauth/store.py
@@ -5,7 +5,7 @@ implements https://python-oauth2.readthedocs.io/en/latest/store.html
 
 import threading
 
-from oauth2.datatype import Client, AccessToken, AuthorizationCode
+from oauth2.datatype import Client, AuthorizationCode
 from oauth2.error import AuthCodeNotFound, ClientNotFoundError, UserNotAuthenticated
 from oauth2.grant import AuthorizationCodeGrant
 from oauth2.web import AuthorizationCodeGrantSiteAdapter
@@ -17,7 +17,7 @@ from sqlalchemy.orm import scoped_session
 from tornado.escape import url_escape
 
 from .. import orm
-from ..utils import url_path_join, hash_token, compare_token, new_token
+from ..utils import url_path_join, hash_token, compare_token
 
 
 class JupyterHubSiteAdapter(AuthorizationCodeGrantSiteAdapter):

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -638,6 +638,8 @@ class HubOAuthCallbackHandler(HubOAuthenticated, RequestHandler):
         # TODO: make async (in a Thread?)
         token = self.hub_auth.token_for_code(code)
         user_model = self.hub_auth.user_for_token(token)
+        if user_model is None:
+            raise HTTPError(500, "oauth callback failed to identify a user")
         app_log.info("Logged-in user %s", user_model)
         self.hub_auth.set_cookie(self, token)
         next_url = self.get_argument('next', '') or self.hub_auth.base_url

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -5,12 +5,13 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+from textwrap import dedent
 from urllib.parse import urlparse
 
 from jinja2 import ChoiceLoader, FunctionLoader
 
 from tornado import ioloop
-from textwrap import dedent
+from tornado.web import HTTPError
 
 try:
     import notebook
@@ -119,6 +120,8 @@ class OAuthCallbackHandler(HubOAuthCallbackHandler, IPythonHandler):
         # TODO: make async (in a Thread?)
         token = self.hub_auth.token_for_code(code)
         user_model = self.hub_auth.user_for_token(token)
+        if user_model is None:
+            raise HTTPError(500, "oauth callback failed to identify a user")
         self.log.info("Logged-in user %s", user_model)
         self.hub_auth.set_cookie(self, token)
         next_url = self.get_argument('next', '') or self.base_url


### PR DESCRIPTION
We don't want servers that identify users via OAuth to be able to take actions on behalf of those users (for now).

Eventually, we may want to enable this (e.g. services that can start user servers), which would require:

1. a full introduction of auth scopes to API tokens.
2. a permissions-confirmation page in the OAuth flow, which is currently absent because there is only one OAuth scope.

I don't want to introduce that complexity now, so I've just separated OAuth access tokens and enabled them them only on the `/authorizations/token` and `/user` (whoami) entrypoints.