### PR TITLE
Update pip before install of dependencies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - npm install
   - npm install -g configurable-http-proxy
 install:
+  - pip install -U pip
   - pip install --pre -r dev-requirements.txt .
 
 # running tests


### PR DESCRIPTION
Latest requests version can not be installed with an older version of pip. Upgrade pip before installing dependencies.

https://github.com/kennethreitz/requests/issues/4006