### PR TITLE
Don't use getuser to find out current user name for spawning

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1058,7 +1058,6 @@ class JupyterHub(Application):
                 base_url=self.base_url,
                 db=self.db, orm=orm_service,
                 domain=domain, host=host,
-                hub_api_url=self.hub.api_url,
                 hub=self.hub,
             )
 

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -88,6 +88,12 @@ class _ServiceSpawner(LocalProcessSpawner):
             return
         return set_user_setuid(name, chdir=False)
 
+    def user_env(self, env):
+        if not self.user.name:
+            return env
+        else:
+            return super().user_env(env)
+
     def start(self):
         """Start the process"""
         env = self.get_env()

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -39,7 +39,6 @@ A hub-managed service with no URL:
     }
 """
 
-from getpass import getuser
 import pipes
 import shutil
 from subprocess import Popen
@@ -84,7 +83,7 @@ class _ServiceSpawner(LocalProcessSpawner):
     cmd = Command(minlen=0)
 
     def make_preexec_fn(self, name):
-        if not name or name == getuser():
+        if not name:
             # no setuid if no name
             return
         return set_user_setuid(name, chdir=False)
@@ -167,7 +166,7 @@ class Service(LoggingConfigurable):
     def managed(self):
         """Am I managed by the Hub?"""
         return bool(self.command)
-    
+
     @property
     def kind(self):
         """The name of the kind of service as a string
@@ -188,7 +187,7 @@ class Service(LoggingConfigurable):
         Only used if the Hub is spawning the service.
         """
     ).tag(input=True)
-    user = Unicode(getuser(),
+    user = Unicode("",
         help="""The user to become when launching the service.
 
         If unspecified, run the service as the same user as the Hub.

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -258,7 +258,7 @@ class Service(LoggingConfigurable):
 
         env['JUPYTERHUB_SERVICE_NAME'] = self.name
         env['JUPYTERHUB_API_TOKEN'] = self.api_token
-        env['JUPYTERHUB_API_URL'] = self.hub_api_url
+        env['JUPYTERHUB_API_URL'] = self.hub.api_url
         env['JUPYTERHUB_BASE_URL'] = self.base_url
         if self.url:
             env['JUPYTERHUB_SERVICE_URL'] = self.url


### PR DESCRIPTION
It can easily be spoofed, since it only looks at env vars.

Also this causes JupyterHub to needlessly hit the pwd databases, which can fail in interesitng ways.