### PR TITLE
add hub_connect_ip

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -392,11 +392,26 @@ class JupyterHub(Application):
         )
 
     hub_port = Integer(8081,
-        help="The port for this process"
+        help="The port for the Hub process"
     ).tag(config=True)
     hub_ip = Unicode('127.0.0.1',
-        help="The ip for this process"
+        help="""The ip address for the Hub process to *bind* to.
+
+        See `hub_connect_ip` for cases where the bind and connect address should differ.
+        """
     ).tag(config=True)
+    hub_connect_ip = Unicode('',
+        help="""The ip or hostname for proxies and spawners to use
+        for connecting to the Hub.
+
+        Use when the bind address (`hub_ip`) is 0.0.0.0 or otherwise different
+        from the connect address.
+
+        Default: when `hub_ip` is 0.0.0.0, use `socket.gethostname()`, otherwise use `hub_ip`.
+
+        .. versionadded:: 0.8
+        """
+    )
     hub_prefix = URLPrefix('/hub/',
         help="The prefix for the hub server.  Always /base_url/hub/"
     )
@@ -836,7 +851,8 @@ class JupyterHub(Application):
             cookie_name='jupyter-hub-token',
             public_host=self.subdomain_host,
         )
-        print(self.hub)
+        if self.hub_connect_ip:
+            self.hub.connect_ip = self.hub_connect_ip
 
     @gen.coroutine
     def init_users(self):

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -32,14 +32,20 @@ class Server(HasTraits):
     port = Integer()
     base_url = Unicode('/')
     cookie_name = Unicode('')
-    
+
     @property
     def _connect_ip(self):
-        """Property for connect_ip"""
+        """The address to use when connecting to this server
+
+        When `ip` is set to a real ip address, the same value is used.
+        When `ip` refers to 'all interfaces' (e.g. '0.0.0.0'),
+        clients connect via hostname by default.
+        Setting `connect_ip` explicitly overrides any default behavior.
+        """
         if self.connect_ip:
             return self.connect_ip
         elif self.ip in {'', '0.0.0.0'}:
-            # if listening on all interfaces, default to hostname
+            # if listening on all interfaces, default to hostname for connect
             return socket.gethostname()
         else:
             return self.ip

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -246,8 +246,8 @@ class StubSingleUserSpawner(MockSpawner):
     _thread = None
     @gen.coroutine
     def start(self):
-        ip = self.user.server.ip
-        port = self.user.server.port = random_port()
+        ip = self.ip = '127.0.0.1'
+        port = self.port = random_port()
         env = self.get_env()
         args = self.get_args()
         evt = threading.Event()

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -3,6 +3,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import socket
+
 import pytest
 from tornado import gen
 
@@ -24,11 +26,15 @@ def test_server(db):
 
     # test wrapper
     server = objects.Server(orm_server=server)
-    assert server.host == 'http://127.0.0.1:%i' % server.port
+    assert server.host == 'http://%s:%i' % (socket.gethostname(), server.port)
     assert server.url == server.host + '/'
     assert server.bind_url == 'http://*:%i/' % server.port
     server.ip = '127.0.0.1'
     assert server.host == 'http://127.0.0.1:%i' % server.port
+    assert server.url == server.host + '/'
+
+    server.connect_ip = 'hub'
+    assert server.host == 'http://hub:%i' % server.port
     assert server.url == server.host + '/'
 
 


### PR DESCRIPTION
allows specifying the connect ip/hostname for the Hub when it differs from hub_ip (the bind address).

Used when the Hub is not on the same host as the spawners and/or proxy (e.g. docker, kubernetes, etc.)

One default change: when `hub_ip` is 0.0.0.0 (all-interfaces), the default connect ip is `socket.gethostname()` instead of 127.0.0.1, which increases the likelihood that it will work by default, though container cases will likely still need to set this value.

This should mean that Spawner-specific config (e.g. `DockerSpawner.hub_connect_ip`) should no longer be necessary.

closes #1163

cc @yuvipanda