### PR TITLE
disconnect logging during MockHub cleanup

### DIFF
--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -53,6 +53,9 @@ def app(request):
 
 
     def fin():
+        # disconnect logging during cleanup because pytest closes captured FDs prematurely
+        mocked_app.log.handlers = []
+
         MockHub.clear_instance()
         mocked_app.stop()
     request.addfinalizer(fin)


### PR DESCRIPTION
pytest appears to close captured FDs prematurely, causing huge "I/O operation on closed file" tracebacks whenever tests stop early due to a failure.

This should quiet the extra traceback, though it could potentially silence useful log messages during cleanup in rare cases