### PR TITLE
pass more arguments as environment variables instead of CLI args

### DIFF
--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -71,6 +71,12 @@ class _MockUser(HasTraits):
             return self.host + self.server.base_url
         else:
             return self.server.base_url
+    
+    @property
+    def base_url(self):
+        if not self.server:
+            return ''
+        return self.server.base_url
 
 # We probably shouldn't use a Spawner here,
 # but there are too many concepts to share.
@@ -261,9 +267,6 @@ class Service(LoggingConfigurable):
         env.update(self.environment)
 
         env['JUPYTERHUB_SERVICE_NAME'] = self.name
-        env['JUPYTERHUB_API_TOKEN'] = self.api_token
-        env['JUPYTERHUB_API_URL'] = self.hub.api_url
-        env['JUPYTERHUB_BASE_URL'] = self.base_url
         if self.url:
             env['JUPYTERHUB_SERVICE_URL'] = self.url
             env['JUPYTERHUB_SERVICE_PREFIX'] = self.server.base_url

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -241,13 +241,21 @@ class SingleUserNotebookApp(NotebookApp):
     def _port_default(self):
         if os.environ.get('JUPYTERHUB_SERVICE_URL'):
             url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
-            return url.port or 8888
+            if url.port:
+                return url.port
+            elif url.scheme == 'http':
+                return 80
+            elif url.scheme == 'https':
+                return 443
+        return 8888
 
     @default('ip')
     def _ip_default(self):
         if os.environ.get('JUPYTERHUB_SERVICE_URL'):
             url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
-            return url.hostname or '127.0.0.1'
+            if url.hostname:
+                return url.hostname
+        return '127.0.0.1'
 
     aliases = aliases
     flags = flags

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -193,6 +193,14 @@ class SingleUserNotebookApp(NotebookApp):
 
     user = CUnicode().tag(config=True)
     group = CUnicode().tag(config=True)
+    
+    @default('user')
+    def _default_user(self):
+        return os.environ.get('JUPYTERHUB_USER') or ''
+
+    @default('group')
+    def _default_group(self):
+        return os.environ.get('JUPYTERHUB_GROUP') or ''
 
     @observe('user')
     def _user_changed(self, change):
@@ -233,13 +241,13 @@ class SingleUserNotebookApp(NotebookApp):
     def _port_default(self):
         if os.environ.get('JUPYTERHUB_SERVICE_URL'):
             url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
-            return url.port
+            return url.port or 8888
 
     @default('ip')
     def _ip_default(self):
         if os.environ.get('JUPYTERHUB_SERVICE_URL'):
             url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
-            return url.hostname
+            return url.hostname or '127.0.0.1'
 
     aliases = aliases
     flags = flags

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -438,8 +438,8 @@ class Spawner(LoggingConfigurable):
         # Info previously passed on args
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_API_URL'] = self.hub.api_url
-        env['JUPYTERHUB_BASE_URL'] = self.hub.base_url
-        env['JUPYTERHUB_SERVICE_PREFIX'] = self.user.server.base_url
+        env['JUPYTERHUB_BASE_URL'] = self.hub.base_url[:-4]
+        env['JUPYTERHUB_SERVICE_PREFIX'] = self.user.base_url
 
         # Put in limit and guarantee info if they exist.
         # Note that this is for use by the humans / notebook extensions in the

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -65,7 +65,7 @@ class Spawner(LoggingConfigurable):
         """
     )
 
-    ip = Unicode('127.0.0.1',
+    ip = Unicode('',
         help="""
         The IP address (or hostname) the single-user server should listen on.
 
@@ -434,6 +434,12 @@ class Spawner(LoggingConfigurable):
         env['JUPYTERHUB_HOST'] = self.hub.public_host
         env['JUPYTERHUB_OAUTH_CALLBACK_URL'] = \
             url_path_join(self.user.url, 'oauth_callback')
+        
+        # Info previously passed on args
+        env['JUPYTERHUB_USER'] = self.user.name
+        env['JUPYTERHUB_API_URL'] = self.hub.api_url
+        env['JUPYTERHUB_BASE_URL'] = self.hub.base_url
+        env['JUPYTERHUB_SERVICE_PREFIX'] = self.user.server.base_url
 
         # Put in limit and guarantee info if they exist.
         # Note that this is for use by the humans / notebook extensions in the
@@ -493,13 +499,7 @@ class Spawner(LoggingConfigurable):
 
         Doesn't expect shell expansion to happen.
         """
-        args = [
-            '--user="%s"' % self.user.name,
-            '--base-url="%s"' % self.user.base_url,
-            '--hub-host="%s"' % self.hub.public_host,
-            '--hub-prefix="%s"' % self.hub.base_url,
-            '--hub-api-url="%s"' % self.hub.api_url,
-        ]
+        args = []
         if self.ip:
             args.append('--ip="%s"' % self.ip)
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -423,10 +423,13 @@ def test_spawn(app, io_loop):
     r = requests.get(ujoin(url, 'args'))
     assert r.status_code == 200
     argv = r.json()
-    for expected in ['--user="%s"' % name, '--base-url="%s"' % user.server.base_url]:
-        assert expected in argv
+    assert '--port' in ' '.join(argv)
+    r = requests.get(ujoin(url, 'env'))
+    env = r.json()
+    for expected in ['JUPYTERHUB_USER', 'JUPYTERHUB_BASE_URL', 'JUPYTERHUB_API_TOKEN']:
+        assert expected in env
     if app.subdomain_host:
-        assert '--hub-host="%s"' % app.subdomain_host in argv
+        assert env['JUPYTERHUB_HOST'] == app.subdomain_host
 
     r = api_request(app, 'users', name, 'server', method='delete')
     assert r.status_code == 204


### PR DESCRIPTION
env is often easier to deal with for Spawners

Now, only optional args are passed on the command-line and all required args come from environment variables.