### PR TITLE
close socket when testing connections

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -40,7 +40,7 @@ def can_connect(ip, port):
     if ip in {'', '0.0.0.0'}:
         ip = '127.0.0.1'
     try:
-        socket.create_connection((ip, port))
+        socket.create_connection((ip, port)).close()
     except socket.error as e:
         if e.errno not in {errno.ECONNREFUSED, errno.ETIMEDOUT}:
             app_log.error("Unexpected error connecting to %s:%i %s", ip, port, e)


### PR DESCRIPTION
rather than relying on garbage collection

cleans up some "open file descriptor" warnings