### PR TITLE
Inter-sphinx with Python 3, not 2.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,7 +164,7 @@ epub_exclude_files = ['search.html']
 
 # -- Intersphinx ----------------------------------------------------------
 
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/3/': None}
 
 # -- Read The Docs --------------------------------------------------------
 


### PR DESCRIPTION
Python 2 is the default, you need to be explicit for Python 3.