### PR TITLE
delay errors on pamela import

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -12,7 +12,11 @@ import sys
 from subprocess import Popen, PIPE, STDOUT
 
 from tornado import gen
-import pamela
+try:
+    import pamela
+except Exception as e:
+    pamela = None
+    _pamela_error = e
 
 from traitlets.config import LoggingConfigurable
 from traitlets import Bool, Set, Unicode, Dict, Any, default, observe
@@ -486,6 +490,11 @@ class PAMAuthenticator(LocalAuthenticator):
         this is automatically set to False.
         """
     ).tag(config=True)
+    
+    def __init__(self, **kwargs):
+        if pamela is None:
+            raise _pamela_error from None
+        super().__init__(**kwargs)
 
     @gen.coroutine
     def authenticate(self, handler, data):


### PR DESCRIPTION
only raise ImportError on pamela if PAMAuthenticator is actually used

avoids failure to start in rare cases where pamela is not importable (e.g. broken libpam) and deployment is using another Authenticator, anyway.