### PR TITLE
define routespec

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -27,6 +27,7 @@ JupyterHub API Reference:
     app
     auth
     spawner
+    proxy
     user
     services.auth
 

--- a/docs/source/api/proxy.rst
+++ b/docs/source/api/proxy.rst
@@ -1,0 +1,19 @@
+=======
+Proxies
+=======
+
+Module: :mod:`jupyterhub.proxy`
+===============================
+
+.. automodule:: jupyterhub.proxy
+
+.. currentmodule:: jupyterhub.proxy
+
+
+
+.. autoconfigurable:: Proxy
+    :members:
+
+.. autoconfigurable:: ConfigurableHTTPProxy
+    :members: debug, auth_token, check_running_interval, api_url, command
+

--- a/jupyterhub/apihandlers/proxy.py
+++ b/jupyterhub/apihandlers/proxy.py
@@ -9,26 +9,9 @@ from urllib.parse import urlparse
 from tornado import gen, web
 
 from .. import orm
-from ..proxy import RouteSpec
 from ..utils import admin_only
 from .base import APIHandler
 
-class _RouteSpecJSONEncoder(json.JSONEncoder):
-    """JSON encoder that handles routespecs"""
-    def encode(self, obj):
-        if isinstance(obj, RouteSpec):
-            obj = obj.host + obj.path
-        return super().encode(obj)
-
-    def iterencode(self, obj, _one_shot=True):
-        if isinstance(obj, dict):
-            obj = {
-                key.host + key.path if isinstance(key, RouteSpec) else key : value
-                for key, value in obj.items()
-            }
-        return super().iterencode(obj)
-
-_json = _RouteSpecJSONEncoder()
 
 class ProxyAPIHandler(APIHandler):
     
@@ -41,7 +24,7 @@ class ProxyAPIHandler(APIHandler):
         but without clients needing to maintain separate
         """
         routes = yield self.proxy.get_all_routes()
-        self.write(_json.encode(routes))
+        self.write(json.dumps(routes))
 
     @admin_only
     @gen.coroutine

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1182,6 +1182,7 @@ class JupyterHub(Application):
             app=self,
             log=self.log,
             hub=self.hub,
+            host_routing=bool(self.subdomain_host),
             ssl_cert=self.ssl_cert,
             ssl_key=self.ssl_key,
         )

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -12,6 +12,7 @@ from traitlets import (
     HasTraits, Instance, Integer, Unicode,
     default, observe,
 )
+from .traitlets import URLPrefix
 from . import orm
 from .utils import (
     url_path_join, can_connect, wait_for_server,
@@ -30,7 +31,7 @@ class Server(HasTraits):
     connect_ip = Unicode()
     proto = Unicode('http')
     port = Integer()
-    base_url = Unicode('/')
+    base_url = URLPrefix('/')
     cookie_name = Unicode('')
 
     @property

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -29,7 +29,24 @@ from .utils import url_path_join
 
 
 class RouteSpec(namedtuple('RouteSpec', ['path', 'host'])):
+    """Object wrapping a proxy route specification
+
+    Attributes:
+
+        path (str): The URL path prefix for this route. Required.
+        host (str): The hostname used for routing when host-based routing is enabled.
+
+    """
     def __new__(cls, path, *, host=''):
+        """Create a route specification.
+
+        Arguments:
+
+            path (str): The path prefix. Leading and trailing slashes will be added
+                if missing. Required.
+            host (str): The hostname used for routing when host-based routing is enabled.
+                Optional, keyword-only.
+        """
         # give host a default value
         if isinstance(path, cls) and host == '':
             # RouteSpec(routespec) makes a copy

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -35,6 +35,13 @@ class RouteSpec(namedtuple('RouteSpec', ['path', 'host'])):
             # RouteSpec(routespec) makes a copy
             path, host = path
 
+        # ensure leading/trailing slashes
+        if not path.startswith('/'):
+            path = '/' + path
+        if not path.endswith('/'):
+            path = path + '/'
+        return super().__new__(cls, path, host)
+
     @classmethod
     def as_routespec(cls, routespec):
         """Ensure a RouteSpec or str is a RouteSpec
@@ -400,6 +407,8 @@ class ConfigurableHTTPProxy(Proxy):
             if not self.host_routing:
                 raise RuntimeError("Adding route with a host")
             path = '/' + url_path_join(routespec.host, path)
+        if path != '/' and path.endswith('/'):
+            path = path.rstrip('/')
         return path
 
     def _routespec_from_chp_path(self, chp_path):

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -175,6 +175,7 @@ class Service(LoggingConfigurable):
         """
     ).tag(input=True)
     # Managed service API:
+    spawner = Any()
 
     @property
     def managed(self):
@@ -299,6 +300,7 @@ class Service(LoggingConfigurable):
     def stop(self):
         """Stop a managed service"""
         if not self.managed:
-            raise RuntimeError("Cannot start unmanaged service %s" % self)
-        self.spawner.stop_polling()
-        return self.spawner.stop()
+            raise RuntimeError("Cannot stop unmanaged service %s" % self)
+        if self.spawner:
+            self.spawner.stop_polling()
+            return self.spawner.stop()

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -52,7 +52,6 @@ from traitlets.config import LoggingConfigurable
 
 from .. import orm
 from ..objects import Server
-from ..proxy import RouteSpec
 from ..traitlets import Command
 from ..spawner import LocalProcessSpawner, set_user_setuid
 from ..utils import url_path_join
@@ -249,9 +248,9 @@ class Service(LoggingConfigurable):
         if not self.server:
             return ''
         if self.domain:
-            return RouteSpec(path=self.server.base_url, host=self.domain)
+            return self.domain + self.server.base_url
         else:
-            return RouteSpec(self.server.base_url)
+            return self.server.base_url
 
     def __repr__(self):
         return "<{cls}(name={name}{managed})>".format(

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -52,6 +52,7 @@ from traitlets.config import LoggingConfigurable
 
 from .. import orm
 from ..objects import Server
+from ..proxy import RouteSpec
 from ..traitlets import Command
 from ..spawner import LocalProcessSpawner, set_user_setuid
 from ..utils import url_path_join
@@ -243,13 +244,13 @@ class Service(LoggingConfigurable):
         return url_path_join(self.base_url, 'services', self.name + '/')
 
     @property
-    def proxy_path(self):
+    def proxy_spec(self):
         if not self.server:
             return ''
         if self.domain:
-            return url_path_join('/' + self.domain, self.server.base_url)
+            return RouteSpec(path=self.server.base_url, host=self.domain)
         else:
-            return self.server.base_url
+            return RouteSpec(self.server.base_url)
 
     def __repr__(self):
         return "<{cls}(name={name}{managed})>".format(

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -413,9 +413,8 @@ def test_spawn(app, io_loop):
     status = io_loop.run_sync(app_user.spawner.poll)
     assert status is None
 
-    assert user.server.base_url == ujoin(app.base_url, 'user/%s' % name)
+    assert user.server.base_url == ujoin(app.base_url, 'user/%s' % name) + '/'
     url = public_url(app, user)
-    print(url)
     r = requests.get(url)
     assert r.status_code == 200
     assert r.text == user.server.base_url

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -97,7 +97,7 @@ def test_spawn_redirect(app, io_loop):
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
-    assert path == ujoin(app.base_url, 'user/%s' % name)
+    assert path == ujoin(app.base_url, 'user/%s/' % name)
     
     # should have started server
     status = io_loop.run_sync(u.spawner.poll)
@@ -108,7 +108,7 @@ def test_spawn_redirect(app, io_loop):
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
-    assert path == ujoin(app.base_url, '/user/%s' % name)
+    assert path == ujoin(app.base_url, '/user/%s/' % name)
 
 def test_spawn_page(app):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -221,7 +221,10 @@ def test_check_routes(app, io_loop, username, endpoints):
     False,
 ])
 def test_add_get_delete(app, route_str, as_str):
-    routespec = RouteSpec.as_routespec(route_str)
+    if app.subdomain_host and as_str:
+        # can't use simple str args when host is not empty
+        pytest.skip()
+    routespec = RouteSpec(route_str, host=urlparse(app.subdomain_host).hostname or '')
     proxy = app.proxy
     arg = route_str if as_str else routespec
     target = 'https://localhost:1234'

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -15,7 +15,6 @@ from . import orm
 from .objects import Server
 from traitlets import HasTraits, Any, Dict, observe, default
 from .spawner import LocalProcessSpawner
-from .proxy import RouteSpec
 
 class UserDict(dict):
     """Like defaultdict, but for users
@@ -120,7 +119,7 @@ class User(HasTraits):
         self.allow_named_servers = self.settings.get('allow_named_servers', False)
 
         self.base_url = url_path_join(
-            self.settings.get('base_url', '/'), 'user', self.escaped_name)
+            self.settings.get('base_url', '/'), 'user', self.escaped_name) + '/'
 
         self.spawner = self.spawner_class(
             user=self,
@@ -171,9 +170,9 @@ class User(HasTraits):
     @property
     def proxy_spec(self):
         if self.settings.get('subdomain_host'):
-            return RouteSpec(path=self.base_url, host=self.domain)
+            return self.domain + self.base_url
         else:
-            return RouteSpec(path=self.base_url)
+            return self.base_url
 
     @property
     def domain(self):
@@ -223,7 +222,7 @@ class User(HasTraits):
                 server_name = options['server_name']
             else:
                 server_name = default_server_name(self)
-            base_url = url_path_join(self.base_url, server_name)
+            base_url = url_path_join(self.base_url, server_name) + '/'
         else:
             server_name = ''
             base_url = self.base_url

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -15,7 +15,7 @@ from . import orm
 from .objects import Server
 from traitlets import HasTraits, Any, Dict, observe, default
 from .spawner import LocalProcessSpawner
-
+from .proxy import RouteSpec
 
 class UserDict(dict):
     """Like defaultdict, but for users
@@ -169,11 +169,11 @@ class User(HasTraits):
         return quote(self.name, safe='@')
 
     @property
-    def proxy_path(self):
+    def proxy_spec(self):
         if self.settings.get('subdomain_host'):
-            return url_path_join('/' + self.domain, self.base_url)
+            return RouteSpec(path=self.base_url, host=self.domain)
         else:
-            return self.base_url
+            return RouteSpec(path=self.base_url)
 
     @property
     def domain(self):


### PR DESCRIPTION
namedtuple separating host and path. host is optional and will be `''` unless host-based routing is  involved.

Since RouteSpecs are almost always just a path, everywhere that accepts a RouteSpec argument must also accept a str and wrap it in `RouteSpec(s)`, e.g. via `RouteSpec.as_routespec(spec)`, which is a no-op for RouteSpec objects, for convenience/clarity.

closes #1175