### PR TITLE
allow .authenticate to return a dict containing name and state

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -36,13 +36,13 @@ class TokenAPIHandler(APIHandler):
             # for authenticators where that's possible
             data = self.get_json_body()
             try:
-                username = yield self.authenticator.authenticate(self, data)
+                authenticated = yield self.authenticate(self, data)
             except Exception as e:
                 self.log.error("Failure trying to authenticate with form data: %s" % e)
-                username = None
-            if username is None:
+                authenticated = None
+            if authenticated is None:
                 raise web.HTTPError(403)
-            user = self.find_user(username)
+            user = self.find_user(authenticated['name'])
         api_token = user.new_api_token()
         self.write(json.dumps({'token': api_token}))
 

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -223,7 +223,8 @@ class Authenticator(LoggingConfigurable):
 
         Checking the whitelist is handled separately by the caller.
 
-        .. versionchanged:: Allow `authenticate` to return a dict containing auth_state.
+        .. versionchanged:: 0.8
+            Allow `authenticate` to return a dict containing auth_state.
 
         Args:
             handler (tornado.web.RequestHandler): the current request handler

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -19,7 +19,6 @@ from tornado import gen, web
 from .. import orm
 from ..objects import Server
 from ..spawner import LocalProcessSpawner
-from ..user import User
 from ..utils import url_path_join
 
 # pattern for the authentication token header
@@ -292,14 +291,8 @@ class BaseHandler(RequestHandler):
         if not self.get_current_user_cookie():
             self.set_hub_cookie(user)
 
-    @gen.coroutine
     def authenticate(self, data):
-        auth = self.authenticator
-        if auth is not None:
-            result = yield auth.get_authenticated_user(self, data)
-            return result
-        else:
-            self.log.error("No authentication function, login is impossible!")
+        return gen.maybe_future(self.authenticator.get_authenticated_user(self, data))
 
 
     #---------------------------------------------------------------

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -87,13 +87,9 @@ class LoginHandler(BaseHandler):
         authenticated = yield self.authenticate(data)
         auth_timer.stop(send=False)
 
-        if isinstance(authenticated, dict):
-            # unpack auth dict
-            username = authenticated['name']
-            auth_state = authenticated.get('state')
-        else:
-            username = authenticated
-            auth_state = None
+        # unpack auth dict
+        username = authenticated['name']
+        auth_state = authenticated.get('auth_state')
 
         if authenticated:
             self.statsd.incr('login.success')

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -84,13 +84,24 @@ class LoginHandler(BaseHandler):
             data[arg] = self.get_argument(arg, strip=False)
 
         auth_timer = self.statsd.timer('login.authenticate').start()
-        username = yield self.authenticate(data)
+        authenticated = yield self.authenticate(data)
         auth_timer.stop(send=False)
 
-        if username:
+        if isinstance(authenticated, dict):
+            # unpack auth dict
+            username = authenticated['name']
+            auth_state = authenticated.get('state')
+        else:
+            username = authenticated
+            auth_state = None
+
+        if authenticated:
             self.statsd.incr('login.success')
             self.statsd.timing('login.authenticate.success', auth_timer.ms)
             user = self.user_from_username(username)
+            if auth_state is not None:
+                user.auth_state = auth_state
+                self.db.commit()
             already_running = False
             if user.spawner:
                 status = yield user.spawner.poll()

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -16,7 +16,7 @@ def test_pam_auth(io_loop):
         'username': 'match',
         'password': 'match',
     }))
-    assert authorized == 'match'
+    assert authorized['name'] == 'match'
     
     authorized = io_loop.run_sync(lambda : authenticator.get_authenticated_user(None, {
         'username': 'match',
@@ -30,7 +30,7 @@ def test_pam_auth_whitelist(io_loop):
         'username': 'kaylee',
         'password': 'kaylee',
     }))
-    assert authorized == 'kaylee'
+    assert authorized['name'] == 'kaylee'
     
     authorized = io_loop.run_sync(lambda : authenticator.get_authenticated_user(None, {
         'username': 'wash',
@@ -62,7 +62,7 @@ def test_pam_auth_group_whitelist(io_loop):
             'username': 'kaylee',
             'password': 'kaylee',
         }))
-    assert authorized == 'kaylee'
+    assert authorized['name'] == 'kaylee'
 
     with mock.patch.object(auth, 'getgrnam', getgrnam):
         authorized = io_loop.run_sync(lambda : authenticator.get_authenticated_user(None, {
@@ -166,25 +166,25 @@ def test_normalize_names(io_loop):
         'username': 'ZOE',
         'password': 'ZOE',
     }))
-    assert authorized == 'zoe'
+    assert authorized['name'] == 'zoe'
 
     authorized = io_loop.run_sync(lambda: a.get_authenticated_user(None, {
         'username': 'Glenn',
         'password': 'Glenn',
     }))
-    assert authorized == 'glenn'
+    assert authorized['name'] == 'glenn'
 
     authorized = io_loop.run_sync(lambda: a.get_authenticated_user(None, {
         'username': 'hExi',
         'password': 'hExi',
     }))
-    assert authorized == 'hexi'
+    assert authorized['name'] == 'hexi'
 
     authorized = io_loop.run_sync(lambda: a.get_authenticated_user(None, {
         'username': 'Test',
         'password': 'Test',
     }))
-    assert authorized == 'test'
+    assert authorized['name'] == 'test'
 
 def test_username_map(io_loop):
     a = MockPAMAuthenticator(username_map={'wash': 'alpha'})
@@ -193,13 +193,13 @@ def test_username_map(io_loop):
         'password': 'WASH',
     }))
 
-    assert authorized == 'alpha'
+    assert authorized['name'] == 'alpha'
 
     authorized = io_loop.run_sync(lambda : a.get_authenticated_user(None, {
         'username': 'Inara',
         'password': 'Inara',
     }))
-    assert authorized == 'inara'
+    assert authorized['name'] == 'inara'
 
 
 def test_validate_names(io_loop):


### PR DESCRIPTION
Allows authenticators to set .auth_state from info in the initial authentication.

cc @yuvipanda this is the PR I forgot to open