### PR TITLE
add default hub route via Proxy.add_route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 # running tests
 script:
-  - pytest --maxfail=2 --cov=jupyterhub jupyterhub/tests
+  - pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
 after_success:
   - codecov
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1433,6 +1433,7 @@ class JupyterHub(Application):
                 self.exit(1)
         else:
             self.log.info("Not starting proxy")
+        yield self.proxy.add_hub_route(self.hub)
 
         # start the service(s)
         for service_name, service in self._service_map.items():

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1176,7 +1176,7 @@ class JupyterHub(Application):
             base_url=self.base_url,
         )
         self.proxy = self.proxy_class(
-            db=self.db,
+            db_factory=lambda: self.db,
             public_url=public_url,
             parent=self,
             app=self,

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -521,6 +521,7 @@ class ConfigurableHTTPProxy(Proxy):
     def add_route(self, routespec, target, data=None):
         body = data or {}
         body['target'] = target
+        body['jupyterhub'] = True
         path = self._routespec_to_chp_path(routespec)
         return self.api_request(path,
                                 method='POST',
@@ -534,6 +535,7 @@ class ConfigurableHTTPProxy(Proxy):
     def _reformat_routespec(self, routespec, chp_data):
         """Reformat CHP data format to JupyterHub's proxy API."""
         target = chp_data.pop('target')
+        chp_data.pop('jupyterhub')
         return {
             'routespec': routespec,
             'target': target,
@@ -548,6 +550,10 @@ class ConfigurableHTTPProxy(Proxy):
         all_routes = {}
         for chp_path, chp_data in chp_routes.items():
             routespec = self._routespec_from_chp_path(chp_path)
+            if 'jupyterhub' not in chp_data:
+                # exclude routes not associated with JupyterHub
+                self.log.debug("Omitting non-jupyterhub route %r", routespec)
+                continue
             all_routes[routespec] = self._reformat_routespec(
                 routespec, chp_data)
         return all_routes

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -67,7 +67,11 @@ class Proxy(LoggingConfigurable):
       of fetching a single route.
     """
 
-    db = Any()
+    db_factory = Any()
+    @property
+    def db(self):
+        return self.db_factory()
+
     app = Any()
     hub = Any()
     public_url = Unicode()
@@ -445,7 +449,6 @@ class ConfigurableHTTPProxy(Proxy):
                 else:
                     break
             yield server.wait_up(1)
-        time.sleep(1)
         _check_process()
         self.log.debug("Proxy started and appears to be up")
         pc = PeriodicCallback(self.check_running, 1e3 * self.check_running_interval)

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -5,6 +5,7 @@ import sys
 from tempfile import NamedTemporaryFile
 import threading
 from unittest import mock
+from urllib.parse import urlparse
 
 import requests
 
@@ -139,6 +140,10 @@ class MockHub(JupyterHub):
 
     @default('port')
     def _port_default(self):
+        if self.subdomain_host:
+            port = urlparse(self.subdomain_host).port
+            if port:
+                return port
         return random_port()
 
     @default('authenticator_class')

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -136,7 +136,11 @@ class MockHub(JupyterHub):
     @default('ip')
     def _ip_default(self):
         return '127.0.0.1'
-    
+
+    @default('port')
+    def _port_default(self):
+        return random_port()
+
     @default('authenticator_class')
     def _authenticator_class_default(self):
         return MockPAMAuthenticator

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -43,7 +43,7 @@ def test_external_proxy(request, io_loop):
         '--port', str(app.port),
         '--api-ip', proxy_ip,
         '--api-port', str(proxy_port),
-        '--default-target', 'http://%s:%i' % (app.hub_ip, app.hub_port),
+        '--log-level=debug',
     ]
     if app.subdomain_host:
         cmd.append('--host-routing')
@@ -90,7 +90,7 @@ def test_external_proxy(request, io_loop):
 
     routes = io_loop.run_sync(app.proxy.get_all_routes)
 
-    assert list(routes.keys()) == ['/']
+    assert list(routes.keys()) == []
     
     # poke the server to update the proxy
     r = api_request(app, 'proxy', method='post')


### PR DESCRIPTION
instead of relying on default target when the proxy starts

also add filtering to CHP to avoid including any routes not associated with JupyterHub on a shared proxy.

closes #1186