### PR TITLE
Fix in-document anchors

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -2,14 +2,14 @@
 
 This section contains getting started information on the following topics:
 
-- [Technical Overview](getting-started.html#technical-overview)
-- [Installation](getting-started.html#installation)
-- [Configuration](getting-started.html#configuration)
-- [Networking](getting-started.html#networking)
-- [Security](getting-started.html#security)
-- [Authentication and users](getting-started.html#authentication-and-users)
-- [Spawners and single-user notebook servers](getting-started.html#spawners-and-single-user-notebook-servers)
-- [External Services](getting-started.html#external-services)
+- [Technical Overview](#technical-overview)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Networking](#networking)
+- [Security](#security)
+- [Authentication and users](#authentication-and-users)
+- [Spawners and single-user notebook servers](#spawners-and-single-user-notebook-servers)
+- [External Services](#external-services)
 
 
 ## Technical Overview
@@ -36,7 +36,7 @@ To use JupyterHub, you need a Unix server (typically Linux) running somewhere
 that is accessible to your team on the network. The JupyterHub server can be
 on an internal network at your organization, or it can run on the public
 internet (in which case, take care with the Hub's
-[security](getting-started.html#security)).
+[security](#security)).
 
 ### Basic operation
 Users access JupyterHub through a web browser, by going to the IP address or

--- a/docs/source/services.md
+++ b/docs/source/services.md
@@ -4,13 +4,13 @@ With version 0.7, JupyterHub adds support for **Services**.
 
 This section provides the following information about Services:
 
-- [Definition of a Service](services.html#definition-of-a-service)
-- [Properties of a Service](services.html#properties-of-a-service)
-- [Hub-Managed Services](services.html#hub-managed-services)
-- [Launching a Hub-Managed Service](services.html#launching-a-hub-managed-service)
-- [Externally-Managed Services](services.html#externally-managed-services)
-- [Writing your own Services](services.html#writing-your-own-services)
-- [Hub Authentication and Services](services.html#hub-authentication-and-services)
+- [Definition of a Service](#definition-of-a-service)
+- [Properties of a Service](#properties-of-a-service)
+- [Hub-Managed Services](#hub-managed-services)
+- [Launching a Hub-Managed Service](#launching-a-hub-managed-service)
+- [Externally-Managed Services](#externally-managed-services)
+- [Writing your own Services](#writing-your-own-services)
+- [Hub Authentication and Services](#hub-authentication-and-services)
 
 ## Definition of a Service
 


### PR DESCRIPTION
Removes the explicit extension of the target if it's in the same
document. This allows these links to work in GitHub or in Read the Docs.

The link in "See [Security documentation]" in `getting-started.md` already omits the filename, showing that this should work (unless the Markdown file is sourced somewhere else).