### PR TITLE
Add mkdocs as RTD workaround

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - traitlets>=4.1
 - sphinx>=1.4, !=1.5.4
 - sphinx_rtd_theme
+- mkdocs
 - pip:
   - jupyter_alabaster_theme
   - python-oauth2


### PR DESCRIPTION
This works around an issue in RTD's current core build.