### PR TITLE
Mark `data` param to proxy.add_route optional

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -128,7 +128,7 @@ class Proxy(LoggingConfigurable):
             return routespec
 
     @gen.coroutine
-    def add_route(self, routespec, target, data):
+    def add_route(self, routespec, target, data=None):
         """Add a route to the proxy.
 
         **Subclasses must define this method**


### PR DESCRIPTION
It is used as optional throughout the code, and the CHP implementation
makes it optional too. So let's explicitly mark it as such.