### PR TITLE
Don't fail when there's no 'data' for a route

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1373,7 +1373,8 @@ class JupyterHub(Application):
         users_count = 0
         active_users_count = 0
         for prefix, route in routes.items():
-            route_data = route['data']
+            # 'data' could be empty
+            route_data = route.get('data', {})
             if 'user' not in route_data:
                 # not a user route, ignore it
                 continue


### PR DESCRIPTION
Adding extra data is optional, so we shouldn't fail when
data is not present.