### PR TITLE
Make data a non-optional arg to add_route

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -128,7 +128,7 @@ class Proxy(LoggingConfigurable):
             return routespec
 
     @gen.coroutine
-    def add_route(self, routespec, target, data=None):
+    def add_route(self, routespec, target, data):
         """Add a route to the proxy.
 
         **Subclasses must define this method**
@@ -331,7 +331,7 @@ class Proxy(LoggingConfigurable):
     def add_hub_route(self, hub):
         """Add the default route for the Hub"""
         self.log.info("Adding default route for Hub: / => %s", hub.host)
-        return self.add_route('/', self.hub.host)
+        return self.add_route('/', self.hub.host, {'hub': True})
 
     @gen.coroutine
     def restore_routes(self):
@@ -521,7 +521,7 @@ class ConfigurableHTTPProxy(Proxy):
 
         return client.fetch(req)
 
-    def add_route(self, routespec, target, data=None):
+    def add_route(self, routespec, target, data):
         body = data or {}
         body['target'] = target
         body['jupyterhub'] = True

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -204,7 +204,7 @@ def test_add_get_delete(app, routespec):
     proxy = app.proxy
     target = 'https://localhost:1234'
     with context():
-        yield proxy.add_route(arg, target=target, {})
+        yield proxy.add_route(arg, target, {})
     routes = yield proxy.get_all_routes()
     if not expect_value_error:
         assert routespec in routes.keys()

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -204,7 +204,7 @@ def test_add_get_delete(app, routespec):
     proxy = app.proxy
     target = 'https://localhost:1234'
     with context():
-        yield proxy.add_route(arg, target=target)
+        yield proxy.add_route(arg, target=target, {})
     routes = yield proxy.get_all_routes()
     if not expect_value_error:
         assert routespec in routes.keys()


### PR DESCRIPTION
We expect at least an empty dict when we fetch it,
so let's make it non-optional and always pass in something.
This is clearer.