### PR TITLE
Add missing config tag to `will_resume`

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -63,7 +63,7 @@ class Spawner(LoggingConfigurable):
         (e.g. resuming a Docker container),
         and API tokens in use when the Spawner stops will not be deleted.
         """
-    )
+    ).tag(config=True)
 
     ip = Unicode('',
         help="""


### PR DESCRIPTION
Following jupyterhub/jupyterhub#910 we tried to add `c.Spawner.will_resume = True` to our settings, but JupyterHub doesn't recognize it, following line is printed in the logs: 
```
[W 2017-07-04 11:46:15.817 JupyterHub configurable:168] Config option `will_resume` not recognized by `DockerSpawner`.
```
We found out that this is due to the `will_resume` option not being exposed with the config tag.