### PR TITLE
Tag hub_ip_connect as configurable

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -412,7 +412,7 @@ class JupyterHub(Application):
 
         .. versionadded:: 0.8
         """
-    )
+    ).tag(config=True)
     hub_prefix = URLPrefix('/hub/',
         help="The prefix for the hub server.  Always /base_url/hub/"
     )


### PR DESCRIPTION
This value is expected to be provided by the user.

Fixes #1213 