### PR TITLE
fix leftover `self.exit` in proxy

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -433,7 +433,7 @@ class ConfigurableHTTPProxy(Proxy):
                 "The proxy can be installed with `npm install -g configurable-http-proxy`"
                 % self.command
             )
-            self.exit(1)
+            raise
 
         def _check_process():
             status = self.proxy_process.poll()


### PR DESCRIPTION
self.exit is a method on Application, missed copying the proxy code out of the JupyterHub app.

cf #1216