### PR TITLE
fix filtering of services with no endpoint

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -308,8 +308,7 @@ class Proxy(LoggingConfigurable):
         # check service routes
         service_routes = {r['data']['service']
                           for r in routes.values() if 'service' in r['data']}
-        for orm_service in db.query(Service).filter(
-                Service.server is not None):
+        for orm_service in db.query(Service).filter(Service.server != None):
             service = service_dict[orm_service.name]
             if service.server is None:
                 # This should never be True, but seems to be on rare occasion.


### PR DESCRIPTION
use `!=` to check for None, not `is not`. The weird thing appears to be that `is not` *sometimes* works? Seems like it should be never or always, but `!=` is the right thing to use, in any case.

closes #1215