### PR TITLE
apply exponential backoff to all waits

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -27,7 +27,7 @@ from traitlets import (
 )
 
 from .traitlets import Command, ByteSpecification
-from .utils import random_port, url_path_join
+from .utils import random_port, url_path_join, DT_MIN, DT_MAX, DT_SCALE
 
 
 class Spawner(LoggingConfigurable):
@@ -630,7 +630,7 @@ class Spawner(LoggingConfigurable):
                 self.log.exception("Unhandled error in poll callback for %s", self)
         return status
 
-    death_interval = Float(0.1)
+    death_interval = Float(DT_MIN)
 
     @gen.coroutine
     def wait_for_death(self, timeout=10):
@@ -644,7 +644,7 @@ class Spawner(LoggingConfigurable):
                 break
             else:
                 yield gen.sleep(dt)
-            dt = min(dt * 2, timeout - (loop.time() - tic))
+            dt = min(dt * DT_SCALE, DT_MAX, timeout - (loop.time() - tic))
 
 
 def _try_setcwd(path):


### PR DESCRIPTION
Waiting for servers to come up and shut down was polled at an even interval of 100ms. If things are slow and busy, this is a lot of waiting events (and outstanding http requests). Exponential backoff reduces the number of callbacks triggered by slow spawners.

Note that this only really affects Spawners where the time between `Spawner.start()` returning and the server becoming responsive is long. *Not* spawners where `Spawner.start` itself takes a long time.

This may improve the load a bit when there’s a bunch of outstanding spawns.