### PR TITLE
More Windows Fixes

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -24,6 +24,15 @@ from .utils import url_path_join
 from .traitlets import Command
 
 
+
+def getgrnam(name):
+    """Wrapper function to protect against `grp` not being available 
+    on Windows
+    """
+    import grp
+    return grp.getgrnam(name)
+
+
 class Authenticator(LoggingConfigurable):
     """Base class for implementing an authentication provider for JupyterHub"""
 
@@ -429,7 +438,6 @@ class LocalAuthenticator(Authenticator):
         """
         If group_whitelist is configured, check if authenticating user is part of group.
         """
-        from grp import getgrnam
         if not self.group_whitelist:
             return False
         for grnam in self.group_whitelist:

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -3,9 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from grp import getgrnam
 import pipes
-import pwd
 import re
 from shutil import which
 import sys
@@ -431,6 +429,7 @@ class LocalAuthenticator(Authenticator):
         """
         If group_whitelist is configured, check if authenticating user is part of group.
         """
+        from grp import getgrnam
         if not self.group_whitelist:
             return False
         for grnam in self.group_whitelist:
@@ -461,6 +460,7 @@ class LocalAuthenticator(Authenticator):
     @staticmethod
     def system_user_exists(user):
         """Check if the user exists on the system"""
+        import pwd
         try:
             pwd.getpwnam(user.name)
         except KeyError:

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -424,8 +424,9 @@ class ConfigurableHTTPProxy(Proxy):
                              "  I hope there is SSL termination happening somewhere else...")
         self.log.info("Starting proxy @ %s", public_server.bind_url)
         self.log.debug("Proxy cmd: %s", cmd)
+        shell = os.name == 'nt' 
         try:
-            self.proxy_process = Popen(cmd, env=env, start_new_session=True)
+            self.proxy_process = Popen(cmd, env=env, start_new_session=True, shell=shell)
         except FileNotFoundError as e:
             self.log.error(
                 "Failed to find proxy %r\n"

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -8,11 +8,9 @@ Contains base Spawner class & default implementation
 import errno
 import os
 import pipes
-import pwd
 import shutil
 import signal
 import sys
-import grp
 import warnings
 from subprocess import Popen
 from tempfile import mkdtemp
@@ -668,6 +666,8 @@ def set_user_setuid(username, chdir=True):
     Returned preexec_fn will set uid/gid, and attempt to chdir to the target user's
     home directory.
     """
+    import grp
+    import pwd
     user = pwd.getpwnam(username)
     uid = user.pw_uid
     gid = user.pw_gid
@@ -808,6 +808,7 @@ class LocalProcessSpawner(Spawner):
 
     def user_env(self, env):
         """Augment environment of spawned process with user specific env variables."""
+        import pwd
         env['USER'] = self.user.name
         home = pwd.getpwnam(self.user.name).pw_dir
         shell = pwd.getpwnam(self.user.name).pw_shell


### PR DESCRIPTION
The `grp` and `pwd` modules aren't available on Windows but when using  `DockerSpawner` with the `LDAPAuthenticator` we never need these modules.

This PR just moves the imports inside the methods where they're used to avoid coupling `auth.py` and `proxy.py` to these modules

