### PR TITLE
Document more fully platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ for administration of the Hub and its users.
 
 ### Check prerequisites
 
+A Linux/Unix based system with the following:
+
 - [Python](https://www.python.org/downloads/) 3.3 or greater
 - [nodejs/npm](https://www.npmjs.com/) Install a recent version of
   [nodejs/npm](https://docs.npmjs.com/getting-started/installing-node)
@@ -204,6 +206,20 @@ We use [pytest](http://doc.pytest.org/en/latest/) for **running tests**:
 ```bash
 pytest jupyterhub/tests
 ```
+
+### A note about platform support
+
+JupyterHub is supported on Linux/Unix based systems.
+
+JupyterHub officially **does not** support Windows. You may be able to use
+JupyterHub on Windows if you use a Spawner and Authenticator that work on
+Windows, but the JupyterHub defaults will not. Bugs reported on Windows will not
+be accepted, and the test suite will not run on Windows. Small patches that fix
+minor Windows compatibility issues (such as basic installation) **may** be accepted,
+however. For Windows-based systems, we would recommend running JupyterHub in a
+docker container or Linux VM.
+
+[Additional Reference:](http://www.tornadoweb.org/en/stable/#installation) Tornado's documentation on Windows platform support
 
 ## License
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -30,8 +30,8 @@ Three major subsystems run by the `jupyterhub` command line program:
 
 ![JupyterHub subsystems](images/jhub-parts.png)
 
-
 ### Deployment server
+
 To use JupyterHub, you need a Unix server (typically Linux) running somewhere
 that is accessible to your team on the network. The JupyterHub server can be
 on an internal network at your organization, or it can run on the public
@@ -119,6 +119,20 @@ The location of these files can be specified via configuration, discussed below.
 
 See the project's [README](https://github.com/jupyterhub/jupyterhub/blob/master/README.md)
 for help installing JupyterHub.
+
+### Platform support
+
+JupyterHub is supported on Linux/Unix based systems.
+
+JupyterHub officially **does not** support Windows. You may be able to use
+JupyterHub on Windows if you use a Spawner and Authenticator that work on
+Windows, but the JupyterHub defaults will not. Bugs reported on Windows will not
+be accepted, and the test suite will not run on Windows. Small patches that fix
+minor Windows compatibility issues (such as basic installation) **may** be accepted,
+however. For Windows-based systems, we would recommend running JupyterHub in a
+docker container or Linux VM.
+
+[Additional Reference:](http://www.tornadoweb.org/en/stable/#installation) Tornado's documentation on Windows platform support
 
 ### Planning your installation
 
@@ -385,7 +399,7 @@ to also be able to connect to the Proxy.
 ### Security audits
 
 We recommend that you do periodic reviews of your deployment's security. It's
-good practice to keep JupyterHub, configurable-http-proxy, and nodejs 
+good practice to keep JupyterHub, configurable-http-proxy, and nodejs
 versions up to date.
 
 A handy website for testing your deployment is

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-**Before installing JupyterHub**, you will need:
+**Before installing JupyterHub**, you will need a Linux/Unix based system:
 
 - [Python](https://www.python.org/downloads/) 3.3 or greater
 
@@ -19,7 +19,7 @@
   ```bash
   sudo apt-get install npm nodejs-legacy
   ```
-  
+
   (The `nodejs-legacy` package installs the `node` executable and is currently
   required for npm to work on Debian/Ubuntu.)
 


### PR DESCRIPTION
Recent technical work by @dhirschfeld on packaging JupyterHub for Windows installation raised our awareness that our documentation is a bit sparse re: platform support. This PR attempts to better document our unofficial support for Windows. 

- Better document our position on support for platforms
    - Official: Linux/Unix based systems
    - Unofficial: Windows
- Clarify contribution/issues re: Windows in README

