### PR TITLE
Update docs main TOC and edit quickstart

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,4 +1,4 @@
-# Change log summary
+# Changelog
 
 For detailed changes from the prior release, click on the version number, and
 its link will bring up a GitHub listing of changes. Use `git log` on the

--- a/docs/source/configuration-guide.rst
+++ b/docs/source/configuration-guide.rst
@@ -4,9 +4,11 @@ Configuration Guide
 .. toctree::
    :maxdepth: 2
 
+   howitworks
+   websecurity
+   rest
    authenticators
    spawners
    services
-   config-examples
    upgrading
-   troubleshooting
+   config-examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,33 +35,40 @@ For convenient administration of the Hub, its users, and :doc:`services`
 Contents
 --------
 
-**User Guide**
+**Installation Guide**
 
 * :doc:`quickstart`
 * :doc:`getting-started`
-* :doc:`howitworks`
-* :doc:`websecurity`
-* :doc:`rest`
 
 
 **Configuration Guide**
 
+* :doc:`howitworks`
+* :doc:`websecurity`
+* :doc:`rest`
 * :doc:`authenticators`
 * :doc:`spawners`
 * :doc:`services`
-* :doc:`config-examples`
 * :doc:`upgrading`
-* :doc:`troubleshooting`
-
+* :doc:`config-examples`
 
 **API Reference**
 
 * :doc:`api/index`
 
 
-**About JupyterHub**
+**Troubleshooting**
+
+* :doc:`troubleshooting`
+
+
+**Changelog**
 
 * :doc:`changelog`
+
+
+**About JupyterHub**
+
 * :doc:`contributor-list`
 * :doc:`gallery-jhub-deployments`
 
@@ -90,6 +97,7 @@ Full Table of Contents
    user-guide
    configuration-guide
    api/index
+   troubleshooting
    changelog
    contributor-list
    gallery-jhub-deployments

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -1,18 +1,14 @@
-# Quickstart - Installation
+# Quickstart
 
 ## Prerequisites
 
 **Before installing JupyterHub**, you will need a Linux/Unix based system:
 
-- [Python](https://www.python.org/downloads/) 3.3 or greater
-
-  An understanding of using [`pip`](https://pip.pypa.io/en/stable/) or
+- [Python](https://www.python.org/downloads/) 3.3 or greater. An understanding
+  of using [`pip`](https://pip.pypa.io/en/stable/) or
   [`conda`](http://conda.pydata.org/docs/get-started.html) for
   installing Python packages is helpful.
-
-- [nodejs/npm](https://www.npmjs.com/)
-
-  [Install nodejs/npm](https://docs.npmjs.com/getting-started/installing-node),
+- [nodejs/npm](https://www.npmjs.com/) [Install nodejs/npm](https://docs.npmjs.com/getting-started/installing-node),
   using your operating system's package manager. For example, install on Linux
   (Debian/Ubuntu) using:
 
@@ -24,7 +20,6 @@
   required for npm to work on Debian/Ubuntu.)
 
 - TLS certificate and key for HTTPS communication
-
 - Domain name
 
 **Before running the single-user notebook servers** (which may be on the same
@@ -35,17 +30,21 @@ system as the Hub or not):
 
 ## Installation
 
-JupyterHub can be installed with `pip` or `conda` and the proxy with `npm`:
+JupyterHub can be installed with `pip` (and the proxy with `npm`) or `conda`:
 
 **pip, npm:**
+
 ```bash
 python3 -m pip install jupyterhub
 npm install -g configurable-http-proxy
+python3 -m pip install notebook # needed if running the notebook servers locally
 ```
 
 **conda** (one command installs jupyterhub and proxy):
+
 ```bash
 conda install -c conda-forge jupyterhub
+conda install notebook  # needed if running the notebook servers locally
 ```
 
 To test your installation:
@@ -53,19 +52,6 @@ To test your installation:
 ```bash
 jupyterhub -h
 configurable-http-proxy -h
-```
-
-If you plan to run notebook servers locally, you will need also to install
-Jupyter notebook:
-
-**pip:**
-```bash
-python3 -m pip install notebook
-```
-
-**conda:**
-```bash
-conda install notebook
 ```
 
 ## Start the Hub server
@@ -79,7 +65,8 @@ jupyterhub
 Visit `https://localhost:8000` in your browser, and sign in with your unix
 credentials.
 
-To allow multiple users to sign into the Hub server, you must start `jupyterhub` as a *privileged user*, such as root:
+To allow multiple users to sign into the Hub server, you must start
+`jupyterhub` as a *privileged user*, such as root:
 
 ```bash
 sudo jupyterhub

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -1,11 +1,8 @@
-JupyterHub User Guide
-=====================
+Installation Guide
+==================
 
 .. toctree::
    :maxdepth: 3
 
    quickstart
    getting-started
-   howitworks
-   websecurity
-   rest


### PR DESCRIPTION
- Revise main table of contents for 3 user personas (want to get started now, troubleshooting, learning more about jhub)
- Move troubleshooting to main TOC
- Move gallery of deployments doc to main TOC
- Move docs that cover stuff other than installation to Configuration Guide section to simplify Installation Guide
- Simplify quickstart installation instructions

[Rendered version](http://test-jupyterhub.readthedocs.io/en/doc-refresh/)