### PR TITLE
Require Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup_args = dict(
     license             = "BSD",
     platforms           = "Linux, Mac OS X",
     keywords            = ['Interactive', 'Interpreter', 'Shell', 'Web'],
+    python_requires     = ">=3.4",
     classifiers         = [
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
Specify Requires-Python (PEP345) metadata

follow-up to #1239