### PR TITLE
various singleuser header fixes

### DIFF
--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -27,7 +27,7 @@ def _check_version(hub_version, singleuser_version, log):
     if hub_version != singleuser_version:
         from distutils.version import LooseVersion as V
         hub_major_minor = V(hub_version).version[:2]
-        singleuser_major_minor = V(__version__).version[:2]
+        singleuser_major_minor = V(singleuser_version).version[:2]
         if singleuser_major_minor == hub_major_minor:
             # patch-level mismatch or lower, log difference at debug-level
             # because this should be fine
@@ -36,5 +36,7 @@ def _check_version(hub_version, singleuser_version, log):
             # log warning-level for more significant mismatch, such as 0.8 vs 0.9, etc.
             log_method = log.warning
         log_method("jupyterhub version %s != jupyterhub-singleuser version %s",
-            hub_version, __version__,
+            hub_version, singleuser_version,
         )
+    else:
+        log.debug("jupyterhub and jupyterhub-singleuser both on version %s" % hub_version)

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -13,7 +13,7 @@ from jinja2 import ChoiceLoader, FunctionLoader
 from tornado.httpclient import AsyncHTTPClient
 from tornado import gen
 from tornado import ioloop
-from tornado.web import HTTPError
+from tornado.web import HTTPError, RequestHandler
 
 try:
     import notebook
@@ -400,8 +400,14 @@ class SingleUserNotebookApp(NotebookApp):
         s['hub_prefix'] = self.hub_prefix
         s['hub_host'] = self.hub_host
         s['hub_auth'] = self.hub_auth
-        s['csp_report_uri'] = self.hub_host + url_path_join(self.hub_prefix, 'security/csp-report')
-        s.setdefault('headers', {})['X-JupyterHub-Version'] = __version__
+        csp_report_uri = s['csp_report_uri'] = self.hub_host + url_path_join(self.hub_prefix, 'security/csp-report')
+        headers = s.setdefault('headers', {})
+        headers['X-JupyterHub-Version'] = __version__
+        # set CSP header directly to workaround bugs in jupyter/notebook 5.0
+        headers.setdefault('Content-Security-Policy', ';'.join([
+            "frame-ancestors 'self'",
+            "report-uri " + csp_report_uri,
+        ]))
         super(SingleUserNotebookApp, self).init_webapp()
 
         # add OAuth callback
@@ -409,9 +415,21 @@ class SingleUserNotebookApp(NotebookApp):
             urlparse(self.hub_auth.oauth_redirect_uri).path,
             OAuthCallbackHandler
         )])
-
+        
+        # apply X-JupyterHub-Version to *all* request handlers (even redirects)
+        self.patch_default_headers()
         self.patch_templates()
     
+    def patch_default_headers(self):
+        if hasattr(RequestHandler, '_orig_set_default_headers'):
+            return
+        RequestHandler._orig_set_default_headers = RequestHandler.set_default_headers
+        def set_jupyterhub_header(self):
+            self._orig_set_default_headers()
+            self.set_header('X-JupyterHub-Version', __version__)
+
+        RequestHandler.set_default_headers = set_jupyterhub_header
+
     def patch_templates(self):
         """Patch page templates to add Hub-related buttons"""
 


### PR DESCRIPTION
Workaround occasional Content security policy bug:

- always set content security policy header, to workaround bug in notebook 5.0 (https://github.com/jupyter/notebook/pull/2671)

Fixes for version-checking, which had some mistakes:

- set x-jupyterhub-version on all requests, including simple redirects
- fix version comparison in _check_version (leftover `__version__`)
- even log version matches at debug-level (verifies that check happened)