### PR TITLE
Do not 500 if cannot authenticate.

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -87,11 +87,11 @@ class LoginHandler(BaseHandler):
         authenticated = yield self.authenticate(data)
         auth_timer.stop(send=False)
 
-        # unpack auth dict
-        username = authenticated['name']
-        auth_state = authenticated.get('auth_state')
-
         if authenticated:
+            # unpack auth dict
+            username = authenticated['name']
+            auth_state = authenticated.get('auth_state')
+
             self.statsd.incr('login.success')
             self.statsd.timing('login.authenticate.success', auth_timer.ms)
             user = self.user_from_username(username)
@@ -101,7 +101,7 @@ class LoginHandler(BaseHandler):
             already_running = False
             if user.spawner:
                 status = yield user.spawner.poll()
-                already_running = (status == None)
+                already_running = (status is None)
             if not already_running and not user.spawner.options_form:
                 yield self.spawn_single_user(user)
             self.set_login_cookie(user)
@@ -117,7 +117,7 @@ class LoginHandler(BaseHandler):
             self.log.debug("Failed login for %s", data.get('username', 'unknown user'))
             html = self._render(
                 login_error='Invalid username or password',
-                username=username,
+                username=data['username'],
             )
             self.finish(html)
 


### PR DESCRIPTION
self.authenticate can return None, in which case you can't subscript.
So move extracting data into the branch checking whether authenticate is
not `None`.

Now that extracting the username is inside the if branch, it can't be
used in the else one, so extract username from the request itself.

This can be easily reproduce with the default PAM login with a wrong
non existing/ wrong username.