### PR TITLE
Don't add route if there's already a route addition pending

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -304,6 +304,8 @@ class Proxy(LoggingConfigurable):
                     self.log.warning(
                         "Adding missing route for %s (%s)", user.name, user.server)
                     futures.append(self.add_user(user))
+            elif user.proxy_pending:
+                good_routes.add(user.proxy_spec)
 
         # check service routes
         service_routes = {r['data']['service']


### PR DESCRIPTION
This race seems to happen when check_routes is called in the middle of
the route being added.