### PR TITLE
Dirty database fixes

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -94,7 +94,9 @@ class BaseHandler(RequestHandler):
 
     def finish(self, *args, **kwargs):
         """Roll back any uncommitted transactions from the handler."""
-        self.db.rollback()
+        if self.db.dirty:
+            self.log.warning("Rolling back dirty objects %s", self.db.dirty)
+            self.db.rollback()
         super().finish(*args, **kwargs)
 
     #---------------------------------------------------------------

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -83,7 +83,8 @@ class Server(HasTraits):
     @observe('ip', 'proto', 'port', 'base_url', 'cookie_name')
     def _change(self, change):
         if self.orm_server:
-            setattr(self.orm_server, change.name, change.new)
+            if getattr(self.orm_server, change.name) != change.new:
+                setattr(self.orm_server, change.name, change.new)
 
     @property
     def host(self):

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -82,9 +82,12 @@ class Server(HasTraits):
     # setter to pass through to the database
     @observe('ip', 'proto', 'port', 'base_url', 'cookie_name')
     def _change(self, change):
-        if self.orm_server:
-            if getattr(self.orm_server, change.name) != change.new:
-                setattr(self.orm_server, change.name, change.new)
+        if self.orm_server and getattr(self.orm_server, change.name) != change.new:
+            # setattr on an sqlalchemy object sets the dirty flag,
+            # even if the value doesn't change.
+            # Avoid calling setattr when there's been no change,
+            # to avoid setting the dirty flag and triggering rollback.
+            setattr(self.orm_server, change.name, change.new)
 
     @property
     def host(self):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -72,10 +72,7 @@ def test_admin_not_admin(app):
     assert r.status_code == 403
 
 def test_admin(app):
-    cookies = app.login_user('river')
-    u = orm.User.find(app.db, 'river')
-    u.admin = True
-    app.db.commit()
+    cookies = app.login_user('admin')
     r = get_page('admin', app, cookies=cookies)
     r.raise_for_status()
     assert r.url.endswith('/admin')


### PR DESCRIPTION
- Only set attributes on orm_server if they changed.
  Setting things on orm_server set the dirty flag, even if they haven't changed,
  so avoid it. The wrappers were effectively calling `orm_server.ip = orm_server.ip`,
  due to how the trait notifiers are hooked up.
- Only call `db.rollback()` if there are dirty objects to rollback.
  And log what objects are dirty when we do.
  Note: These may not actually be modified (`db.is_modified` could check this).