### PR TITLE
don't salt & re-hash generated UUID tokens

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -427,7 +427,7 @@ class OAuthAccessToken(Hashed, Base):
 
     # from Hashed
     hashed = Column(Unicode(64))
-    prefix = Column(Unicode(16))
+    prefix = Column(Unicode(16), index=True)
     
     def __repr__(self):
         return "<{cls}('{prefix}...', user='{user}'>".format(

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -268,7 +268,19 @@ class Hashed(object):
     def token(self, token):
         """Store the hashed value and prefix for a token"""
         self.prefix = token[:self.prefix_length]
-        self.hashed = hash_token(token, rounds=self.rounds, salt=self.salt_bytes, algorithm=self.algorithm)
+        if len(token) >= 32:
+            # Tokens are generally UUIDs, which have sufficient entropy on their own
+            # and don't need salt & hash rounds.
+            # ref: https://security.stackexchange.com/a/151262/155114
+            rounds = 1
+            salt_bytes = b''
+        else:
+            # users can still specify API tokens in a few ways,
+            # so trigger salt & hash rounds if they provide a short token
+            app_log.warning("Applying salt & hash rounds to %sB token" % len(token))
+            rounds = self.rounds
+            salt_bytes = self.salt_bytes
+        self.hashed = hash_token(token, rounds=rounds, salt=salt_bytes, algorithm=self.algorithm)
 
     def match(self, token):
         """Is this my token?"""


### PR DESCRIPTION
UUIDs have enough entropy on their own, so use just a simple sha512 (sha256 ought to be enough, really).

ref: https://security.stackexchange.com/a/151262/155114

The same scheme is used, just with one round of hashing and zero bytes of salt.

If admins insert short API tokens, the original salt&hash is still applied.

cc @ssanderson for double-checking that this is actually sensible.

@yuvipanda has found that our token hashing is a significant contributor to the total CPU time spent in the Hub, and a limiting factor with thousands of users, so using a simple hash here could save some real time. On my test machine, hashing tokens drops from ~3-4ms to ~60-80µs.