### PR TITLE
Ignore a couple other of regularly non followed lint rules.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,10 @@
 # F403: import *
 # F811: redefinition of unused `name` from line `N`
 # F841: local variable assigned but never used
-ignore = E, C, W, F401, F403, F811, F841
+# E402: module level import not at top of file
+# I100: Import statements are in the wrong order
+# I101: Imported names are in the wrong order. Should be
+ignore = E, C, W, F401, F403, F811, F841, E402, I100, I101
 
 exclude =
     .cache,


### PR DESCRIPTION
These rules are not followed in a lot of place leading to too many
warnnigs which (at least in my editor) make code unreadable.