### PR TITLE
simplify Hub object a bit

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -852,7 +852,6 @@ class JupyterHub(Application):
             ip=self.hub_ip,
             port=self.hub_port,
             base_url=self.hub_prefix,
-            cookie_name='jupyter-hub-token',
             public_host=self.subdomain_host,
         )
         if self.hub_connect_ip:
@@ -1164,7 +1163,7 @@ class JupyterHub(Application):
         db.commit()
 
     def init_oauth(self):
-        base_url = self.hub.server.base_url
+        base_url = self.hub.base_url
         self.oauth_provider = make_provider(
             self.session_factory,
             url_prefix=url_path_join(base_url, 'api/oauth2'),

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -285,7 +285,7 @@ class BaseHandler(RequestHandler):
 
     def set_hub_cookie(self, user):
         """set the login cookie for the Hub"""
-        self._set_user_cookie(user, self.hub.server)
+        self._set_user_cookie(user, self.hub)
 
     def set_login_cookie(self, user):
         """Set login cookies for the Hub and single-user server."""

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -37,7 +37,7 @@ class LoginHandler(BaseHandler):
                 custom_html=self.authenticator.custom_html,
                 login_url=self.settings['login_url'],
                 authenticator_login_url=url_concat(
-                    self.authenticator.login_url(self.hub.server.base_url),
+                    self.authenticator.login_url(self.hub.base_url),
                     {'next': self.get_argument('next', '')},
                 ),
         )
@@ -64,7 +64,7 @@ class LoginHandler(BaseHandler):
             self.redirect(next_url, permanent=False)
         else:
             if self.authenticator.auto_login:
-                auto_login_url = self.authenticator.login_url(self.hub.server.base_url)
+                auto_login_url = self.authenticator.login_url(self.hub.base_url)
                 if auto_login_url == self.settings['login_url']:
                     self.authenticator.auto_login = False
                     self.log.warning("Authenticator.auto_login cannot be used without a custom login_url")

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -5,8 +5,7 @@
 
 import socket
 from urllib.parse import urlparse
-
-from tornado import gen
+import warnings
 
 from traitlets import (
     HasTraits, Instance, Integer, Unicode,
@@ -136,9 +135,14 @@ class Hub(Server):
     of the server base_url.
     """
 
+    cookie_name = 'jupyter-hub-token'
+
     @property
     def server(self):
-        """backward-compat"""
+        warnings.warn("Hub.server is deprecated in JupyterHub 0.8. Access attributes on the Hub directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self
     public_host = Unicode()
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -536,7 +536,7 @@ def test_cookie(app):
     app_user = get_app_user(app, name)
 
     cookies = app.login_user(name)
-    cookie_name = app.hub.server.cookie_name
+    cookie_name = app.hub.cookie_name
     # cookie jar gives '"cookie-value"', we want 'cookie-value'
     cookie = cookies[cookie_name][1:-1]
     r = api_request(app, 'authorizations/cookie',

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -27,7 +27,7 @@ def test_root_no_auth(app, io_loop):
     print(app.hub.is_up())
     routes = io_loop.run_sync(app.proxy.get_all_routes)
     print(routes)
-    print(app.hub.server)
+    print(app.hub)
     url = ujoin(public_host(app), app.hub.base_url)
     print(url)
     r = requests.get(url)
@@ -280,7 +280,7 @@ def test_auto_login(app, io_loop, request):
             self.write('ok!')
     base_url = public_url(app) + '/'
     app.tornado_application.add_handlers(".*$", [
-        (ujoin(app.hub.server.base_url, 'dummy'), DummyLoginHandler),
+        (ujoin(app.hub.base_url, 'dummy'), DummyLoginHandler),
     ])
     # no auto_login: end up at /hub/login
     r = requests.get(base_url)


### PR DESCRIPTION
- remove use of deprecated Hub.server
- add deprecation warning to Hub.server property
- move cookie_name declaration to Hub, so it doesn't need to be passed to the constructor.
  It's not configurable, anyway.

Related to #1270