### PR TITLE
eliminate test application thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
   - 3.6
   - 3.5
   - 3.4
+env:
+  global:
+    - ASYNC_TEST_TIMEOUT=15
 
 # installing dependencies
 before_install:

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -38,8 +38,7 @@ def db():
 
 @fixture(scope='module')
 def io_loop(request):
-    """Same as pytest-tornado.gen"""
-    print("my io_loop fixture")
+    """Same as pytest-tornado.io_loop, but re-scoped to module-level"""
     io_loop = ioloop.IOLoop()
     io_loop.make_current()
 
@@ -78,7 +77,7 @@ class MockServiceSpawner(jupyterhub.services.service._ServiceSpawner):
 
 _mock_service_counter = 0
 
-def _mockservice(request, app, io_loop, url=False):
+def _mockservice(request, app, url=False):
     global _mock_service_counter
     _mock_service_counter += 1
     name = 'mock-service-%i' % _mock_service_counter
@@ -90,6 +89,8 @@ def _mockservice(request, app, io_loop, url=False):
     if url:
         spec['url'] = 'http://127.0.0.1:%i' % random_port()
 
+    io_loop = app.io_loop
+
     with mock.patch.object(jupyterhub.services.service, '_ServiceSpawner', MockServiceSpawner):
         app.services = [spec]
         app.init_services()
@@ -100,20 +101,17 @@ def _mockservice(request, app, io_loop, url=False):
             # wait for proxy to be updated before starting the service
             yield app.proxy.add_all_services(app._service_map)
             service.start()
-        app.io_loop.add_callback(start)
+        io_loop.run_sync(start)
         def cleanup():
             service.stop()
             app.services[:] = []
             app._service_map.clear()
         request.addfinalizer(cleanup)
-        for i in range(20):
-            if not getattr(service, 'proc', False):
-                time.sleep(0.2)
         # ensure process finishes starting
         with raises(TimeoutExpired):
             service.proc.wait(1)
         if url:
-            ioloop.IOLoop().run_sync(service.server.wait_up)
+            io_loop.run_sync(service.server.wait_up)
     return service
 
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -36,25 +36,35 @@ def db():
     return _db
 
 
-@fixture
-def io_loop():
-    """Get the current IOLoop"""
-    loop = ioloop.IOLoop()
-    loop.make_current()
-    return loop
+@fixture(scope='module')
+def io_loop(request):
+    """Same as pytest-tornado.gen"""
+    print("my io_loop fixture")
+    io_loop = ioloop.IOLoop()
+    io_loop.make_current()
 
+    def _close():
+        io_loop.clear_current()
+        if (not ioloop.IOLoop.initialized() or
+                io_loop is not ioloop.IOLoop.instance()):
+            io_loop.close(all_fds=True)
+
+    request.addfinalizer(_close)
+    return io_loop
 
 @fixture(scope='module')
-def app(request):
+def app(request, io_loop):
     """Mock a jupyterhub app for testing"""
     mocked_app = MockHub.instance(log_level=logging.DEBUG)
-    mocked_app.start([])
-
+    @gen.coroutine
+    def make_app():
+        yield mocked_app.initialize([])
+        yield mocked_app.start()
+    io_loop.run_sync(make_app)
 
     def fin():
         # disconnect logging during cleanup because pytest closes captured FDs prematurely
         mocked_app.log.handlers = []
-
         MockHub.clear_instance()
         mocked_app.stop()
     request.addfinalizer(fin)
@@ -68,7 +78,7 @@ class MockServiceSpawner(jupyterhub.services.service._ServiceSpawner):
 
 _mock_service_counter = 0
 
-def _mockservice(request, app, url=False):
+def _mockservice(request, app, io_loop, url=False):
     global _mock_service_counter
     _mock_service_counter += 1
     name = 'mock-service-%i' % _mock_service_counter

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -22,6 +22,7 @@ from ..objects import Server
 from ..spawner import LocalProcessSpawner
 from ..singleuser import SingleUserNotebookApp
 from ..utils import random_port, url_path_join
+from .utils import async_requests
 
 from pamela import PAMError
 
@@ -178,10 +179,11 @@ class MockHub(JupyterHub):
         self.cleanup = lambda : None
         self.db_file.close()
     
+    @gen.coroutine
     def login_user(self, name):
         """Login a user by name, returning her cookies."""
         base_url = public_url(self)
-        r = requests.post(base_url + 'hub/login',
+        r = yield async_requests.post(base_url + 'hub/login',
             data={
                 'username': name,
                 'password': name,

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -462,7 +462,7 @@ def test_slow_spawn(app, no_patience, request):
 
     @gen.coroutine
     def wait_spawn():
-        while app_user.spawner._spawn_pending:
+        while not app_user.running(''):
             yield gen.sleep(0.1)
 
     yield wait_spawn()

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -134,7 +134,7 @@ def test_auth_api(app):
 
 
 @mark.gen_test
-def test_referer_check(app, io_loop):
+def test_referer_check(app):
     url = ujoin(public_host(app), app.hub.base_url)
     host = urlparse(url).netloc
     user = find_user(app.db, 'admin')
@@ -390,7 +390,7 @@ def test_make_admin(app):
 
 
 @mark.gen_test
-def test_spawn(app, io_loop):
+def test_spawn(app):
     db = app.db
     name = 'wash'
     user = add_user(db, app=app, name=name)
@@ -445,7 +445,7 @@ def test_spawn(app, io_loop):
 
 
 @mark.gen_test
-def test_slow_spawn(app, io_loop, no_patience, request):
+def test_slow_spawn(app, no_patience, request):
     patch = mock.patch.dict(app.tornado_settings, {'spawner_class': mocking.SlowSpawner})
     patch.start()
     request.addfinalizer(patch.stop)
@@ -495,7 +495,7 @@ def test_slow_spawn(app, io_loop, no_patience, request):
 
 
 @mark.gen_test
-def test_never_spawn(app, io_loop, no_patience, request):
+def test_never_spawn(app, no_patience, request):
     patch = mock.patch.dict(app.tornado_settings, {'spawner_class': mocking.NeverSpawner})
     patch.start()
     request.addfinalizer(patch.stop)
@@ -520,7 +520,7 @@ def test_never_spawn(app, io_loop, no_patience, request):
 
 
 @mark.gen_test
-def test_get_proxy(app, io_loop):
+def test_get_proxy(app):
     r = yield api_request(app, 'proxy')
     r.raise_for_status()
     reply = r.json()

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -3,6 +3,8 @@ import os
 import shutil
 
 from sqlalchemy.exc import OperationalError
+
+import pytest
 from pytest import raises
 
 from ..dbutil import upgrade
@@ -24,7 +26,8 @@ def test_upgrade(tmpdir):
     print(db_url)
     upgrade(db_url)
 
-def test_upgrade_entrypoint(tmpdir, io_loop):
+@pytest.mark.gen_test
+def test_upgrade_entrypoint(tmpdir):
     generate_old_db(str(tmpdir))
     tmpdir.chdir()
     tokenapp = NewToken()
@@ -36,7 +39,7 @@ def test_upgrade_entrypoint(tmpdir, io_loop):
     assert len(sqlite_files) == 1
 
     upgradeapp = UpgradeDB()
-    io_loop.run_sync(lambda : upgradeapp.initialize([]))
+    yield upgradeapp.initialize([])
     upgradeapp.start()
 
     # check that backup was created:

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -140,7 +140,8 @@ def test_token_find(db):
     assert found is None
 
 
-def test_spawn_fails(db, io_loop):
+@pytest.mark.gen_test
+def test_spawn_fails(db):
     orm_user = orm.User(name='aeofel')
     db.add(orm_user)
     db.commit()
@@ -156,7 +157,7 @@ def test_spawn_fails(db, io_loop):
     })
     
     with pytest.raises(RuntimeError) as exc:
-        io_loop.run_sync(user.spawn)
+        yield user.spawn()
     assert user.spawners[''].server is None
     assert not user.running('')
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -2,7 +2,6 @@
 
 from urllib.parse import urlencode, urlparse
 
-import requests
 from tornado import gen
 
 from ..handlers import BaseHandler
@@ -11,8 +10,11 @@ from .. import orm
 from ..auth import Authenticator
 
 import mock
+import pytest
+
 from .mocking import FormSpawner, public_url, public_host
 from .test_api import api_request
+from .utils import async_requests
 
 def get_page(path, app, hub=True, **kw):
     if hub:
@@ -20,113 +22,128 @@ def get_page(path, app, hub=True, **kw):
     else:
         prefix = app.base_url
     base_url = ujoin(public_host(app), prefix)
-    print(base_url)
-    return requests.get(ujoin(base_url, path), **kw)
+    return async_requests.get(ujoin(base_url, path), **kw)
 
-def test_root_no_auth(app, io_loop):
-    print(app.hub.is_up())
-    routes = io_loop.run_sync(app.proxy.get_all_routes)
-    print(routes)
-    print(app.hub)
+
+@pytest.mark.gen_test
+def test_root_no_auth(app):
     url = ujoin(public_host(app), app.hub.base_url)
-    print(url)
-    r = requests.get(url)
+    r = yield async_requests.get(url)
     r.raise_for_status()
     assert r.url == ujoin(url, 'login')
 
+
+@pytest.mark.gen_test
 def test_root_auth(app):
-    cookies = app.login_user('river')
-    r = requests.get(public_url(app), cookies=cookies)
+    cookies = yield app.login_user('river')
+    r = yield async_requests.get(public_url(app), cookies=cookies)
     r.raise_for_status()
     assert r.url == public_url(app, app.users['river'])
 
+
+@pytest.mark.gen_test
 def test_root_redirect(app):
     name = 'wash'
-    cookies = app.login_user(name)
+    cookies = yield app.login_user(name)
     next_url = ujoin(app.base_url, 'user/other/test.ipynb')
     url = '/?' + urlencode({'next': next_url})
-    r = get_page(url, app, cookies=cookies)
+    r = yield get_page(url, app, cookies=cookies)
     r.raise_for_status()
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, 'user/%s/test.ipynb' % name)
 
+
+@pytest.mark.gen_test
 def test_home_no_auth(app):
-    r = get_page('home', app, allow_redirects=False)
+    r = yield get_page('home', app, allow_redirects=False)
     r.raise_for_status()
     assert r.status_code == 302
     assert '/hub/login' in r.headers['Location']
 
+
+@pytest.mark.gen_test
 def test_home_auth(app):
-    cookies = app.login_user('river')
-    r = get_page('home', app, cookies=cookies)
+    cookies = yield app.login_user('river')
+    r = yield get_page('home', app, cookies=cookies)
     r.raise_for_status()
     assert r.url.endswith('home')
 
+
+@pytest.mark.gen_test
 def test_admin_no_auth(app):
-    r = get_page('admin', app)
+    r = yield get_page('admin', app)
     assert r.status_code == 403
 
+
+@pytest.mark.gen_test
 def test_admin_not_admin(app):
-    cookies = app.login_user('wash')
-    r = get_page('admin', app, cookies=cookies)
+    cookies = yield app.login_user('wash')
+    r = yield get_page('admin', app, cookies=cookies)
     assert r.status_code == 403
 
+
+@pytest.mark.gen_test
 def test_admin(app):
-    cookies = app.login_user('admin')
-    r = get_page('admin', app, cookies=cookies)
+    cookies = yield app.login_user('admin')
+    r = yield get_page('admin', app, cookies=cookies)
     r.raise_for_status()
     assert r.url.endswith('/admin')
 
 
-def test_spawn_redirect(app, io_loop):
+@pytest.mark.gen_test
+def test_spawn_redirect(app):
     name = 'wash'
-    cookies = app.login_user(name)
+    cookies = yield app.login_user(name)
     u = app.users[orm.User.find(app.db, name)]
     
     # ensure wash's server isn't running:
-    r = api_request(app, 'users', name, 'server', method='delete', cookies=cookies)
+    r = yield api_request(app, 'users', name, 'server', method='delete', cookies=cookies)
     r.raise_for_status()
-    status = io_loop.run_sync(u.spawner.poll)
+    status = yield u.spawner.poll()
     assert status is not None
     
     # test spawn page when no server is running
-    r = get_page('spawn', app, cookies=cookies)
+    r = yield get_page('spawn', app, cookies=cookies)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, 'user/%s/' % name)
     
     # should have started server
-    status = io_loop.run_sync(u.spawner.poll)
+    status = yield u.spawner.poll()
     assert status is None
     
     # test spawn page when server is already running (just redirect)
-    r = get_page('spawn', app, cookies=cookies)
+    r = yield get_page('spawn', app, cookies=cookies)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s/' % name)
 
+
+@pytest.mark.gen_test
 def test_spawn_page(app):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
-        cookies = app.login_user('jones')
-        r = get_page('spawn', app, cookies=cookies)
+        cookies = yield app.login_user('jones')
+        r = yield get_page('spawn', app, cookies=cookies)
         assert r.url.endswith('/spawn')
         assert FormSpawner.options_form in r.text
 
-        r = get_page('spawn?next=foo', app, cookies=cookies)
+        r = yield get_page('spawn?next=foo', app, cookies=cookies)
         assert r.url.endswith('/spawn?next=foo')
         assert FormSpawner.options_form in r.text
 
-def test_spawn_form(app, io_loop):
+
+@pytest.mark.gen_test
+def test_spawn_form(app):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.base_url)
-        cookies = app.login_user('jones')
+        cookies = yield app.login_user('jones')
         orm_u = orm.User.find(app.db, 'jones')
         u = app.users[orm_u]
-        io_loop.run_sync(u.stop)
+        yield u.stop()
     
-        r = requests.post(ujoin(base_url, 'spawn?next=/user/jones/tree'), cookies=cookies, data={
+        r = yield async_requests.post(ujoin(base_url, 'spawn?next=/user/jones/tree'), cookies=cookies, data={
             'bounds': ['-1', '1'],
             'energy': '511keV',
         })
@@ -140,15 +157,17 @@ def test_spawn_form(app, io_loop):
             'notspecified': 5,
         }
 
-def test_spawn_form_with_file(app, io_loop):
+
+@pytest.mark.gen_test
+def test_spawn_form_with_file(app):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.base_url)
-        cookies = app.login_user('jones')
+        cookies = yield app.login_user('jones')
         orm_u = orm.User.find(app.db, 'jones')
         u = app.users[orm_u]
-        io_loop.run_sync(u.stop)
+        yield u.stop()
 
-        r = requests.post(ujoin(base_url, 'spawn'),
+        r = yield async_requests.post(ujoin(base_url, 'spawn'),
                           cookies=cookies,
                           data={
                               'bounds': ['-1', '1'],
@@ -167,11 +186,12 @@ def test_spawn_form_with_file(app, io_loop):
         }
 
 
+@pytest.mark.gen_test
 def test_user_redirect(app):
     name = 'wash'
-    cookies = app.login_user(name)
+    cookies = yield app.login_user(name)
 
-    r = get_page('/user-redirect/tree/top/', app)
+    r = yield get_page('/user-redirect/tree/top/', app)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
@@ -181,31 +201,32 @@ def test_user_redirect(app):
         'next': ujoin(app.hub.base_url, '/user-redirect/tree/top/')
     })
 
-    r = get_page('/user-redirect/notebooks/test.ipynb', app, cookies=cookies)
+    r = yield get_page('/user-redirect/notebooks/test.ipynb', app, cookies=cookies)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s/notebooks/test.ipynb' % name)
 
 
+@pytest.mark.gen_test
 def test_user_redirect_deprecated(app):
     """redirecting from /user/someonelse/ URLs (deprecated)"""
     name = 'wash'
-    cookies = app.login_user(name)
+    cookies = yield app.login_user(name)
 
-    r = get_page('/user/baduser', app, cookies=cookies, hub=False)
+    r = yield get_page('/user/baduser', app, cookies=cookies, hub=False)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s' % name)
 
-    r = get_page('/user/baduser/test.ipynb', app, cookies=cookies, hub=False)
+    r = yield get_page('/user/baduser/test.ipynb', app, cookies=cookies, hub=False)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s/test.ipynb' % name)
 
-    r = get_page('/user/baduser/test.ipynb', app, hub=False)
+    r = yield get_page('/user/baduser/test.ipynb', app, hub=False)
     r.raise_for_status()
     print(urlparse(r.url))
     path = urlparse(r.url).path
@@ -216,10 +237,11 @@ def test_user_redirect_deprecated(app):
     })
 
 
+@pytest.mark.gen_test
 def test_login_fail(app):
     name = 'wash'
     base_url = public_url(app)
-    r = requests.post(base_url + 'hub/login',
+    r = yield async_requests.post(base_url + 'hub/login',
         data={
             'username': name,
             'password': 'wrong',
@@ -229,6 +251,7 @@ def test_login_fail(app):
     assert not r.cookies
 
 
+@pytest.mark.gen_test
 def test_login_strip(app):
     """Test that login form doesn't strip whitespace from passwords"""
     form_data = {
@@ -242,7 +265,7 @@ def test_login_strip(app):
         called_with.append(data)
 
     with mock.patch.object(app.authenticator, 'authenticate', mock_authenticate):
-        r = requests.post(base_url + 'hub/login',
+        yield async_requests.post(base_url + 'hub/login',
             data=form_data,
             allow_redirects=False,
         )
@@ -250,31 +273,33 @@ def test_login_strip(app):
     assert called_with == [form_data]
 
 
-def test_login_redirect(app, io_loop):
-    cookies = app.login_user('river')
+@pytest.mark.gen_test
+def test_login_redirect(app):
+    cookies = yield app.login_user('river')
     user = app.users['river']
     # no next_url, server running
-    io_loop.run_sync(user.spawn)
-    r = get_page('login', app, cookies=cookies, allow_redirects=False)
+    yield user.spawn()
+    r = yield get_page('login', app, cookies=cookies, allow_redirects=False)
     r.raise_for_status()
     assert r.status_code == 302
     assert '/user/river' in r.headers['Location']
     
     # no next_url, server not running
-    io_loop.run_sync(user.stop)
-    r = get_page('login', app, cookies=cookies, allow_redirects=False)
+    yield user.stop()
+    r = yield get_page('login', app, cookies=cookies, allow_redirects=False)
     r.raise_for_status()
     assert r.status_code == 302
     assert '/hub/' in r.headers['Location']
     
     # next URL given, use it
-    r = get_page('login?next=/hub/admin', app, cookies=cookies, allow_redirects=False)
+    r = yield get_page('login?next=/hub/admin', app, cookies=cookies, allow_redirects=False)
     r.raise_for_status()
     assert r.status_code == 302
     assert r.headers['Location'].endswith('/hub/admin')
 
 
-def test_auto_login(app, io_loop, request):
+@pytest.mark.gen_test
+def test_auto_login(app, request):
     class DummyLoginHandler(BaseHandler):
         def get(self):
             self.write('ok!')
@@ -283,7 +308,7 @@ def test_auto_login(app, io_loop, request):
         (ujoin(app.hub.base_url, 'dummy'), DummyLoginHandler),
     ])
     # no auto_login: end up at /hub/login
-    r = requests.get(base_url)
+    r = yield async_requests.get(base_url)
     assert r.url == public_url(app, path='hub/login')
     # enable auto_login: redirect from /hub/login to /hub/dummy
     authenticator = Authenticator(auto_login=True)
@@ -292,38 +317,41 @@ def test_auto_login(app, io_loop, request):
     with mock.patch.dict(app.tornado_application.settings, {
         'authenticator': authenticator,
     }):
-        r = requests.get(base_url)
+        r = yield async_requests.get(base_url)
     assert r.url == public_url(app, path='hub/dummy')
 
 
+@pytest.mark.gen_test
 def test_logout(app):
     name = 'wash'
-    cookies = app.login_user(name)
-    r = requests.get(public_host(app) + app.tornado_settings['logout_url'], cookies=cookies)
+    cookies = yield app.login_user(name)
+    r = yield async_requests.get(public_host(app) + app.tornado_settings['logout_url'], cookies=cookies)
     r.raise_for_status()
     login_url = public_host(app) + app.tornado_settings['login_url']
     assert r.url == login_url
     assert r.cookies == {}
 
 
+@pytest.mark.gen_test
 def test_login_no_whitelist_adds_user(app):
     auth = app.authenticator
     mock_add_user = mock.Mock()
     with mock.patch.object(auth, 'add_user', mock_add_user):
-        cookies = app.login_user('jubal')
+        cookies = yield app.login_user('jubal')
 
     user = app.users['jubal']
     assert mock_add_user.mock_calls == [mock.call(user)]
 
 
+@pytest.mark.gen_test
 def test_static_files(app):
     base_url = ujoin(public_host(app), app.hub.base_url)
-    r = requests.get(ujoin(base_url, 'logo'))
+    r = yield async_requests.get(ujoin(base_url, 'logo'))
     r.raise_for_status()
     assert r.headers['content-type'] == 'image/png'
-    r = requests.get(ujoin(base_url, 'static', 'images', 'jupyter.png'))
+    r = yield async_requests.get(ujoin(base_url, 'static', 'images', 'jupyter.png'))
     r.raise_for_status()
     assert r.headers['content-type'] == 'image/png'
-    r = requests.get(ujoin(base_url, 'static', 'css', 'style.min.css'))
+    r = yield async_requests.get(ujoin(base_url, 'static', 'css', 'style.min.css'))
     r.raise_for_status()
     assert r.headers['content-type'] == 'text/css'

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -28,6 +28,9 @@ def test_external_proxy(request):
     cfg.ConfigurableHTTPProxy.should_start = False
 
     app = MockHub.instance(config=cfg)
+    # disable last_activity polling to avoid check_routes being called during the test,
+    # which races with some of our test conditions
+    app.last_activity_interval = 0
 
     def fin():
         MockHub.clear_instance()
@@ -53,10 +56,7 @@ def test_external_proxy(request):
 
     def _cleanup_proxy():
         if proxy.poll() is None:
-            print("Terminating proxy")
             proxy.terminate()
-        else:
-            print("Not stopping proxy", proxy)
     request.addfinalizer(_cleanup_proxy)
 
     def wait_for_proxy():

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -16,7 +16,8 @@ from .test_api import api_request
 from ..utils import wait_for_http_server, url_path_join as ujoin
 
 
-def test_external_proxy(request, io_loop):
+@pytest.mark.gen_test
+def test_external_proxy(request):
 
     auth_token = 'secret!'
     proxy_ip = '127.0.0.1'
@@ -30,7 +31,7 @@ def test_external_proxy(request, io_loop):
 
     def fin():
         MockHub.clear_instance()
-        app.stop()
+        app.http_server.stop()
 
     request.addfinalizer(fin)
 
@@ -52,28 +53,32 @@ def test_external_proxy(request, io_loop):
 
     def _cleanup_proxy():
         if proxy.poll() is None:
+            print("Terminating proxy")
             proxy.terminate()
+        else:
+            print("Not stopping proxy", proxy)
     request.addfinalizer(_cleanup_proxy)
 
     def wait_for_proxy():
-        io_loop.run_sync(lambda: wait_for_http_server('http://%s:%i' % (proxy_ip, proxy_port)))
-    wait_for_proxy()
+        return wait_for_http_server('http://%s:%i' % (proxy_ip, proxy_port))
+    yield wait_for_proxy()
 
-    app.start([])
+    yield app.initialize([])
+    yield app.start()
     assert app.proxy.proxy_process is None
 
     # test if api service has a root route '/'
-    routes = io_loop.run_sync(app.proxy.get_all_routes)
+    routes = yield app.proxy.get_all_routes()
     assert list(routes.keys()) == ['/']
     
     # add user to the db and start a single user server
     name = 'river'
-    r = api_request(app, 'users', name, method='post')
+    r = yield api_request(app, 'users', name, method='post')
     r.raise_for_status()
-    r = api_request(app, 'users', name, 'server', method='post')
+    r = yield api_request(app, 'users', name, 'server', method='post')
     r.raise_for_status()
     
-    routes = io_loop.run_sync(app.proxy.get_all_routes)
+    routes = yield app.proxy.get_all_routes()
     # sets the desired path result
     user_path = ujoin(app.base_url, 'user/river') + '/'
     print(app.base_url, user_path)
@@ -86,18 +91,18 @@ def test_external_proxy(request, io_loop):
     # teardown the proxy and start a new one in the same place
     proxy.terminate()
     proxy = Popen(cmd, env=env)
-    wait_for_proxy()
+    yield wait_for_proxy()
 
-    routes = io_loop.run_sync(app.proxy.get_all_routes)
+    routes = yield app.proxy.get_all_routes()
 
     assert list(routes.keys()) == []
     
     # poke the server to update the proxy
-    r = api_request(app, 'proxy', method='post')
+    r = yield api_request(app, 'proxy', method='post')
     r.raise_for_status()
 
     # check that the routes are correct
-    routes = io_loop.run_sync(app.proxy.get_all_routes)
+    routes = yield app.proxy.get_all_routes()
     assert sorted(routes.keys()) == ['/', user_spec]
 
     # teardown the proxy, and start a new one with different auth and port
@@ -115,41 +120,35 @@ def test_external_proxy(request, io_loop):
     if app.subdomain_host:
         cmd.append('--host-routing')
     proxy = Popen(cmd, env=env)
-    wait_for_proxy()
+    yield wait_for_proxy()
 
     # tell the hub where the new proxy is
     new_api_url = 'http://{}:{}'.format(proxy_ip, proxy_port)
-    r = api_request(app, 'proxy', method='patch', data=json.dumps({
+    r = yield api_request(app, 'proxy', method='patch', data=json.dumps({
         'api_url': new_api_url,
         'auth_token': new_auth_token,
     }))
     r.raise_for_status()
     assert app.proxy.api_url == new_api_url
 
-    # get updated auth token from main thread
-    def get_app_proxy_token():
-        q = Queue()
-        app.io_loop.add_callback(lambda: q.put(app.proxy.auth_token))
-        return q.get(timeout=2)
-
-    assert get_app_proxy_token() == new_auth_token
-    app.proxy.auth_token = new_auth_token
+    assert app.proxy.auth_token == new_auth_token
 
     # check that the routes are correct
-    routes = io_loop.run_sync(app.proxy.get_all_routes)
+    routes = yield app.proxy.get_all_routes()
     assert sorted(routes.keys()) == ['/', user_spec]
 
 
+@pytest.mark.gen_test
 @pytest.mark.parametrize("username, endpoints", [
     ('zoe', ['users/zoe', 'users/zoe/server']),
     ('50fia', ['users/50fia', 'users/50fia/server']),
     ('秀樹', ['users/秀樹', 'users/秀樹/server']),
 ])
-def test_check_routes(app, io_loop, username, endpoints):
+def test_check_routes(app,  username, endpoints):
     proxy = app.proxy
 
     for endpoint in endpoints:
-        r = api_request(app, endpoint, method='post')
+        r = yield api_request(app, endpoint, method='post')
         r.raise_for_status()
 
     test_user = orm.User.find(app.db, username)
@@ -157,18 +156,21 @@ def test_check_routes(app, io_loop, username, endpoints):
 
     # check a valid route exists for user
     test_user = app.users[username]
-    before = sorted(io_loop.run_sync(app.proxy.get_all_routes))
+    routes = yield app.proxy.get_all_routes()
+    before = sorted(routes)
     assert test_user.proxy_spec() in before
 
     # check if a route is removed when user deleted
-    io_loop.run_sync(lambda: app.proxy.check_routes(app.users, app._service_map))
-    io_loop.run_sync(lambda: proxy.delete_user(test_user))
-    during = sorted(io_loop.run_sync(app.proxy.get_all_routes))
+    yield app.proxy.check_routes(app.users, app._service_map)
+    yield proxy.delete_user(test_user)
+    routes = yield app.proxy.get_all_routes()
+    during = sorted(routes)
     assert test_user.proxy_spec() not in during
 
     # check if a route exists for user
-    io_loop.run_sync(lambda: app.proxy.check_routes(app.users, app._service_map))
-    after = sorted(io_loop.run_sync(app.proxy.get_all_routes))
+    yield app.proxy.check_routes(app.users, app._service_map)
+    routes = yield app.proxy.get_all_routes()
+    after = sorted(routes)
     assert test_user.proxy_spec() in after
 
     # check that before and after state are the same
@@ -222,7 +224,8 @@ def test_add_get_delete(app, routespec):
         assert route is None
 
 
+@pytest.mark.gen_test
 @pytest.mark.parametrize("test_data", [None, 'notjson', json.dumps([])])
 def test_proxy_patch_bad_request_data(app, test_data):
-    r = api_request(app, 'proxy', method='patch', data=test_data)
+    r = yield api_request(app, 'proxy', method='patch', data=test_data)
     assert r.status_code == 400

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -3,68 +3,72 @@
 from subprocess import check_output
 import sys
 
-import requests
+import pytest
 
 import jupyterhub
 from .mocking import StubSingleUserSpawner, public_url
 from ..utils import url_path_join
 
+from .utils import async_requests
 
-def test_singleuser_auth(app, io_loop):
+
+@pytest.mark.gen_test
+def test_singleuser_auth(app):
     # use StubSingleUserSpawner to launch a single-user app in a thread
     app.spawner_class = StubSingleUserSpawner
     app.tornado_settings['spawner_class'] = StubSingleUserSpawner
     
     # login, start the server
-    cookies = app.login_user('nandy')
+    cookies = yield app.login_user('nandy')
     user = app.users['nandy']
     if not user.running(''):
-        io_loop.run_sync(user.spawn)
+        yield user.spawn()
     url = public_url(app, user)
     
     # no cookies, redirects to login page
-    r = requests.get(url)
+    r = yield async_requests.get(url)
     r.raise_for_status()
     assert '/hub/login' in r.url
     
     # with cookies, login successful
-    r = requests.get(url, cookies=cookies)
+    r = yield async_requests.get(url, cookies=cookies)
     r.raise_for_status()
     assert r.url.rstrip('/').endswith('/user/nandy/tree')
     assert r.status_code == 200
     
     # logout
-    r = requests.get(url_path_join(url, 'logout'), cookies=cookies)
+    r = yield async_requests.get(url_path_join(url, 'logout'), cookies=cookies)
     assert len(r.cookies) == 0
 
     # another user accessing should get 403, not redirect to login
-    cookies = app.login_user('burgess')
-    r = requests.get(url, cookies=cookies)
+    cookies = yield app.login_user('burgess')
+    r = yield async_requests.get(url, cookies=cookies)
     assert r.status_code == 403
     assert 'burgess' in r.text
 
 
-def test_disable_user_config(app, io_loop):
+@pytest.mark.gen_test
+def test_disable_user_config(app):
     # use StubSingleUserSpawner to launch a single-user app in a thread
     app.spawner_class = StubSingleUserSpawner
     app.tornado_settings['spawner_class'] = StubSingleUserSpawner
     # login, start the server
-    cookies = app.login_user('nandy')
+    cookies = yield app.login_user('nandy')
     user = app.users['nandy']
     # stop spawner, if running:
     if user.running(''):
         print("stopping")
-        io_loop.run_sync(user.stop)
+        yield user.stop()
     # start with new config:
     user.spawner.debug = True
     user.spawner.disable_user_config = True
-    io_loop.run_sync(user.spawn)
-    io_loop.run_sync(lambda : app.proxy.add_user(user))
+    yield user.spawn()
+    yield app.proxy.add_user(user)
     
     url = public_url(app, user)
     
     # with cookies, login successful
-    r = requests.get(url, cookies=cookies)
+    r = yield async_requests.get(url, cookies=cookies)
     r.raise_for_status()
     assert r.url.rstrip('/').endswith('/user/nandy/tree')
     assert r.status_code == 200

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -13,7 +13,6 @@ import time
 from unittest import mock
 
 import pytest
-import requests
 from tornado import gen
 
 from ..user import User
@@ -21,6 +20,7 @@ from ..objects import Hub
 from .. import spawner as spawnermod
 from ..spawner import LocalProcessSpawner
 from .. import orm
+from .utils import async_requests
 
 _echo_sleep = """
 import sys, time
@@ -239,7 +239,7 @@ def test_shell_cmd(db, tmpdir, request):
     s.server.port = port
     db.commit()
     yield wait_for_spawner(s)
-    r = requests.get('http://%s:%i/env' % (ip, port))
+    r = yield async_requests.get('http://%s:%i/env' % (ip, port))
     r.raise_for_status()
     env = r.json()
     assert env['TESTVAR'] == 'foo'

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -1,0 +1,18 @@
+from concurrent.futures import ThreadPoolExecutor
+import requests
+
+class _AsyncRequests:
+    """Wrapper around requests to return a Future from request methods
+    
+    A single thread is allocated to avoid blocking the IOLoop thread.
+    """
+    def __init__(self):
+        self.executor = ThreadPoolExecutor(1)
+
+    def __getattr__(self, name):
+        requests_method = getattr(requests, name)
+        return lambda *args, **kwargs: self.executor.submit(requests_method, *args, **kwargs)
+
+# async_requests.get = requests.get returning a Future, etc.
+async_requests = _AsyncRequests()
+

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -98,27 +98,7 @@ class User(HasTraits):
         if self.orm_user:
             return inspect(self.orm_user).session
 
-    @observe('db')
-    def _db_changed(self, change):
-        """Changing db session reacquires ORM User object"""
-        # db session changed, re-get orm User
-        db = change.new
-        if self._user_id is not None:
-            # fetch our orm.User from the new db session
-            self.orm_user = db.query(orm.User).filter(orm.User.id == self._user_id).first()
-        # update our spawners' ORM objects with the new session,
-        # which can be found on our new orm_user.
-        for name, spawner in self.spawners.items():
-            spawner.orm_spawner = self.orm_user.orm_spawners[name]
-
-    _user_id = None
     orm_user = Any(allow_none=True)
-    @observe('orm_user')
-    def _orm_user_changed(self, change):
-        if change.new:
-            self._user_id = change.new.id
-        else:
-            self._user_id = None
 
     @property
     def authenticator(self):


### PR DESCRIPTION
Thanks to @willingc for finding pytest-tornado, we can run tests in the application thread.

To avoid blocking the IOLoop, instead of trading requests for tornado's AsyncHTTPClient, I added `utils.requests_async`, which just plops the request in a ThreadPoolExecutor. It's still a thread, but the important thing is that test code isn't run in a thread (no concurrent connections to the database). Only actual requests run in threads, which should be fine.

This should hopefully eliminate at least a few of the intermittent failures we have been seeing.

TODO:

- [x] remove some remaining run_sync tests in favor of `@gen_test`
- [x] remove some of the actual application code added to handle the test thread