### PR TITLE
Allow Hub to listen on a unix-socket

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -18,6 +18,7 @@ import sys
 from textwrap import dedent
 from urllib.parse import urlparse
 
+
 if sys.version_info[:2] < (3, 3):
     raise ValueError("Python < 3.3 not supported: %s" % sys.version)
 
@@ -32,6 +33,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.log import app_log, access_log, gen_log
 import tornado.options
 from tornado import gen, web
+from tornado.netutil import bind_unix_socket
 
 from traitlets import (
     Unicode, Integer, Dict, TraitError, List, Bool, Any,
@@ -397,6 +399,13 @@ class JupyterHub(Application):
         help="""The ip address for the Hub process to *bind* to.
 
         See `hub_connect_ip` for cases where the bind and connect address should differ.
+        """
+    ).tag(config=True)
+
+    hub_socket = Unicode('',
+        help="""Set the tornado application to listen on a unix socket.
+
+        If set, take precedence over the `hub_port` and `hub_ip` settings.
         """
     ).tag(config=True)
 
@@ -1435,12 +1444,16 @@ class JupyterHub(Application):
         # start the webserver
         self.http_server = tornado.httpserver.HTTPServer(self.tornado_application, xheaders=True)
         try:
-            self.http_server.listen(self.hub_port, address=self.hub_ip)
+            if self.hub_socket:
+                socket = bind_unix_socket(self.hub_socket)
+                self.http_server.add_socket(socket)
+                self.log.info("Hub API listening on %s", self.hub_socket)
+            else:
+                self.http_server.listen(self.hub_port, address=self.hub_ip)
+                self.log.info("Hub API listening on %s", self.hub.bind_url)
         except Exception:
             self.log.error("Failed to bind hub to %s", self.hub.bind_url)
             raise
-        else:
-            self.log.info("Hub API listening on %s", self.hub.bind_url)
 
         # start the proxy
         if self.proxy.should_start:


### PR DESCRIPTION
Add the hub_socket option to the JupyterHub class, which takes
precedence over the hub_ip and hub_port setting. It does not forward
this setting to the Hub class though, and a few log messages still say
the hub is listening on `http://:8000` that works fine when testing with
netcat:

```
$ nc -U /tmp/jhub.sock
GET /login HTTP/1.1

HTTP/1.1 302 Found
Server: TornadoServer/4.5.1
Content-Type: text/html; charset=UTF-8
Date: Fri, 28 Jul 2017 02:05:36 GMT
X-Jupyterhub-Version: 0.8.0.dev
Content-Security-Policy: frame-ancestors 'self'; report-uri /hub/security/csp-report
Location: /hub/login
Content-Length: 0
```

Closes #1283

Should still be better documented I guess.