### PR TITLE
Default port is 8081 not 8080

### DIFF
--- a/docs/source/networking-basics.md
+++ b/docs/source/networking-basics.md
@@ -66,7 +66,7 @@ settings, `proxy_api_ip` and `proxy_api_port`.
 
 ## Configure the Hub if the Proxy or Spawners are remote or isolated
 
-The Hub service listens only on `localhost` (port 8080) by default.
+The Hub service listens only on `localhost` (port 8081) by default.
 The Hub needs to be accessible from both the proxy and all Spawners.
 When spawning local servers, an IP address setting of `localhost` is fine.
 


### PR DESCRIPTION
As far as I can tell from [this line](https://github.com/Carreau/jupyterhub/blob/8f88fae530671564fb2caeb7edce4f2fd5d5dad6/jupyterhub/app.py#L393) and what I observed.