### PR TITLE
Add support for limiting the number of concurrent spawns

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -545,16 +545,14 @@ class JupyterHub(Application):
     ).tag(config=True)
 
     concurrent_spawn_limit = Integer(
-        None,
-        allow_none=True,
+        0,
         help="""
         Maximum number of concurrent users that can be spawning at a time.
 
-        If more than this many users attempt to spawn at a time, they
-        enter an exponential delay with a timeout.
+        If more than this many users attempt to spawn at a time, their
+        request is rejected with a 429 error asking them to try again.
 
-        If set to `None`, no concurrent limit is enforced. If set to 0,
-        then no spawning is allowed.
+        If set to 0, no concurrent_spawn_limit is enforced.
         """
     ).tag(config=True)
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -369,15 +369,13 @@ class BaseHandler(RequestHandler):
 
         if self.settings['concurrent_spawn_limit'] is not None and \
            self.hub.pending_spawns > self.settings['concurrent_spawn_limit']:
-            # This will throw an error if we hit our timeout
             self.log.info(
                 'More than %s pending spawns, throttling',
                 self.settings['concurrent_spawn_limit']
             )
-            yield exponential_backoff(
-                lambda: self.hub.pending_spawns < self.settings['concurrent_spawn_limit'],
-                'Too many users are starting right now, try again later',
-            )
+            raise web.HTTPError(
+                429,
+                "Too many users are starting now, try again shortly")
 
         self.hub.pending_spawns += 1
         tic = IOLoop.current().time()

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -149,15 +149,6 @@ class Hub(Server):
 
     cookie_name = 'jupyter-hub-token'
 
-    spawn_pending_count = Integer(
-        0,
-        help="""
-        Number of users currently attempting to spawn.
-
-        Tracked by BaseHandler.spawn_single_user. It's in the Hub object
-        since this needs a central place for it to be kept track of.
-        """
-    )
     @property
     def server(self):
         warnings.warn("Hub.server is deprecated in JupyterHub 0.8. Access attributes on the Hub directly.",

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -149,6 +149,15 @@ class Hub(Server):
 
     cookie_name = 'jupyter-hub-token'
 
+    pending_spawns = Integer(
+        0,
+        help="""
+        Number of users currently attempting to spawn.
+
+        Tracked by BaseHandler.spawn_single_user. It's in the Hub object
+        since this needs a central place for it to be kept track of.
+        """
+    )
     @property
     def server(self):
         warnings.warn("Hub.server is deprecated in JupyterHub 0.8. Access attributes on the Hub directly.",

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -149,7 +149,7 @@ class Hub(Server):
 
     cookie_name = 'jupyter-hub-token'
 
-    pending_spawns = Integer(
+    spawn_pending_count = Integer(
         0,
         help="""
         Number of users currently attempting to spawn.


### PR DESCRIPTION
This lets admin throttle maximum number of concurrent pending spawns.

It'll fail them early, which lets us maintain a consistent level of service for the users we 
can service. Users can try again soon!