### PR TITLE
always include and check alembic revision

### DIFF
--- a/jupyterhub/alembic.ini
+++ b/jupyterhub/alembic.ini
@@ -62,5 +62,6 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S
+class = jupyterhub.log.CoroutineLogFormatter
+format = %(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s
+datefmt = %Y-%m-%d %H:%M:%S

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -185,6 +185,7 @@ class UpgradeDB(Application):
     def start(self):
         hub = JupyterHub(parent=self)
         hub.load_config_file(hub.config_file)
+        self.log = hub.log
         if (hub.db_url.startswith('sqlite:///')):
             db_file = hub.db_url.split(':///', 1)[1]
             self._backup_db_file(db_file)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -862,6 +862,8 @@ class JupyterHub(Application):
                 "to upgrade your JupyterHub database schema",
             ]))
             self.exit(1)
+        except orm.DatabaseSchemaMismatch as e:
+            self.exit(e)
 
     def init_hub(self):
         """Load the Hub config into the database"""

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -2,8 +2,6 @@ from glob import glob
 import os
 import shutil
 
-from sqlalchemy.exc import OperationalError
-
 import pytest
 from pytest import raises
 
@@ -32,7 +30,7 @@ def test_upgrade_entrypoint(tmpdir):
     tmpdir.chdir()
     tokenapp = NewToken()
     tokenapp.initialize(['kaylee'])
-    with raises(OperationalError):
+    with raises(SystemExit):
         tokenapp.start()
 
     sqlite_files = glob(os.path.join(str(tmpdir), 'jupyterhub.sqlite*'))


### PR DESCRIPTION
check database revision on launch

Fail with informative error if version mismatches, pointing to `upgrade-db`

Since we weren't always tagging before, we have to handle no tag being present:

- database empty (use latest because we are about to create everything
anew)
- if 'spawners' is present, assume 0.8.dev
- if 'services' is present, assume 0.7.x
- else: assume base revision when we started tracking revisions

closes #1162