### PR TITLE
prevent saving auth_state if auth_state is not enabled.

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -334,6 +334,9 @@ class BaseHandler(RequestHandler):
             # always set auth_state and commit,
             # because there could be key-rotation or clearing of previous values
             # going on.
+            if not self.authenticator.enable_auth_state:
+                # auth_state is not enabled. Force None.
+                auth_state = None
             yield user.save_auth_state(auth_state)
             self.db.commit()
             self.set_login_cookie(user)

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -178,6 +178,7 @@ def auth_state_enabled(app):
     app.authenticator.auth_state = {
         'who': 'cares',
     }
+    app.authenticator.enable_auth_state = True
     ck = crypto.CryptKeeper.instance()
     before_keys = ck.keys
     ck.keys = [os.urandom(32)]
@@ -185,6 +186,7 @@ def auth_state_enabled(app):
         yield
     finally:
         ck.keys = before_keys
+        app.authenticator.enable_auth_state = False
         app.authenticator.auth_state = None
 
 
@@ -200,22 +202,13 @@ def test_auth_state(app, auth_state_enabled):
 
 
 @pytest.fixture
-def auth_state_unavailable(app):
+def auth_state_unavailable(auth_state_enabled):
     """auth_state enabled at the Authenticator level,
     
     but unavailable due to no crypto keys.
     """
-    app.authenticator.auth_state = {
-        'who': 'cares',
-    }
-    ck = crypto.CryptKeeper.instance()
-    before_keys = ck.keys
-    ck.keys = []
-    try:
-        yield
-    finally:
-        ck.keys = before_keys
-        app.authenticator.auth_state = None
+    crypto.CryptKeeper.instance().keys = []
+    yield
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
allows Authenticators to always return auth_state without having to check enable_auth_state themselves.

Came up in https://github.com/jupyterhub/oauthenticator/pull/97#issuecomment-319304667