### PR TITLE
[WIP] Default pre_spawn_start loads env from auth_state.env if defined

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -269,11 +269,23 @@ class Authenticator(LoggingConfigurable):
                 of auth state that will be persisted.
         """
 
+    @gen.coroutine
     def pre_spawn_start(self, user, spawner):
         """Hook called before spawning a user's server
 
-        Can be used to do auth-related startup, e.g. opening PAM sessions.
+        Can be used to do auth-related startup, e.g. opening PAM sessions
+        or specifying auth-related environment variables.
+
+        Default: load environment variables from auth_state.env
+        if auth_state is enabled and auth_state.env is defined.
         """
+        if not self.enable_auth_state:
+            return
+        auth_state = yield user.get_auth_state()
+        if not auth_state:
+            return
+        if 'env' in auth_state:
+            spawner.environment.update(auth_state['env'])
 
     def post_spawn_stop(self, user, spawner):
         """Hook called after stopping a user container
@@ -560,8 +572,11 @@ class PAMAuthenticator(LocalAuthenticator):
         else:
             return username
 
+    @gen.coroutine
     def pre_spawn_start(self, user, spawner):
         """Open PAM session for user if so configured"""
+        yield super().pre_spawn_start(user, spawner)
+
         if not self.open_sessions:
             return
         try:

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -131,9 +131,12 @@ class MockPAMAuthenticator(PAMAuthenticator):
         if username is None:
             return
         if self.auth_state:
+            state = {}
+            state.update(self.auth_state)
+            state['env'] = {'AUTH_NAME': username}
             return {
                 'name': username,
-                'auth_state': self.auth_state,
+                'auth_state': state,
             }
         else:
             return username

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -198,7 +198,10 @@ def test_auth_state(app, auth_state_enabled):
     assert user.encrypted_auth_state is None
     cookies = yield app.login_user(name)
     auth_state = yield user.get_auth_state()
+    assert auth_state is not None
+    auth_env = auth_state.pop('env')
     assert auth_state == app.authenticator.auth_state
+    assert user.spawner.environment == auth_env
 
 
 @pytest.fixture


### PR DESCRIPTION
Authenticators that return auth_state with `env` defined will automatically set environment for the Spawner.