### PR TITLE
add active_server_limit

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -552,10 +552,35 @@ class JupyterHub(Application):
         help="""
         Maximum number of concurrent users that can be spawning at a time.
 
-        If more than this many users attempt to spawn at a time, their
-        request is rejected with a 429 error asking them to try again.
+        Spawning lots of servers at the same time can cause performance
+        problems for the Hub or the underlying spawning system.
+        Set this limit to prevent bursts of logins from attempting
+        to spawn too many servers at the same time.
 
-        If set to 0, no concurrent_spawn_limit is enforced.
+        This does not limit the number of total running servers.
+        See concurrent_user_limit for that.
+
+        If more than this many users attempt to spawn at a time, their
+        requests will be rejected with a 429 error asking them to try again.
+        Users will have to wait for some of the spawning services
+        to finish starting before they can start their own.
+
+        If set to 0, no limit is enforced.
+        """
+    ).tag(config=True)
+
+    concurrent_user_limit = Integer(
+        0,
+        help="""
+        Maximum number of concurrent users that can be active at a time.
+
+        This can limit the total resources your users can consume.
+
+        If this many user servers are active, users will not be able to
+        launch new servers until a server is shutdown.
+        Spawn requests will be rejected with a 429 error asking them to try again.
+
+        If set to 0, no limit is enforced.
         """
     ).tag(config=True)
 
@@ -1270,6 +1295,7 @@ class JupyterHub(Application):
             allow_named_servers=self.allow_named_servers,
             oauth_provider=self.oauth_provider,
             concurrent_spawn_limit=self.concurrent_spawn_limit,
+            concurrent_user_limit=self.concurrent_user_limit,
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -558,7 +558,7 @@ class JupyterHub(Application):
         to spawn too many servers at the same time.
 
         This does not limit the number of total running servers.
-        See concurrent_user_limit for that.
+        See active_server_limit for that.
 
         If more than this many users attempt to spawn at a time, their
         requests will be rejected with a 429 error asking them to try again.
@@ -569,12 +569,16 @@ class JupyterHub(Application):
         """
     ).tag(config=True)
 
-    concurrent_user_limit = Integer(
+    active_server_limit = Integer(
         0,
         help="""
-        Maximum number of concurrent users that can be active at a time.
+        Maximum number of concurrent servers that can be active at a time.
 
-        This can limit the total resources your users can consume.
+        Setting this can limit the total resources your users can consume.
+
+        An active server is any server that's not fully stopped.
+        It is considered active from the time it has been requested
+        until the time that it has completely stopped.
 
         If this many user servers are active, users will not be able to
         launch new servers until a server is shutdown.
@@ -1295,7 +1299,7 @@ class JupyterHub(Application):
             allow_named_servers=self.allow_named_servers,
             oauth_provider=self.oauth_provider,
             concurrent_spawn_limit=self.concurrent_spawn_limit,
-            concurrent_user_limit=self.concurrent_user_limit,
+            active_server_limit=self.active_server_limit,
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -373,7 +373,7 @@ class BaseHandler(RequestHandler):
 
     @gen.coroutine
     def spawn_single_user(self, user, server_name='', options=None):
-        if server_name in user.spawners and user.spawners[server_name].pending:
+        if server_name in user.spawners and user.spawners[server_name].pending == 'spawn':
             raise RuntimeError("Spawn already pending for: %s" % user.name)
 
         # count active servers and pending spawns

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -368,27 +368,41 @@ class BaseHandler(RequestHandler):
         return self.settings.get('concurrent_spawn_limit', 0)
 
     @property
-    def spawn_pending_count(self):
-        return self.settings.setdefault('_spawn_pending_count', 0)
-
-    @spawn_pending_count.setter
-    def spawn_pending_count(self, value):
-        self.settings['_spawn_pending_count'] = value
+    def concurrent_user_limit(self):
+        return self.settings.get('concurrent_user_limit', 0)
 
     @gen.coroutine
     def spawn_single_user(self, user, server_name='', options=None):
-        if server_name in user.spawners and user.spawners[server_name]._spawn_pending:
+        if server_name in user.spawners and user.spawners[server_name].pending:
             raise RuntimeError("Spawn already pending for: %s" % user.name)
 
+        # count active users and pending spawns
+        # we could do careful bookkeeping to avoid
+        # but for 10k users this takes ~5ms
+        # and saves us from bookkeeping errors
+        active_counts = self.users.count_active_users()
+        spawn_pending_count = active_counts['spawn_pending'] + active_counts['proxy_pending']
+        active_count = active_counts['active']
+
         concurrent_spawn_limit = self.concurrent_spawn_limit
-        if concurrent_spawn_limit and self.spawn_pending_count >= concurrent_spawn_limit:
+        concurrent_user_limit = self.concurrent_user_limit
+
+        if concurrent_spawn_limit and spawn_pending_count >= concurrent_spawn_limit:
                 self.log.info(
                     '%s pending spawns, throttling',
-                    concurrent_spawn_limit,
+                    spawn_pending_count,
                 )
                 raise web.HTTPError(
                     429,
-                    "User startup rate limit exceeded. Try to start again in a few minutes.")
+                    "User startup rate limit exceeded. Try again in a few minutes.")
+        if concurrent_user_limit and active_count >= concurrent_user_limit:
+                self.log.info(
+                    '%s servers active, no space available',
+                    active_count,
+                )
+                raise web.HTTPError(
+                    429,
+                    "Active user limit exceeded. Try again in a few minutes.")
 
         tic = IOLoop.current().time()
         user_server_name = user.name
@@ -401,15 +415,14 @@ class BaseHandler(RequestHandler):
 
         f = user.spawn(server_name, options)
 
-        # increment spawn_pending only after spawn starts
         self.log.debug("%i%s concurrent spawns",
-            self.spawn_pending_count,
+            spawn_pending_count,
             '/%i' % concurrent_spawn_limit if concurrent_spawn_limit else '')
-        # FIXME: Move this out of settings, since this isn't really a setting
-        self.spawn_pending_count += 1
+        self.log.debug("%i%s active users",
+            active_count,
+            '/%i' % concurrent_user_limit if concurrent_user_limit else '')
 
         spawner = user.spawners[server_name]
-        spawner._proxy_pending = True
 
         @gen.coroutine
         def finish_user_spawn(f=None):
@@ -420,12 +433,12 @@ class BaseHandler(RequestHandler):
             """
             if f and f.exception() is not None:
                 # failed, don't add to the proxy
-                self.spawn_pending_count -= 1
                 return
             toc = IOLoop.current().time()
             self.log.info("User %s took %.3f seconds to start", user_server_name, toc-tic)
             self.statsd.timing('spawner.success', (toc - tic) * 1000)
             try:
+                spawner._proxy_pending = True
                 yield self.proxy.add_user(user, server_name)
             except Exception:
                 self.log.exception("Failed to add %s to proxy!", user_server_name)
@@ -435,7 +448,6 @@ class BaseHandler(RequestHandler):
                 spawner.add_poll_callback(self.user_stopped, user)
             finally:
                 spawner._proxy_pending = False
-                self.spawn_pending_count -= 1
 
         try:
             yield gen.with_timeout(timedelta(seconds=self.slow_spawn_timeout), f)
@@ -462,14 +474,9 @@ class BaseHandler(RequestHandler):
                     # schedule finish for when the user finishes spawning
                     IOLoop.current().add_future(f, finish_user_spawn)
                 else:
-                    self.spawn_pending_count -= 1
                     toc = IOLoop.current().time()
                     self.statsd.timing('spawner.failure', (toc - tic) * 1000)
                     raise web.HTTPError(500, "Spawner failed to start [status=%s]" % status)
-        except Exception:
-            # error in start
-            self.spawn_pending_count -= 1
-            raise
         else:
             yield finish_user_spawn()
 

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -63,6 +63,11 @@ class Server(HasTraits):
         return self.port
 
     @classmethod
+    def from_orm(cls, orm_server):
+        """Create a server from an orm.Server"""
+        return cls(orm_server=orm_server)
+
+    @classmethod
     def from_url(cls, url):
         """Create a Server from a given URL"""
         urlinfo = urlparse(url)

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -235,7 +235,7 @@ class Service(LoggingConfigurable):
     @property
     def server(self):
         if self.orm.server:
-            return Server(orm_server=self.orm.server)
+            return Server.from_orm(self.orm.server)
         else:
             return None
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -59,10 +59,8 @@ class Spawner(LoggingConfigurable):
 
         Return False if nothing is pending.
         """
-        if self._spawn_pending:
+        if self._spawn_pending or self._proxy_pending:
             return 'spawn'
-        elif self._proxy_pending:
-            return 'proxy'
         elif self._stop_pending:
             return 'stop'
         return False

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -51,6 +51,41 @@ class Spawner(LoggingConfigurable):
     _proxy_pending = False
     _waiting_for_response = False
 
+    @property
+    def pending(self):
+        """Return the current pending event, if any
+
+        Return False if nothing is pending.
+        """
+        if self._spawn_pending:
+            return 'spawn'
+        elif self._proxy_pending:
+            return 'proxy'
+        elif self._stop_pending:
+            return 'stop'
+        return False
+
+    @property
+    def ready(self):
+        """Is this server ready to use?
+
+        A server is not ready if an event is pending.
+        """
+        if self.pending:
+            return False
+        if self.server is None:
+            return False
+        return True
+
+    @property
+    def active(self):
+        """Return True if the server is active.
+
+        This includes fully running and ready or any pending start/stop event.
+        """
+        return bool(self.pending or self.ready)
+
+
     authenticator = Any()
     hub = Any()
     orm_spawner = Any()

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -16,7 +16,7 @@ import pytest
 from tornado import gen
 
 from ..user import User
-from ..objects import Hub
+from ..objects import Hub, Server
 from .. import spawner as spawnermod
 from ..spawner import LocalProcessSpawner, Spawner
 from .. import orm
@@ -234,7 +234,10 @@ def test_shell_cmd(db, tmpdir, request):
         cmd=[sys.executable, '-m', 'jupyterhub.tests.mocksu'],
         shell_cmd=['bash', '--rcfile', str(f), '-i', '-c'],
     )
-    s.orm_spawner.server = orm.Server()
+    server = orm.Server()
+    db.add(server)
+    db.commit()
+    s.server = Server.from_orm(server)
     db.commit()
     (ip, port) = yield s.start()
     request.addfinalizer(s.stop)


### PR DESCRIPTION
This is the total user limit, which deployments like tmpnb will want to set to limit resource usage. If hit, throws the same 429 error as concurrent_spawn_limit.

For managing this, I also added properties on Spawner for the various active/ready/pending states so they are easier to check. I used these properties to implement a `users.count_active_users` method for collecting and reporting totals of the various active/pending counts, which is used for limit enforcement rather than adding more running bookkeeping, which I think is brittle with many different avenues for spawn failure. I verified that computing this value takes only a few milliseconds for 5k users (db is never touched), so I think it's okay.

closes #1282
