### PR TITLE
restore user.running property

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -100,7 +100,7 @@ class APIHandler(BaseHandler):
             'name': user.name,
             'admin': user.admin,
             'groups': [ g.name for g in user.groups ],
-            'server': user.url if user.running('') else None,
+            'server': user.url if user.running else None,
             'pending': None,
             'last_activity': user.last_activity.isoformat(),
         }
@@ -112,7 +112,7 @@ class APIHandler(BaseHandler):
         if self.allow_named_servers:
             servers = model['servers'] = {}
             for name, spawner in user.spawners.items():
-                if user.running(name):
+                if spawner.ready:
                     servers[name] = s = {'name': name}
                     if spawner._spawn_pending:
                         s['pending'] = 'spawn'

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -314,7 +314,7 @@ class BaseHandler(RequestHandler):
         if not next_url.startswith('/'):
             next_url = ''
         if not next_url:
-            if user and user.running(''):
+            if user and user.running:
                 next_url = user.url
             else:
                 next_url = self.hub.base_url

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -45,7 +45,7 @@ class RootHandler(BaseHandler):
             return
         user = self.get_current_user()
         if user:
-            if user.running(''):
+            if user.running:
                 url = user.url
                 self.log.debug("User is running: %s", url)
                 self.set_login_cookie(user) # set cookie
@@ -64,7 +64,7 @@ class HomeHandler(BaseHandler):
     @gen.coroutine
     def get(self):
         user = self.get_current_user()
-        if user.running(''):
+        if user.running:
             # trigger poll_and_notify event in case of a server that died
             yield user.spawner.poll_and_notify()
         html = self.render_template('home.html',
@@ -94,7 +94,7 @@ class SpawnHandler(BaseHandler):
     def get(self):
         """GET renders form for spawning with user-specified options"""
         user = self.get_current_user()
-        if not self.allow_named_servers and user.running(''):
+        if not self.allow_named_servers and user.running:
             url = user.url
             self.log.debug("User is running: %s", url)
             self.redirect(url)
@@ -110,7 +110,7 @@ class SpawnHandler(BaseHandler):
     def post(self):
         """POST spawns with user-specified options"""
         user = self.get_current_user()
-        if not self.allow_named_servers and user.running(''):
+        if not self.allow_named_servers and user.running:
             url = user.url
             self.log.warning("User is already running: %s", url)
             self.redirect(url)
@@ -182,7 +182,7 @@ class AdminHandler(BaseHandler):
 
         users = self.db.query(orm.User).order_by(*ordered)
         users = [ self._user_from_orm(u) for u in users ]
-        running = [ u for u in users if u.running('') ]
+        running = [ u for u in users if u.running ]
 
         html = self.render_template('admin.html',
             user=self.get_current_user(),

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -110,6 +110,8 @@ class Spawner(LoggingConfigurable):
         if missing:
             raise NotImplementedError("class `{}` needs to redefine the `start`,"
                   "`stop` and `poll` methods. `{}` not redefined.".format(cls.__name__, '`, `'.join(missing)))
+    
+    proxy_spec = Unicode()
 
     @property
     def server(self):
@@ -117,7 +119,7 @@ class Spawner(LoggingConfigurable):
             return self._server
         if self.orm_spawner and self.orm_spawner.server:
             return Server(orm_server=self.orm_spawner.server)
-    
+
     @server.setter
     def server(self, server):
         self._server = server

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -61,16 +61,21 @@ class MockSpawner(LocalProcessSpawner):
 
 class SlowSpawner(MockSpawner):
     """A spawner that takes a few seconds to start"""
-    
+
+    delay = 2
+    _start_future = None
     @gen.coroutine
     def start(self):
         (ip, port) = yield super().start()
-        yield gen.sleep(2)
+        if self._start_future is not None:
+            yield self._start_future
+        else:
+            yield gen.sleep(self.delay)
         return ip, port
-    
+
     @gen.coroutine
     def stop(self):
-        yield gen.sleep(2)
+        yield gen.sleep(self.delay)
         yield super().stop()
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -461,7 +461,7 @@ def test_slow_spawn(app, no_patience, slow_spawn):
 
     @gen.coroutine
     def wait_spawn():
-        while not app_user.running(''):
+        while not app_user.running:
             yield gen.sleep(0.1)
 
     yield wait_spawn()
@@ -538,7 +538,7 @@ def test_slow_bad_spawn(app, no_patience, slow_bad_spawn):
     while user.spawner.pending:
         yield gen.sleep(0.1)
     # spawn failed
-    assert not user.running('')
+    assert not user.running
     assert app.users.count_active_users()['pending'] == 0
 
 
@@ -566,7 +566,7 @@ def test_spawn_limit(app, no_patience, slow_spawn, request):
     assert r.status_code == 429
 
     # wait for ykka to finish
-    while not users[0].running(''):
+    while not users[0].running:
         yield gen.sleep(0.1)
 
     # race? hjarka could finish in this time
@@ -576,7 +576,7 @@ def test_spawn_limit(app, no_patience, slow_spawn, request):
     r.raise_for_status()
     assert app.users.count_active_users()['pending'] == 2
     users.append(user)
-    while not all(u.running('') for u in users):
+    while not all(u.running for u in users):
         yield gen.sleep(0.1)
 
     # everybody's running, pending count should be back to 0

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -161,7 +161,7 @@ def test_spawn_fails(db):
     with pytest.raises(RuntimeError) as exc:
         yield user.spawn()
     assert user.spawners[''].server is None
-    assert not user.running('')
+    assert not user.running
 
 
 def test_groups(db):

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -158,20 +158,20 @@ def test_check_routes(app,  username, endpoints):
     test_user = app.users[username]
     routes = yield app.proxy.get_all_routes()
     before = sorted(routes)
-    assert test_user.proxy_spec() in before
+    assert test_user.proxy_spec in before
 
     # check if a route is removed when user deleted
     yield app.proxy.check_routes(app.users, app._service_map)
     yield proxy.delete_user(test_user)
     routes = yield app.proxy.get_all_routes()
     during = sorted(routes)
-    assert test_user.proxy_spec() not in during
+    assert test_user.proxy_spec not in during
 
     # check if a route exists for user
     yield app.proxy.check_routes(app.users, app._service_map)
     routes = yield app.proxy.get_all_routes()
     after = sorted(routes)
-    assert test_user.proxy_spec() in after
+    assert test_user.proxy_spec in after
 
     # check that before and after state are the same
     assert before == after

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -21,7 +21,7 @@ def test_singleuser_auth(app):
     # login, start the server
     cookies = yield app.login_user('nandy')
     user = app.users['nandy']
-    if not user.running(''):
+    if not user.running:
         yield user.spawn()
     url = public_url(app, user)
     
@@ -56,7 +56,7 @@ def test_disable_user_config(app):
     cookies = yield app.login_user('nandy')
     user = app.users['nandy']
     # stop spawner, if running:
-    if user.running(''):
+    if user.running:
         print("stopping")
         yield user.stop()
     # start with new config:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -4,6 +4,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 from urllib.parse import quote, urlparse
+import warnings
 
 from oauth2.error import ClientNotFoundError
 from sqlalchemy import inspect
@@ -241,6 +242,20 @@ class User(HasTraits):
     def active(self):
         """True if any server is active"""
         return any(s.active for s in self.spawners.values())
+
+    @property
+    def spawn_pending(self):
+        warnings.warn("User.spawn_pending is deprecated in JupyterHub 0.8. Use Spawner.pending",
+            DeprecationWarning,
+        )
+        return self.spawner.pending == 'spawn'
+
+    @property
+    def stop_pending(self):
+        warnings.warn("User.stop_pending is deprecated in JupyterHub 0.8. Use Spawner.pending",
+            DeprecationWarning,
+        )
+        return self.spawner.pending == 'stop'
 
     @property
     def server(self):

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -44,12 +44,12 @@
       <td class="admin-col col-sm-2">{% if u.admin %}admin{% endif %}</td>
       <td class="time-col col-sm-3">{{u.last_activity.isoformat() + 'Z'}}</td>
       <td class="server-col col-sm-2 text-center">
-        <span class="stop-server btn btn-xs btn-danger {% if not u.running('') %}hidden{% endif %}">stop server</span>
-        <span class="start-server btn btn-xs btn-success {% if u.running('') %}hidden{% endif %}">start server</span>
+        <span class="stop-server btn btn-xs btn-danger {% if not u.running %}hidden{% endif %}">stop server</span>
+        <span class="start-server btn btn-xs btn-success {% if u.running %}hidden{% endif %}">start server</span>
       </td>
       <td class="server-col col-sm-1 text-center">
         {% if admin_access %}
-        <span class="access-server btn btn-xs btn-success {% if not u.running('') %}hidden{% endif %}">access server</span>
+        <span class="access-server btn btn-xs btn-success {% if not u.running %}hidden{% endif %}">access server</span>
         {% endif %}
       </td>
       <td class="edit-col col-sm-1 text-center">

--- a/share/jupyter/hub/templates/home.html
+++ b/share/jupyter/hub/templates/home.html
@@ -5,11 +5,11 @@
 <div class="container">
   <div class="row">
     <div class="text-center">
-      {% if user.running('') %}
+      {% if user.running %}
       <a id="stop" class="btn btn-lg btn-danger">Stop My Server</a>
       {% endif %}
       <a id="start" class="btn btn-lg btn-success" href="{{ url }}">
-      {% if not user.running('') %}
+      {% if not user.running %}
       Start
       {% endif %}
         My Server


### PR DESCRIPTION
Restores `user.running` as an alias for `user.spawner.ready` (new Spawner property).

`user.running` was made a method recently for handing named_servers, but that made things way more complicated and replaced a boolean flag with a callable, which would behave unexpectedly but without error if any code was still expecting a boolean flag (since methods are truthy).

Spawners have properties for dealing with this now, so use spawners as much as possible.