### PR TITLE
handle OAuthAccessTokens with no user

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -26,6 +26,11 @@ class TokenAPIHandler(APIHandler):
             model = self.user_model(self.users[orm_token.user])
         elif orm_token.service:
             model = self.service_model(orm_token.service)
+        else:
+            self.log.warning("%s has no user or service. Deleting..." % orm_token)
+            self.db.delete(orm_token)
+            self.db.commit()
+            raise web.HTTPError(404)
         self.write(json.dumps(model))
 
     @gen.coroutine

--- a/jupyterhub/oauth/store.py
+++ b/jupyterhub/oauth/store.py
@@ -74,7 +74,10 @@ class AccessTokenStore(HubDBMixin, oauth2.store.AccessTokenStore):
         """
         
         user = self.db.query(orm.User).filter(orm.User.id == access_token.user_id).first()
+        if user is None:
+            raise ValueError("No user for access token: %s" % access_token.user_id)
         orm_access_token = orm.OAuthAccessToken(
+            generated=True,
             client_id=access_token.client_id,
             grant_type=access_token.grant_type,
             expires_at=access_token.expires_at,

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -407,14 +407,14 @@ class OAuthAccessToken(Hashed, Base):
     client_id = Column(Unicode(1023))
     grant_type = Column(Enum(GrantType), nullable=False)
     expires_at = Column(Integer)
-    refresh_token = Column(Unicode(64))
+    refresh_token = Column(Unicode(1023))
     refresh_expires_at = Column(Integer)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
     user = relationship(User)
     service = None # for API-equivalence with APIToken
 
     # from Hashed
-    hashed = Column(Unicode(64))
+    hashed = Column(Unicode(1023))
     prefix = Column(Unicode(16), index=True)
     
     def __repr__(self):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -411,7 +411,7 @@ class OAuthAccessToken(Hashed, Base):
     refresh_expires_at = Column(Integer)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
     user = relationship(User)
-    session = None # for API-equivalence with APIToken
+    service = None # for API-equivalence with APIToken
 
     # from Hashed
     hashed = Column(Unicode(64))


### PR DESCRIPTION
This shouldn’t happen, raise on token creation if it does.

If a token API request is authenticated finds a token with no user or service, delete the token because it is invalid and return with 404 because it doesn’t correspond to an existing user.

This should fix the *error* in #1309, but not the underlying cause, which is an access token that appears to have been created without a user, which should be impossible.

Also fixes the token size, which closes #1255