### PR TITLE
update spawner.start docs

### DIFF
--- a/docs/source/spawners.md
+++ b/docs/source/spawners.md
@@ -36,8 +36,7 @@ Some examples include:
 Information about the user can be retrieved from `self.user`,
 an object encapsulating the user's name, authentication, and server info.
 
-When `Spawner.start` returns, it should have stored the IP and port
-of the single-user server in `self.user.server`.
+The return value of `Spawner.start` should be the (ip, port) of the running server.
 
 **NOTE:** When writing coroutines, *never* `yield` in between a database change and a commit.
 
@@ -45,10 +44,10 @@ Most `Spawner.start` functions will look similar to this example:
 
 ```python
 def start(self):
-    self.user.server.ip = 'localhost' # or other host or IP address, as seen by the Hub
-    self.user.server.port = 1234 # port selected somehow
-    self.db.commit() # always commit before yield, if modifying db values
+    self.ip = '127.0.0.1'
+    self.port = random_port()
     yield self._actually_start_server_somehow()
+    return (self.ip, self.port)
 ```
 
 When `Spawner.start` returns, the single-user server process should actually be running,


### PR DESCRIPTION
remove mention of self.user.server, which is deprecated in 0.7

closes https://github.com/jupyterhub/dockerspawner/issues/176