### PR TITLE
Test against postgres, mysql (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - npm install -g configurable-http-proxy
   - |
     if [[ $JUPYTERHUB_TEST_DB_URL == mysql* ]]; then
-      mysql -e 'CREATE DATABASE IF NOT EXISTS jupyterhub;'
+      mysql -e 'CREATE DATABASE jupyterhub CHARACTER SET utf8 COLLATE utf8_general_ci;'
       pip install 'mysql-connector<2.2'
     elif [[ $JUPYTERHUB_TEST_DB_URL == postgresql* ]]; then
       psql -c 'create database jupyterhub;' -U postgres
@@ -41,6 +41,6 @@ matrix:
     - python: 3.6
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
     - python: 3.6
-      env: JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://travis@127.0.0.1/jupyterhub
+      env: JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://root@127.0.0.1/jupyterhub
     - python: 3.6
       env: JUPYTERHUB_TEST_DB_URL=postgresql://postgres@127.0.0.1/jupyterhub

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,21 @@ python:
 env:
   global:
     - ASYNC_TEST_TIMEOUT=15
+services:
+  - mysql
+  - postgresql
 
 # installing dependencies
 before_install:
   - nvm install 6; nvm use 6
   - npm install
   - npm install -g configurable-http-proxy
+  - |
+    if [[ $JUPYTERHUB_TEST_DB_URL == mysql* ]]; then
+      mysql -e 'CREATE DATABASE IF NOT EXISTS jupyterhub;'
+    elif [[ $JUPYTERHUB_TEST_DB_URL == postgresql* ]]; then
+      psql -c 'create database jupyterhub;' -U postgres
+    fi
 install:
   - pip install -U pip
   - pip install --pre -r dev-requirements.txt .
@@ -29,3 +38,7 @@ matrix:
   include:
     - python: 3.6
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
+    - python: 3.6
+      env: JUPYTERHUB_TEST_DB_URL=mysql://travis@127.0.0.1/jupyterhub
+    - python: 3.6
+      env: JUPYTERHUB_TEST_DB_URL=postgresql://postgres@127.0.0.1/jupyterhub

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ before_install:
   - |
     if [[ $JUPYTERHUB_TEST_DB_URL == mysql* ]]; then
       mysql -e 'CREATE DATABASE IF NOT EXISTS jupyterhub;'
+      pip install 'mysql-connector<2.2'
     elif [[ $JUPYTERHUB_TEST_DB_URL == postgresql* ]]; then
       psql -c 'create database jupyterhub;' -U postgres
+      pip install psycopg2
     fi
 install:
   - pip install -U pip
@@ -39,6 +41,6 @@ matrix:
     - python: 3.6
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
     - python: 3.6
-      env: JUPYTERHUB_TEST_DB_URL=mysql://travis@127.0.0.1/jupyterhub
+      env: JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://travis@127.0.0.1/jupyterhub
     - python: 3.6
       env: JUPYTERHUB_TEST_DB_URL=postgresql://postgres@127.0.0.1/jupyterhub

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1402,9 +1402,9 @@ class JupyterHub(Application):
             self.log.info("Cleaning up single-user servers...")
             # request (async) process termination
             for uid, user in self.users.items():
-                user.db = self.db
-                if user.spawner is not None:
-                    futures.append(user.stop())
+                for name, spawner in user.spawners.items():
+                    if spawner.active:
+                        futures.append(user.stop(name))
         else:
             self.log.info("Leaving single-user servers running")
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1247,7 +1247,7 @@ class JupyterHub(Application):
     def init_oauth(self):
         base_url = self.hub.base_url
         self.oauth_provider = make_provider(
-            self.session_factory,
+            lambda : self.db,
             url_prefix=url_path_join(base_url, 'api/oauth2'),
             login_url=url_path_join(base_url, 'login')
         )

--- a/jupyterhub/oauth/store.py
+++ b/jupyterhub/oauth/store.py
@@ -52,14 +52,7 @@ class JupyterHubSiteAdapter(AuthorizationCodeGrantSiteAdapter):
 class HubDBMixin(object):
     """Mixin for connecting to the hub database"""
     def __init__(self, session_factory):
-        self.session_factory = session_factory
-        self._local = threading.local()
-
-    @property
-    def db(self):
-        if not hasattr(self._local, 'db'):
-            self._local.db = scoped_session(self.session_factory)()
-        return self._local.db
+        self.db = session_factory()
 
 
 class AccessTokenStore(HubDBMixin, oauth2.store.AccessTokenStore):
@@ -77,7 +70,6 @@ class AccessTokenStore(HubDBMixin, oauth2.store.AccessTokenStore):
         if user is None:
             raise ValueError("No user for access token: %s" % access_token.user_id)
         orm_access_token = orm.OAuthAccessToken(
-            generated=True,
             client_id=access_token.client_id,
             grant_type=access_token.grant_type,
             expires_at=access_token.expires_at,

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -87,7 +87,7 @@ class Group(Base):
     """User Groups"""
     __tablename__ = 'groups'
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(Unicode(1023), unique=True)
+    name = Column(Unicode(255), unique=True)
     users = relationship('User', secondary='user_group_map', back_populates='groups')
 
     def __repr__(self):
@@ -127,7 +127,7 @@ class User(Base):
     """
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(Unicode(1023), unique=True)
+    name = Column(Unicode(255), unique=True)
 
     _orm_spawners = relationship("Spawner", backref="user")
     @property
@@ -138,7 +138,7 @@ class User(Base):
     last_activity = Column(DateTime, default=datetime.utcnow)
 
     api_tokens = relationship("APIToken", backref="user")
-    cookie_id = Column(Unicode(1023), default=new_token, nullable=False, unique=True)
+    cookie_id = Column(Unicode(255), default=new_token, nullable=False, unique=True)
     # User.state is actually Spawner state
     # We will need to figure something else out if/when we have multiple spawners per user
     state = Column(JSONDict)
@@ -181,7 +181,7 @@ class Spawner(Base):
     server = relationship(Server)
 
     state = Column(JSONDict)
-    name = Column(Unicode(512))
+    name = Column(Unicode(255))
 
     last_activity = Column(DateTime, default=datetime.utcnow)
 
@@ -207,7 +207,7 @@ class Service(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
 
     # common user interface:
-    name = Column(Unicode(1023), unique=True)
+    name = Column(Unicode(255), unique=True)
     admin = Column(Boolean, default=False)
 
     api_tokens = relationship("APIToken", backref="service")
@@ -317,8 +317,8 @@ class APIToken(Hashed, Base):
         return Column(Integer, ForeignKey('services.id', ondelete="CASCADE"), nullable=True)
 
     id = Column(Integer, primary_key=True)
-    hashed = Column(Unicode(1023))
-    prefix = Column(Unicode(16))
+    hashed = Column(Unicode(255), unique=True)
+    prefix = Column(Unicode(16), index=True)
 
     def __repr__(self):
         if self.user is not None:
@@ -404,17 +404,17 @@ class OAuthAccessToken(Hashed, Base):
     __tablename__ = 'oauth_access_tokens'
     id = Column(Integer, primary_key=True, autoincrement=True)
 
-    client_id = Column(Unicode(1023))
+    client_id = Column(Unicode(255))
     grant_type = Column(Enum(GrantType), nullable=False)
     expires_at = Column(Integer)
-    refresh_token = Column(Unicode(1023))
+    refresh_token = Column(Unicode(255))
     refresh_expires_at = Column(Integer)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
     user = relationship(User)
     service = None # for API-equivalence with APIToken
 
     # from Hashed
-    hashed = Column(Unicode(1023))
+    hashed = Column(Unicode(255), unique=True)
     prefix = Column(Unicode(16), index=True)
     
     def __repr__(self):
@@ -428,7 +428,7 @@ class OAuthAccessToken(Hashed, Base):
 class OAuthCode(Base):
     __tablename__ = 'oauth_codes'
     id = Column(Integer, primary_key=True, autoincrement=True)
-    client_id = Column(Unicode(1023))
+    client_id = Column(Unicode(255))
     code = Column(Unicode(36))
     expires_at = Column(Integer)
     redirect_uri = Column(Unicode(1023))
@@ -438,8 +438,8 @@ class OAuthCode(Base):
 class OAuthClient(Base):
     __tablename__ = 'oauth_clients'
     id = Column(Integer, primary_key=True, autoincrement=True)
-    identifier = Column(Unicode(1023), unique=True)
-    secret = Column(Unicode(1023))
+    identifier = Column(Unicode(255), unique=True)
+    secret = Column(Unicode(255))
     redirect_uri = Column(Unicode(1023))
 
 

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -200,14 +200,13 @@ class MockHub(JupyterHub):
 
     def load_config_file(self, *args, **kwargs):
         pass
-    
+
     @gen.coroutine
     def initialize(self, argv=None):
-        self.db_file = NamedTemporaryFile()
         self.pid_file = NamedTemporaryFile(delete=False).name
-        self.db_url = self.db_file.name
+        self.db_file = NamedTemporaryFile()
+        self.db_url = os.getenv('JUPYTERHUB_TEST_DB_URL') or self.db_file.name
         yield super().initialize([])
-        
         user = orm.User(name='user')
         self.db.add(user)
         self.db.commit()

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -207,9 +207,13 @@ class MockHub(JupyterHub):
         self.db_file = NamedTemporaryFile()
         self.db_url = os.getenv('JUPYTERHUB_TEST_DB_URL') or self.db_file.name
         yield super().initialize([])
-        user = orm.User(name='user')
-        self.db.add(user)
-        self.db.commit()
+
+        # add an initial user
+        user = self.db.query(orm.User).filter(orm.User.name == 'user').first()
+        if user is None:
+            user = orm.User(name='user')
+            self.db.add(user)
+            self.db.commit()
 
     def stop(self):
         super().stop()


### PR DESCRIPTION
It works!

<del>Now that we have dropped the test thread, this should be doable. Almost all passing, and I think the remaining failures are leaking data from one test run to the next, since the temp database is cleared per file, while the real databases persist for the session (useful to test!).
</del>

The main changes here are reducing some unnecessarily long strings from Unicode(1023) to Unicode(255), which is the max a default mysql setup can handle on unique columns (InnoDB max length is 767 = 256 * 3 - 1). This change doesn't require a db migration, because any existing db that was able to create the columns won't be affected, they will just have higher limits than they really need.