### PR TITLE
Update services getting started docs

### DIFF
--- a/docs/source/rest.md
+++ b/docs/source/rest.md
@@ -68,6 +68,26 @@ r.raise_for_status()
 users = r.json()
 ```
 
+This example provides a slightly more complicated request, yet the
+process is very similar:
+
+```python
+import requests
+
+api_url = 'http://127.0.0.1:8081/hub/api'
+
+data = {'name': 'mygroup', 'users': ['user1', 'user2']}
+
+r = requests.post(api_url + '/groups/formgrade-data301/users',
+    headers={
+             'Authorization': 'token %s' % token,
+            },
+    json=data
+)
+r.raise_for_status()
+r.json()
+```
+
 Note that the API token authorizes **JupyterHub** REST API requests. The same
 token does **not** authorize access to the [Jupyter Notebook REST API][]
 provided by notebook servers managed by JupyterHub. A different token is used

--- a/docs/source/rest.md
+++ b/docs/source/rest.md
@@ -34,12 +34,26 @@ generating an API token is:
 openssl rand -hex 32
 ```
 
-Alternatively, use the `jupyterhub token` (*deprecated in version 0.8.0*)
-command to generate a token for a specific hub user:
+This `openssl` command generates a potential token that can then be
+added to JupyterHub using `.api_tokens` configuration setting in
+`jupyterhub_config.py`.
+
+
+Alternatively, use the `jupyterhub token` command to generate a token
+for a specific hub user by passing the 'username':
 
 ```bash
 jupyterhub token <username>
 ```
+
+This command generates a random string to use as a token and registers
+it for the given user with the Hub's database.
+
+In [version 0.8.0](./changelog.html), a TOKEN request page for
+generating an API token is available from the JupyterHub user interface:
+
+![Request API TOKEN page](images/api-token-request.png)
+
 
 ## Add API tokens to the config file
 

--- a/docs/source/rest.md
+++ b/docs/source/rest.md
@@ -24,16 +24,28 @@ Hub.
 
 ## Create an API token
 
-To send requests using JupyterHub API, you must pass an API token with the
-request. You can create a token for an individual user using the following
-command:
+To send requests using JupyterHub API, you must pass an API token with
+the request.
 
-    jupyterhub token USERNAME
+As of [version 0.6.0](./changelog.html), the preferred way of
+generating an API token is:
+
+```bash
+openssl rand -hex 32
+```
+
+Alternatively, use the `jupyterhub token` (*deprecated in version 0.8.0*)
+command to generate a token for a specific hub user:
+
+```bash
+jupyterhub token <username>
+```
 
 ## Add API tokens to the config file
 
 You may also add a dictionary of API tokens and usernames to the hub's
-configuration file, `jupyterhub_config.py`:
+configuration file, `jupyterhub_config.py` (note that
+the **key** is the 'secret-token' while the **value** is the 'username'):
 
 ```python
 c.JupyterHub.api_tokens = {

--- a/docs/source/services-basics.md
+++ b/docs/source/services-basics.md
@@ -13,6 +13,8 @@ JupyterHub has a REST API that can be used by external services. This
 document will:
 
 - explain some basic information about API tokens
+- clarify that API tokens can be used to authenticate to
+  single-user servers as of [version 0.8.0](./changelog.html)
 - show how the [cull_idle_servers]_ script can be:
     - used in a Hub-managed service
     - run as a standalone script
@@ -56,6 +58,7 @@ the **key** is the 'token' while the **value** is the 'username'):
 c.JupyterHub.api_tokens = {'token' : 'username'}
 ```
 
+
 ### Restart JupyterHub
 
 Upon restarting JupyterHub, you should see a message like below in the
@@ -65,6 +68,12 @@ logs:
 Adding API token for <username>
 ```
 
+## Authenticating to single-user servers using API token
+
+In JupyterHub 0.7, there is no mechanism for token authentication to
+single-user servers, and only cookies can be used for authentication.
+0.8 supports using JupyterHub API tokens to authenticate to single-user
+servers.
 
 ## Configure `cull-idle` to run as a Hub-Managed Service
 

--- a/docs/source/services-basics.md
+++ b/docs/source/services-basics.md
@@ -27,15 +27,15 @@ Hub via the REST API.
 To run such an external service, an API token must be created and
 provided to the service.
 
-As of [version 0.6.0](./changelog.html), the preferred way of doing this
-is to first generate an API token:
+As of [version 0.6.0](./changelog.html), the preferred way of
+generating an API token is:
 
 ```bash
 openssl rand -hex 32
 ```
 
-Alternatively, use the `jupyterhub` command to generate a token
-for a specific hub user:
+Alternatively (*deprecated in version 0.8.0*), use the `jupyterhub`
+command to generate a token for a specific hub user:
 
 ```bash
 jupyterhub token <username>
@@ -101,7 +101,7 @@ Generate an API token and store it in the `JUPYTERHUB_API_TOKEN` environment
 variable. Run `cull_idle_servers.py` manually.
 
 ```bash
-    export JUPYTERHUB_API_TOKEN=`jupyterhub token`
+    export JUPYTERHUB_API_TOKEN='token'
     python cull_idle_servers.py [--timeout=900] [--url=http://127.0.0.1:8081/hub/api]
 ```
 

--- a/docs/source/services-basics.md
+++ b/docs/source/services-basics.md
@@ -58,6 +58,16 @@ the **key** is the 'token' while the **value** is the 'username'):
 c.JupyterHub.api_tokens = {'token' : 'username'}
 ```
 
+### Use API tokens for services and tasks that require external access
+
+While API tokens are often associated with a specific user, API tokens
+can be used by services that require external access for activities
+that may not correspond to a specific human, e.g. adding users during
+setup for a tutorial or workshop:
+
+c.JupyterHub.services = [
+    {'name': 'adding-users', 'api_token': 'super-secret-token'},
+]
 
 ### Restart JupyterHub
 

--- a/docs/source/services-basics.md
+++ b/docs/source/services-basics.md
@@ -36,34 +36,23 @@ generating an API token is:
 openssl rand -hex 32
 ```
 
-Alternatively, use the `jupyterhub token` (*deprecated in version 0.8.0*)
-command to generate a token for a specific hub user:
+In [version 0.8.0](./changelog.html), a TOKEN request page for
+generating an API token is available from the JupyterHub user interface:
 
-```bash
-jupyterhub token <username>
-```
+![Request API TOKEN page](images/api-token-request.png)
 
 ### Pass environment variable with token to the Hub
 
 In the case of `cull_idle_servers`, it is passed as the environment
-variable called `JPY_API_TOKEN`.
-
-### Pass token using a configuration file
-
-You can write the API token to your JupyterHub
-configuration file, `jupyterhub_config.py` (note that
-the **key** is the 'token' while the **value** is the 'username'):
-
-```python
-c.JupyterHub.api_tokens = {'token' : 'username'}
-```
+variable called `JUPYTERHUB_API_TOKEN`.
 
 ### Use API tokens for services and tasks that require external access
 
 While API tokens are often associated with a specific user, API tokens
 can be used by services that require external access for activities
 that may not correspond to a specific human, e.g. adding users during
-setup for a tutorial or workshop:
+setup for a tutorial or workshop. Add a service and its API token to the
+JupyterHub configuration file, `jupyterhub_config.py`:
 
 ```python
 c.JupyterHub.services = [
@@ -105,7 +94,8 @@ c.JupyterHub.services = [
 where:
 
 - `'admin': True` indicates that the Service has 'admin' permissions, and
-- `'command'` indicates that the Service will be managed by the Hub.
+- `'command'` indicates that the Service will be launched as a
+  subprocess, managed by the Hub.
 
 ## Run `cull-idle` manually as a standalone script
 

--- a/docs/source/services-basics.md
+++ b/docs/source/services-basics.md
@@ -1,36 +1,110 @@
-## External services
+# External services
 
-JupyterHub has a REST API that can be used by external services like the
-[cull_idle_servers](https://github.com/jupyterhub/jupyterhub/blob/master/examples/cull-idle/cull_idle_servers.py)
-script which monitors and kills idle single-user servers periodically. In order to run such an
-external service, you need to provide it an API token. In the case of `cull_idle_servers`, it is passed
-as the environment variable called `JPY_API_TOKEN`.
+When working with JupyterHub, a **Service** is defined as a process
+that interacts with the Hub's REST API. A Service may perform a specific
+or action or task. For example, shutting down individuals' single user
+notebook servers that have been is a good example of a task that could
+be automated by a Service. Let's look at how the [cull_idle_servers]_
+script can be used as a Service.
 
-Currently there are two ways of registering that token with JupyterHub. The first one is to use
-the `jupyterhub` command to generate a token for a specific hub user:
+## Real-world example to cull idle servers
 
-```bash
-jupyterhub token <username>
-```
+JupyterHub has a REST API that can be used by external services. This
+document will:
 
-As of [version 0.6.0](./changelog.html), the preferred way of doing this is to first generate an API token:
+- explain some basic information about API tokens
+- show how the [cull_idle_servers]_ script can be:
+    - used in a Hub-managed service
+    - run as a standalone script
+
+Both examples for `cull_idle_servers` will communicate tasks to the
+Hub via the REST API.
+
+## API Token basics
+
+### Create an API token
+
+To run such an external service, an API token must be created and
+provided to the service.
+
+As of [version 0.6.0](./changelog.html), the preferred way of doing this
+is to first generate an API token:
 
 ```bash
 openssl rand -hex 32
 ```
 
+Alternatively, use the `jupyterhub` command to generate a token
+for a specific hub user:
 
-and then write it to your JupyterHub configuration file (note that the **key** is the token while the **value** is the username):
+```bash
+jupyterhub token <username>
+```
+
+### Pass environment variable with token to the Hub
+
+In the case of `cull_idle_servers`, it is passed as the environment
+variable called `JPY_API_TOKEN`.
+
+### Pass token using a configuration file
+
+You can write the API token to your JupyterHub
+configuration file, `jupyterhub_config.py` (note that
+the **key** is the 'token' while the **value** is the 'username'):
 
 ```python
 c.JupyterHub.api_tokens = {'token' : 'username'}
 ```
 
-Upon restarting JupyterHub, you should see a message like below in the logs:
+### Restart JupyterHub
+
+Upon restarting JupyterHub, you should see a message like below in the
+logs:
 
 ```
 Adding API token for <username>
 ```
 
-Now you can run your script, i.e. `cull_idle_servers`, by providing it the API token and it will authenticate through
-the REST API to interact with it.
+
+## Configure `cull-idle` to run as a Hub-Managed Service
+
+In `jupyterhub_config.py`, add the following dictionary for the
+`cull-idle` Service to the `c.JupyterHub.services` list:
+
+```python
+c.JupyterHub.services = [
+    {
+        'name': 'cull-idle',
+        'admin': True,
+        'command': 'python cull_idle_servers.py --timeout=3600'.split(),
+    }
+]
+```
+
+where:
+
+- `'admin': True` indicates that the Service has 'admin' permissions, and
+- `'command'` indicates that the Service will be managed by the Hub.
+
+## Run `cull-idle` manually as a standalone script
+
+Now you can run your script, i.e. `cull_idle_servers`, by providing it
+the API token and it will authenticate through the REST API to
+interact with it.
+
+This will run `cull-idle` manually. `cull-idle` can be run as a standalone
+script anywhere with access to the Hub, and will periodically check for idle
+servers and shut them down via the Hub's REST API. In order to shutdown the
+servers, the token given to cull-idle must have admin privileges.
+
+Generate an API token and store it in the `JUPYTERHUB_API_TOKEN` environment
+variable. Run `cull_idle_servers.py` manually.
+
+```bash
+    export JUPYTERHUB_API_TOKEN=`jupyterhub token`
+    python cull_idle_servers.py [--timeout=900] [--url=http://127.0.0.1:8081/hub/api]
+```
+
+
+
+_cull_idle_servers: https://github.com/jupyterhub/jupyterhub/blob/master/examples/cull-idle/cull_idle_servers.py

--- a/docs/source/services-basics.md
+++ b/docs/source/services-basics.md
@@ -4,7 +4,7 @@ When working with JupyterHub, a **Service** is defined as a process
 that interacts with the Hub's REST API. A Service may perform a specific
 or action or task. For example, shutting down individuals' single user
 notebook servers that have been is a good example of a task that could
-be automated by a Service. Let's look at how the [cull_idle_servers]_
+be automated by a Service. Let's look at how the [cull_idle_servers][]
 script can be used as a Service.
 
 ## Real-world example to cull idle servers
@@ -15,7 +15,7 @@ document will:
 - explain some basic information about API tokens
 - clarify that API tokens can be used to authenticate to
   single-user servers as of [version 0.8.0](./changelog.html)
-- show how the [cull_idle_servers]_ script can be:
+- show how the [cull_idle_servers][] script can be:
     - used in a Hub-managed service
     - run as a standalone script
 
@@ -36,7 +36,7 @@ generating an API token is:
 openssl rand -hex 32
 ```
 
-Alternatively (*deprecated in version 0.8.0*), use the `jupyterhub`
+Alternatively, use the `jupyterhub token` (*deprecated in version 0.8.0*)
 command to generate a token for a specific hub user:
 
 ```bash
@@ -65,9 +65,11 @@ can be used by services that require external access for activities
 that may not correspond to a specific human, e.g. adding users during
 setup for a tutorial or workshop:
 
+```python
 c.JupyterHub.services = [
     {'name': 'adding-users', 'api_token': 'super-secret-token'},
 ]
+```
 
 ### Restart JupyterHub
 
@@ -126,4 +128,4 @@ variable. Run `cull_idle_servers.py` manually.
 
 
 
-_cull_idle_servers: https://github.com/jupyterhub/jupyterhub/blob/master/examples/cull-idle/cull_idle_servers.py
+[cull_idle_servers]: https://github.com/jupyterhub/jupyterhub/blob/master/examples/cull-idle/cull_idle_servers.py


### PR DESCRIPTION
Partially addresses #962
Closes #1078 

- provide more clarity on process steps using cull idle server as an example
- deprecate 'jupyterhub token' @minrk if you are cool doing so.
- add example for requests/API from #962 
- add note about tokens and auth to single-user servers in 0.8 #1078
- add small section on using API tokens for service activities that are not tied to a specific user #962