### PR TITLE
Update pin on sqlalchemy for travis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ tornado>=4.1
 jinja2
 pamela
 python-oauth2>=1.0
-sqlalchemy>=1.0
+sqlalchemy>=1.2.0b2
 requests


### PR DESCRIPTION
When investigating a failed test in this [travis build](https://travis-ci.org/jupyterhub/jupyterhub/jobs/262762543), the following error was happening during the pip install of requirements:

<img width="824" alt="screen shot 2017-08-09 at 12 36 47 pm" src="https://user-images.githubusercontent.com/2680980/29140529-a43a0926-7cff-11e7-9b25-1f5390def1fb.png">

For some reason the existing entry in `requirements.txt` as well as `sqlalchemy>=1.1` and `sqlalchemy>=1.2` all throw the same error. 

@minrk Would you mind looking at the test failures in the linked build? Thanks.