### PR TITLE
Add detail to tutorials toc section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,6 +67,8 @@ Contents
 **Tutorials**
 
 * :doc:`tutorials/index`
+* :doc:`tutorials/upgrade-dot-eight`
+* `Zero to JupyterHub with Kubernetes <https://zero-to-jupyterhub.readthedocs.io/en/latest/>`_
 
 **Troubleshooting**
 


### PR DESCRIPTION
add detail to the main table of contents for tutorials

<img width="445" alt="screenshot 2017-08-16 15 50 25" src="https://user-images.githubusercontent.com/2680980/29366579-b3f3edf0-829a-11e7-8bd8-7e5812d942e3.png">
