### PR TITLE
build jupyterhub/singleuser on this repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,7 @@ jupyterhub_cookie_secret
 jupyterhub.sqlite
 jupyterhub_config.py
 node_modules
+docs
+.git
+dist
+build

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules
 *~
 .cache
 .DS_Store
-build
+/build
 dist
 docs/_build
 docs/source/_static/rest-api

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ graft onbuild
 graft jupyterhub
 graft scripts
 graft share
+graft singleuser
 
 # Documentation
 graft docs

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -1,9 +1,10 @@
 # Build as jupyterhub/singleuser
 # Run with the DockerSpawner in JupyterHub
 
-FROM jupyter/base-notebook:5ded1de07260
+ARG BASE_IMAGE=jupyter/base-notebook
+FROM $BASE_IMAGE
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
 ADD install_jupyterhub /tmp/install_jupyterhub
 ARG JUPYTERHUB_VERSION=master
-RUN python /tmp/install_jupyterhub
+RUN python3 /tmp/install_jupyterhub

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -1,0 +1,9 @@
+# Build as jupyterhub/singleuser
+# Run with the DockerSpawner in JupyterHub
+
+FROM jupyter/base-notebook:5ded1de07260
+MAINTAINER Project Jupyter <jupyter@googlegroups.com>
+
+ADD install_jupyterhub /tmp/install_jupyterhub
+ARG JUPYTERHUB_VERSION=master
+RUN python /tmp/install_jupyterhub

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -7,4 +7,6 @@ MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
 ADD install_jupyterhub /tmp/install_jupyterhub
 ARG JUPYTERHUB_VERSION=master
-RUN python3 /tmp/install_jupyterhub
+# install pinned jupyterhub and ensure notebook is installed
+RUN python3 /tmp/install_jupyterhub && \
+    python3 -m pip install notebook

--- a/singleuser/README.md
+++ b/singleuser/README.md
@@ -8,10 +8,26 @@ to be used with the
 [DockerSpawner](https://github.com/jupyterhub/dockerspawner/blob/master/dockerspawner/dockerspawner.py)
 class to launch user notebook servers within docker containers.
 
+The only thing this image accomplishes is pinning the jupyterhub version on top of base-notebook.
+In most cases, one of the Jupyter [docker-stacks](https://github.com/jupyter/docker-stacks) is a better choice.
+You will just have to make sure that you have the right version of JupyterHub installed in your image,
+which can usually be accomplished with one line:
 
-This particular server runs (within the container) as the `jovyan` user, with
-home directory at `/home/jovyan`, and the IPython example notebooks at
-`/home/jovyan/examples`.
+```Dockerfile
+FROM jupyter/base-notebook:5ded1de07260
+RUN pip3 install jupyterhub==0.7.2
+```
+
+The dockerfile that builds this image exposes `BASE_IMAGE` and `JUPYTERHUB_VERSION` as build args, so you can do:
+
+    docker build -t singleuser \
+      --build-arg BASE_IMAGE=jupyter/scipy-notebook \
+      --build-arg JUPYTERHUB_VERSION=0.8.0 \
+      .
+
+in this directory to get a new image `singleuser` that is based on `jupyter/scipy-notebook` with JupyterHub 0.8, for example.
+
+This particular image runs as the `jovyan` user, with home directory at `/home/jovyan`.
 
 ## Note on persistence
 

--- a/singleuser/README.md
+++ b/singleuser/README.md
@@ -1,0 +1,20 @@
+# jupyterhub/singleuser
+
+Built from the `jupyter/base-notebook` base image.
+
+This image contains a single user notebook server for use with
+[JupyterHub](https://github.com/jupyterhub/jupyterhub). In particular, it is meant
+to be used with the
+[DockerSpawner](https://github.com/jupyterhub/dockerspawner/blob/master/dockerspawner/dockerspawner.py)
+class to launch user notebook servers within docker containers.
+
+
+This particular server runs (within the container) as the `jovyan` user, with
+home directory at `/home/jovyan`, and the IPython example notebooks at
+`/home/jovyan/examples`.
+
+## Note on persistence
+
+This home directory, `/home/jovyan`, is *not* persistent by default,
+so some configuration is required unless the directory is to be used
+with temporary or demonstration JupyterHub deployments.

--- a/singleuser/hooks/build
+++ b/singleuser/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+stable=0.7
+
+for V in master 0.7; do
+    docker build --build-arg JUPYTERHUB_VERSION=$V -t $DOCKER_REPO:$V .
+done
+
+echo "tagging $IMAGE_NAME"
+docker tag $DOCKER_REPO:$stable $IMAGE_NAME

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+for V in master 0.7; do
+  docker push $DOCKER_REPO:$V
+done
+
+function get_hub_version() {
+  rm -f hub_version
+  V=$1
+  docker run --rm -v $PWD:/version -u $(id -u) -i $DOCKER_REPO:$V sh -c 'jupyterhub --version > /version/hub_version'
+  hub_xyz=$(cat hub_version)
+  split=( ${hub_xyz//./ } )
+  hub_xy="${split[0]}.${split[1]}"
+}
+# tag e.g. 0.7.2 with 0.7
+get_hub_version 0.7
+docker tag $DOCKER_REPO:0.7 $DOCKER_REPO:$hub_xyz
+docker push $DOCKER_REPO:$hub_xyz
+
+# tag e.g. 0.8 with master
+get_hub_version master
+docker tag $DOCKER_REPO:master $DOCKER_REPO:$hub_xy
+docker push $DOCKER_REPO:$hub_xy

--- a/singleuser/install_jupyterhub
+++ b/singleuser/install_jupyterhub
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import os
+from subprocess import check_call
+
+V = os.environ['JUPYTERHUB_VERSION']
+
+pip_install = [
+    'pip', 'install', '--no-cache', '--upgrade',
+    '--upgrade-strategy', 'only-if-needed',
+]
+if V == 'master':
+    req = 'https://github.com/jupyterhub/jupyterhub/archive/master.tar.gz'
+else:
+    version_info = [ int(part) for part in V.split('.') ]
+    version_info[-1] += 1
+    upper_bound = '.'.join(map(str, version_info))
+    vs = '>=%s,<%s' % (V, upper_bound)
+    req = 'jupyterhub%s' % vs
+
+check_call(pip_install + [req])

--- a/singleuser/install_jupyterhub
+++ b/singleuser/install_jupyterhub
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 import os
 from subprocess import check_call
+import sys
 
 V = os.environ['JUPYTERHUB_VERSION']
 
 pip_install = [
-    'pip', 'install', '--no-cache', '--upgrade',
+    sys.executable, '-m', 'pip', 'install', '--no-cache', '--upgrade',
     '--upgrade-strategy', 'only-if-needed',
 ]
 if V == 'master':


### PR DESCRIPTION
rather than dockerspawner.

The tags are tied to JupyterHub version, so it makes a bit more sense to build here
rather than there.

Plus, recent updates to dockerspawner eliminate any assumptions in dockerspawner about what the image does other than the fact that it launches `jupyterhub-singleuser`, and even that can be overridden with `c.Spawner.cmd`. So literally any image with JupyterHub installed should work.