### PR TITLE
Provide more detailed error message in case of version mismatch

### DIFF
--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -35,8 +35,11 @@ def _check_version(hub_version, singleuser_version, log):
         else:
             # log warning-level for more significant mismatch, such as 0.8 vs 0.9, etc.
             log_method = log.warning
-        log_method("jupyterhub version %s != jupyterhub-singleuser version %s",
-            hub_version, singleuser_version,
+            extra = " This could cause failure to authenticate and result in redirect loops!"
+        log_method(
+            "jupyterhub version %s != jupyterhub-singleuser version %s." + extra,
+            hub_version,
+            singleuser_version,
         )
     else:
         log.debug("jupyterhub and jupyterhub-singleuser both on version %s" % hub_version)

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -53,6 +53,7 @@ class Spawner(LoggingConfigurable):
     _stop_pending = False
     _proxy_pending = False
     _waiting_for_response = False
+    _jupyterhub_version = None
 
     @property
     def _log_name(self):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -472,6 +472,9 @@ class User(HasTraits):
         else:
             server_version = resp.headers.get('X-JupyterHub-Version')
             _check_version(__version__, server_version, self.log)
+            # record the Spawner version for better error messages
+            # if it doesn't work
+            spawner._jupyterhub_version = server_version
         finally:
             spawner._waiting_for_response = False
             spawner._start_pending = False


### PR DESCRIPTION
this is the most likely cause of redirect loops when using docker, so record the spawner version and check it when a redirect is detected.

In the event of a redirect and mismatch, fail with a message explaining the version mismatch and how to fix it.

The redirect threshold is also lower in the case of a version mismatch.

closes #1367