### PR TITLE
Prevent "extra" from being used before definition.

### DIFF
--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -28,6 +28,7 @@ def _check_version(hub_version, singleuser_version, log):
         from distutils.version import LooseVersion as V
         hub_major_minor = V(hub_version).version[:2]
         singleuser_major_minor = V(singleuser_version).version[:2]
+        extra = ""
         if singleuser_major_minor == hub_major_minor:
             # patch-level mismatch or lower, log difference at debug-level
             # because this should be fine


### PR DESCRIPTION
Prevent "extra" from being used before definition.