### PR TITLE
set cookie on singleuser when authenticated with ?token=...

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -731,6 +731,11 @@ class HubAuthenticated(object):
         except Exception:
             self._hub_auth_user_cache = None
             raise
+        token = self.get_argument('token', '')
+        if user_model and token and getattr(self, '_token_authenticated', False):
+            # authenticated via `?token=`
+            # set a cookie for future requests
+            self.hub_auth.set_cookie(self, token)
         return self._hub_auth_user_cache
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -731,11 +731,19 @@ class HubAuthenticated(object):
         except Exception:
             self._hub_auth_user_cache = None
             raise
-        token = self.get_argument('token', '')
-        if user_model and token and getattr(self, '_token_authenticated', False):
+
+        # store ?token=... tokens passed via url in a cookie for future requests
+        url_token = self.get_argument('token', '')
+        if (
+            user_model
+            and url_token
+            and getattr(self, '_token_authenticated', False)
+            and hasattr(self.hub_auth, 'set_cookie')
+        ):
             # authenticated via `?token=`
             # set a cookie for future requests
-            self.hub_auth.set_cookie(self, token)
+            # hub_auth.set_cookie is only available on HubOAuth
+            self.hub_auth.set_cookie(self, url_token)
         return self._hub_auth_user_cache
 
 


### PR DESCRIPTION
Allows `/user/name?token=...` URL to login users for more than one request.

matches token behavior of regular notebook server.

With these two PRs, we have everything we need to manage users external to the Hub for e.g. Binder.

With Binder in mind, I made [an example](https://github.com/jupyterhub/nullauthenticator/tree/master/examples/token-only) where an external service handles user creation, spawning, and login. The service does:

1. create a user
2. spawn the user's server
3. request a token for that user
4. redirect to `/user/name/?token=...`

which should allow a service like Binder to spawn and login users without the redirect shenanigans currently required. This will require 0.8 (after this is merged) to work, because 0.7 doesn't allow token auth to single-user servers.