### PR TITLE
restore db access on Spawner

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -18,7 +18,7 @@ from tempfile import mkdtemp
 from sqlalchemy import inspect
 
 from tornado import gen
-from tornado.ioloop import PeriodicCallback, IOLoop
+from tornado.ioloop import PeriodicCallback
 
 from traitlets.config import LoggingConfigurable
 from traitlets import (
@@ -102,6 +102,7 @@ class Spawner(LoggingConfigurable):
     authenticator = Any()
     hub = Any()
     orm_spawner = Any()
+    db = Any()
 
     @observe('orm_spawner')
     def _orm_spawner_changed(self, change):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -201,6 +201,7 @@ class User(HasTraits):
             authenticator=self.authenticator,
             config=self.settings.get('config'),
             proxy_spec=url_path_join(self.proxy_spec, name, '/'),
+            db=self.db,
         )
         # update with kwargs. Mainly for testing.
         spawn_kwargs.update(kwargs)


### PR DESCRIPTION
Shouldn’t be strictly necessary, but doesn’t hurt

cc @JenCabral who found the bug via sudospawner