### PR TITLE
improve reporting of spawn failure

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -488,7 +488,8 @@ class BaseHandler(RequestHandler):
             if status is not None:
                 toc = IOLoop.current().time()
                 self.statsd.timing('spawner.failure', (toc - tic) * 1000)
-                raise web.HTTPError(500, "Spawner failed to start [status=%s]" % status)
+                raise web.HTTPError(500, "Spawner failed to start [status=%s]. The logs for %s may contain details." % (
+                    status, spawner._log_name))
 
             if spawner._waiting_for_response:
                 # hit timeout waiting for response, but server's running.

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -708,6 +708,15 @@ class UserSpawnHandler(BaseHandler):
                 else:
                     yield self.spawn_single_user(current_user)
 
+            # spawn didn't finish, show pending page
+            if spawner.pending:
+                self.log.info("%s is pending %s", spawner._log_name, spawner.pending)
+                # spawn has started, but not finished
+                self.statsd.incr('redirects.user_spawn_pending', 1)
+                html = self.render_template("spawn_pending.html", user=current_user)
+                self.finish(html)
+                return
+
             # We do exponential backoff here - since otherwise we can get stuck in a redirect loop!
             # This is important in many distributed proxy implementations - those are often eventually
             # consistent and can take upto a couple of seconds to actually apply throughout the cluster.

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -689,7 +689,7 @@ class UserSpawnHandler(BaseHandler):
                 # if the most recent spawn
                 self.log.error("Preventing implicit spawn for %s because last spawn failed: %s",
                     spawner._log_name, spawner._spawn_future.exception())
-                raise web.HTTPError(500, "Last spawn failed. Try spawning again from the Home page.")
+                raise spawner._spawn_future.exception()
 
             # check for pending spawn
             if spawner.pending and spawner._spawn_future:

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -54,6 +54,7 @@ class Spawner(LoggingConfigurable):
     _proxy_pending = False
     _waiting_for_response = False
     _jupyterhub_version = None
+    _spawn_future = None
 
     @property
     def _log_name(self):

--- a/share/jupyter/hub/templates/error.html
+++ b/share/jupyter/hub/templates/error.html
@@ -22,6 +22,11 @@
     {{message_html | safe}}
   </p>
   {% endif %}
+  {% if extra_error_html %}
+  <p>
+    {{extra_error_html | safe}}
+  </p>
+  {% endif %}
   {% endblock error_detail %}
 </div>
 


### PR DESCRIPTION
- add Spawner._spawn_future and wait for it on `/hub/user/:name`, so that if a spawner fails, the error will be raised on waiting pages
- render pending page if triggered spawn doesn't finish, rather than starting redirect loop to `/user/:name`
- point to user logs when spawner exits prematurely, since this usually means an error raised during `jupyterhub-singleuser` startup
- preserve exception from last failed spawn and prevent visits to `/user/:name` from triggering a new spawn if the last attempt failed. Users must visit `/hub/home` and click `Start My Server` if their last spawn failed (or spawn via API or direct visits to /spawn)
- update 'Start My Server' link to visit `/hub/spawn`, which clears the `_spawn_future` exception if there was one, instead of being a simple redirect to `/user/:name`, in order to distinguish between implicit and explicit spawn requests
- Include 'You can try restarting your server from the home page' link on failed spawn error pages.

closes #1389