### PR TITLE
allow Authenticator.custom_html to be HTML

### DIFF
--- a/share/jupyter/hub/templates/login.html
+++ b/share/jupyter/hub/templates/login.html
@@ -8,7 +8,7 @@
 {% block login %}
 <div id="login-main" class="container">
 {% if custom_html %}
-{{ custom_html }}
+{{ custom_html | safe }}
 {% elif login_service %}
 <div class="service-login">
   <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>


### PR DESCRIPTION
we were escaping it, making it impossible to put any actual HTML on the page

closes #1252