### PR TITLE
we require sqlalchemy 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ tornado>=4.1
 jinja2
 pamela
 python-oauth2>=1.0
-SQLAlchemy>=1.0
+SQLAlchemy>=1.1
 requests


### PR DESCRIPTION
...turns out!

We've picked up enum support, which we started using in 0.8 and is new in sqla 1.1.0

[ref](http://docs.sqlalchemy.org/en/latest/changelog/changelog_11.html#change-9d6d98d7acabc8564b8eebb11c28a624)

cc @Siecje