### PR TITLE
test restoring and deleting spawners while the Hub is down

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -213,7 +213,7 @@ class Service(Base):
     api_tokens = relationship("APIToken", backref="service")
 
     # service-specific interface
-    _server_id = Column(Integer, ForeignKey('servers.id'))
+    _server_id = Column(Integer, ForeignKey('servers.id', ondelete='SET NULL'))
     server = relationship(Server, primaryjoin=_server_id == Server.id)
     pid = Column(Integer)
 

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -177,7 +177,7 @@ class Spawner(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
 
-    server_id = Column(Integer, ForeignKey('servers.id'))
+    server_id = Column(Integer, ForeignKey('servers.id', ondelete='SET NULL'))
     server = relationship(Server)
 
     state = Column(JSONDict)

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -301,5 +301,8 @@ class Service(LoggingConfigurable):
         if not self.managed:
             raise RuntimeError("Cannot stop unmanaged service %s" % self)
         if self.spawner:
+            if self.orm.server:
+                self.db.delete(self.orm.server)
+                self.db.commit()
             self.spawner.stop_polling()
             return self.spawner.stop()

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -46,4 +46,3 @@ def test_upgrade_entrypoint(tmpdir):
 
     # run tokenapp again, it should work
     tokenapp.start()
-    


### PR DESCRIPTION
- set ondelete='SET NULL' on spawner->server relation (closes #1414)
- set `spawner.server = None`, which is not triggered when deleting orm_spawner.server
- same ondelete for service->server