### PR TITLE
Fixes (and tests!) for oauth state handling

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -774,7 +774,7 @@ class HubOAuthCallbackHandler(HubOAuthenticated, RequestHandler):
         next_url = None
         if arg_state or cookie_state:
             # clear cookie state now that we've consumed it
-            self.clear_cookie(self.hub_auth.state_cookie_name)
+            self.clear_cookie(self.hub_auth.state_cookie_name, path=self.hub_auth.base_url)
             if isinstance(cookie_state, bytes):
                 cookie_state = cookie_state.decode('ascii', 'replace')
             # check that state matches

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -657,13 +657,12 @@ class HubAuthenticated(object):
     def get_login_url(self):
         """Return the Hub's login URL"""
         login_url = self.hub_auth.login_url
-        app_log.debug("Redirecting to login url: %s", login_url)
-        if isinstance(self.hub_auth, HubOAuthenticated):
+        if isinstance(self.hub_auth, HubOAuth):
             # add state argument to OAuth url
             state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
-            return url_concat(login_url, {'state': state})
-        else:
-            return login_url
+            login_url = url_concat(login_url, {'state': state})
+        app_log.debug("Redirecting to login url: %s", login_url)
+        return login_url
 
     def check_hub_user(self, model):
         """Check whether Hub-authenticated user or service should be allowed.


### PR DESCRIPTION
oauth state is required for redirecting properly, but wasn't being set.

Includes tests that verify that oauth state is handled properly.

Fixes https://github.com/data-8/nbgitpuller/issues/16