### PR TITLE
allow default (empty) server name with named servers

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -114,7 +114,7 @@ class APIHandler(BaseHandler):
                     if spawner.pending:
                         s['pending'] = spawner.pending
                     if spawner.server:
-                        s['url'] = user.url + name + '/'
+                        s['url'] = url_path_join(user.url, name, '/')
         return model
 
     def group_model(self, group):

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -185,8 +185,6 @@ class UserServerAPIHandler(APIHandler):
         user = self.find_user(name)
         if server_name and not self.allow_named_servers:
             raise web.HTTPError(400, "Named servers are not enabled.")
-        if self.allow_named_servers and not server_name:
-            server_name = user.default_server_name()
         spawner = user.spawners[server_name]
         pending = spawner.pending
         if pending == 'spawn':

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -20,7 +20,7 @@ from .. import __version__
 from .. import orm
 from ..objects import Server
 from ..spawner import LocalProcessSpawner
-from ..utils import default_server_name, url_path_join
+from ..utils import url_path_join
 
 # pattern for the authentication token header
 auth_header_pat = re.compile(r'^(?:token|bearer)\s+([^\s]+)$', flags=re.IGNORECASE)
@@ -380,8 +380,6 @@ class BaseHandler(RequestHandler):
         self.extra_error_html = self.spawn_home_error
 
         user_server_name = user.name
-        if self.allow_named_servers and not server_name:
-            server_name = default_server_name(user)
 
         if server_name:
             user_server_name = '%s:%s' % (user.name, server_name)

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -18,6 +18,57 @@ def named_servers(app):
 
 
 @pytest.mark.gen_test
+def test_default_server(app, named_servers):
+    """Test the default /users/:user/server handler when named servers are enabled"""
+    username = 'rosie'
+    user = add_user(app.db, app, name=username)
+    r = yield api_request(app, 'users', username, 'server', method='post')
+    assert r.status_code == 201
+    assert r.text == ''
+
+    r = yield api_request(app, 'users', username)
+    r.raise_for_status()
+
+    user_model = r.json()
+    user_model.pop('last_activity')
+    assert user_model == {
+        'name': username,
+        'groups': [],
+        'kind': 'user',
+        'admin': False,
+        'pending': None,
+        'server': user.url,
+        'servers': {
+            '': {
+                'name': '',
+                'url': user.url,
+            },
+        },
+    }
+
+    # now stop the server
+    r = yield api_request(app, 'users', username, 'server', method='delete')
+    assert r.status_code == 204
+    assert r.text == ''
+
+    r = yield api_request(app, 'users', username)
+    r.raise_for_status()
+
+    user_model = r.json()
+    user_model.pop('last_activity')
+    assert user_model == {
+        'name': username,
+        'groups': [],
+        'kind': 'user',
+        'admin': False,
+        'pending': None,
+        'server': None,
+        'servers': {},
+    }
+
+
+
+@pytest.mark.gen_test
 def test_create_named_server(app, named_servers):
     username = 'walnut'
     user = add_user(app.db, app, name=username)

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -49,13 +49,13 @@ def test_create_named_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
-        'server': None,
+        'server': user.url,
         'servers': {
             name: {
                 'name': name,
                 'url': url_path_join(user.url, name, '/'),
             }
-            for name in ['1', servername]
+            for name in ['', servername]
         },
     }
 
@@ -86,13 +86,13 @@ def test_delete_named_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
-        'server': None,
+        'server': user.url,
         'servers': {
             name: {
                 'name': name,
                 'url': url_path_join(user.url, name, '/'),
             }
-            for name in ['1']
+            for name in ['']
         },
     }
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -12,7 +12,7 @@ from tornado import gen
 from tornado.log import app_log
 from traitlets import HasTraits, Any, Dict, default
 
-from .utils import url_path_join, default_server_name
+from .utils import url_path_join
 
 from . import orm
 from ._version import _check_version, __version__

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -298,17 +298,3 @@ def url_path_join(*pieces):
 
     return result
 
-
-def default_server_name(user):
-    """Return the default name for a new server for a given user.
-
-    Will be the first available integer string, e.g. '1' or '2'.
-    """
-    existing_names = set(user.spawners)
-    # if there are 5 servers, count from 1 to 6
-    for n in range(1, len(existing_names) + 2):
-        name = str(n)
-        if name not in existing_names:
-            return name
-    raise RuntimeError("It should be impossible to get here")
-


### PR DESCRIPTION
Previously POST user/:user/server would create a new named server (e.g. '1') rather than creating the same `/user/:name/` server as the non-named case. But this behavior didn't really work, so restore the behavior of the `/user/:name/server` handler to be the same whether named servers are enabled or not.

Fixes the bug that @Analect found on `POST user/:user/server`, which was failing.