### PR TITLE
Add handling for POST/DELETE of named-servers in hub API introduced in 0.8x

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -203,6 +203,43 @@ paths:
           description: The user's notebook server has stopped
         '202':
           description: The user's notebook server has not yet stopped as it is taking a while to stop
+  /users/{name}/servers/{server_name}:
+    post:
+      summary: Start a user's single-user named-server notebook server
+      parameters:
+        - name: name
+          description: username
+          in: path
+          required: true
+          type: string
+        - name: server_name
+          description: name given to a named-server
+          in: path
+          required: true
+          type: string
+      responses:
+        '201':
+          description: The user's notebook named-server has started
+        '202':
+          description: The user's notebook named-server has not yet started, but has been requested
+    delete:
+      summary: Stop a user's named-server
+      parameters:
+        - name: name
+          description: username
+          in: path
+          required: true
+          type: string
+        - name: server_name
+          description: name given to a named-server
+          in: path
+          required: true
+          type: string
+      responses:
+        '204':
+          description: The user's notebook named-server has stopped
+        '202':
+          description: The user's notebook named-server has not yet stopped as it is taking a while to stop
   /users/{name}/admin-access:
     post:
       summary: Grant admin access to this user's notebook server


### PR DESCRIPTION
You can double-check that this is working OK [here](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/Analect/jupyterhub/c6ac9e1d15a19f72c7bc6d70d4aebdc408a3fe18/docs/rest-api.yml)