### PR TITLE
Adding a short description ref starting/stopping named-servers via API

### DIFF
--- a/docs/source/contributor-list.md
+++ b/docs/source/contributor-list.md
@@ -3,6 +3,7 @@
 Project Jupyter thanks the following people for their help and
 contribution on JupyterHub:
 
+- Analect
 - anderbubble
 - apetresc
 - barrachri

--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -133,7 +133,21 @@ With the named-server functionality, it's now possible to launch more than one
 specifically named servers against a given user.  This could be used, for instance,
 to launch each server based on a different image.
 
-It's activated like this:
+First you must enable named-servers by including the following setting in the `jupyterhub_config.py` file.
+
+`c.JupyterHub.allow_named_servers = True`
+
+If using the [zero-to-jupyterhub-k8s](https://github.com/jupyterhub/zero-to-jupyterhub-k8s) set-up to run JupyterHub, 
+then instead of editing the `jupyterhub_config.py` file directly, you could pass 
+the following as part of the `config.yaml` file, as per the [tutorial](https://zero-to-jupyterhub.readthedocs.io/en/latest/):
+
+```bash
+hub:
+  extraConfig: |
+    c.JupyterHub.allow_named_servers = True
+```
+
+With that setting in place, a new named-server is activated like this:
 ```bash
 curl -X POST -H "Authorization: token <token>" "http://127.0.0.1:8081/hub/api/users/<user>/servers/<serverA>"
 curl -X POST -H "Authorization: token <token>" "http://127.0.0.1:8081/hub/api/users/<user>/servers/<serverB>"

--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -146,7 +146,7 @@ The same servers can be stopped by substituting `DELETE` for `POST` above.
 The named-server capabilities are not fully implemented for JupyterHub as yet.
 While it's possible to start/stop a server via the API, the UI on the 
 JupyterHub control-panel has not been implemented, and so it may not be obvious
-to those viewing that panel and a named-server may be running for a given user.
+to those viewing the panel that a named-server may be running for a given user.
 
 For named-servers via the API to work, the spawner used to spawn these servers
 will need to be able to handle the case of multiple servers per user and ensure

--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -119,6 +119,41 @@ token does **not** authorize access to the [Jupyter Notebook REST API][]
 provided by notebook servers managed by JupyterHub. A different token is used
 to access the **Jupyter Notebook** API.
 
+## Enabling users to spawn multiple named-servers via the API
+
+With JupyterHub version 0.8, support for multiple servers per user has landed.
+Prior to that, each user could only launch a single default server via the API
+like this:
+
+```bash
+curl -X POST -H "Authorization: token <token>" "http://127.0.0.1:8081/hub/api/users/<user>/server"
+```
+
+With the named-server functionality, it's now possible to launch more than one
+specifically named servers against a given user.  This could be used, for instance,
+to launch each server based on a different image.
+
+It's activated like this:
+```bash
+curl -X POST -H "Authorization: token <token>" "http://127.0.0.1:8081/hub/api/users/<user>/servers/<serverA>"
+curl -X POST -H "Authorization: token <token>" "http://127.0.0.1:8081/hub/api/users/<user>/servers/<serverB>"
+```
+
+The same servers can be stopped by substituting `DELETE` for `POST` above.
+
+### Some caveats for using named-servers
+
+The named-server capabilities are not fully implemented for JupyterHub as yet.
+While it's possible to start/stop a server via the API, the UI on the 
+JupyterHub control-panel has not been implemented, and so it may not be obvious
+to those viewing that panel and a named-server may be running for a given user.
+
+For named-servers via the API to work, the spawner used to spawn these servers
+will need to be able to handle the case of multiple servers per user and ensure
+uniqueness of names, particularly if servers are spawned via docker containers
+or kubernetes pods.
+
+
 ## Learn more about the API
 
 You can see the full [JupyterHub REST API][] for details. This REST API Spec can


### PR DESCRIPTION
@willingc 
Not sure if it's premature to add this to the docs ... or if you'd rather put it elsewhere in the docs, but thought I would add given the extended rest-api swagger stuff that you just merged.

As per https://github.com/jupyterhub/kubespawner/pull/83, I'm still working through getting the named-server API working in conjunction with kubespawner.  With a bit of input from @minrk or @yuvipanda, this can get resolved fairly quickly.