### PR TITLE
avoid oauth state cookie collisions

### DIFF
--- a/examples/service-whoami-flask/whoami-oauth.py
+++ b/examples/service-whoami-flask/whoami-oauth.py
@@ -59,7 +59,7 @@ def oauth_callback():
     # validate state field
     arg_state = request.args.get('state', None)
     cookie_state = request.cookies.get(auth.state_cookie_name)
-    if arg_state != cookie_state:
+    if arg_state is None or arg_state != cookie_state:
         # state doesn't match
         return 403
 


### PR DESCRIPTION
in case of multiple simultaneous

- state arg is strictly required now
- default cookie name in case of no collision is unchanged
- in case of collision, randomize cookie name with a suffix and store
cookie_name in state
- expire state cookies after 10 minutes, not 1 day, in case oauth doesn't complete

closes #1438