### PR TITLE
[WIP] Added additional statsd collection for the spawner

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -545,6 +545,7 @@ class BaseHandler(RequestHandler):
                 spawner._stop_pending = False
             toc = IOLoop.current().time()
             self.log.info("User %s server took %.3f seconds to stop", user.name, toc - tic)
+            self.statsd.timing('spawner.stop', (toc - tic) * 1000)
 
         try:
             yield gen.with_timeout(timedelta(seconds=self.slow_stop_timeout), stop())

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -14,6 +14,7 @@ from .. import objects
 from .. import crypto
 from ..user import User
 from .mocking import MockSpawner
+from ..emptyclass import EmptyClass
 
 
 def test_server(db):
@@ -167,6 +168,7 @@ def test_spawn_fails(db):
     user = User(orm_user, {
         'spawner_class': BadSpawner,
         'config': None,
+        'statsd': EmptyClass(),
     })
     
     with pytest.raises(RuntimeError) as exc:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -421,10 +421,12 @@ class User(HasTraits):
                     user=self.name, s=spawner.start_timeout,
                 ))
                 e.reason = 'timeout'
+                self.settings['statsd'].incr('spawner.failure.timeout')
             else:
                 self.log.error("Unhandled error starting {user}'s server: {error}".format(
                     user=self.name, error=e,
                 ))
+                self.settings['statsd'].incr('spawner.failure.error')
                 e.reason = 'error'
             try:
                 yield self.stop()
@@ -457,11 +459,13 @@ class User(HasTraits):
                     )
                 )
                 e.reason = 'timeout'
+                self.settings['statsd'].incr('spawner.failure.http_timeout')
             else:
                 e.reason = 'error'
                 self.log.error("Unhandled error waiting for {user}'s server to show up at {url}: {error}".format(
                     user=self.name, url=server.url, error=e,
                 ))
+                self.settings['statsd'].incr('spawner.failure.http_error')
             try:
                 yield self.stop()
             except Exception:


### PR DESCRIPTION
The spawner was not reporting some statistics that would be useful for debugging and load testing.

* `spawner.failure` counter collects the number of failures for various reasons:
    * `timeout`: When the spawner times out dues to `start_timeout` being exceeded
    * `error`: Any uncaptured errors related to starting the user server
    * `http_timeout`: When the spawner times out dues to `http_timeout` being exceeded
    * `http_error`: Any uncaptured errors related to waiting for the user server to say it's ready
* `spawner.stop` timer for seeing how long it takes a user server to stop

Can anyone else think of any other statistics that should be recorded?
