### PR TITLE
Conditionally substitute $http_host for $host.

### DIFF
--- a/docs/source/reference/config-examples.md
+++ b/docs/source/reference/config-examples.md
@@ -167,6 +167,9 @@ server {
 }
 ```
 
+If `nginx` is not running on port 443, substitute `$http_host` for `$host` on
+the lines setting the `Host` header.
+
 `nginx` will now be the front facing element of JupyterHub on `443` which means
 it is also free to bind other servers, like `NO_HUB.DOMAIN.TLD` to the same port
 on the same machine and network interface. In fact, one can simply use the same


### PR DESCRIPTION
Necessary when using non-standard port. Closes #1457.