### PR TITLE
Enable the asyncio event loop to run with tornado

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1629,6 +1629,7 @@ class JupyterHub(Application):
     @classmethod
     def launch_instance(cls, argv=None):
         self = cls.instance()
+        IOLoop.configure('tornado.platform.asyncio.AsyncIOLoop')
         loop = IOLoop.current()
         loop.add_callback(self.launch_instance_async, argv)
         try:

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -31,6 +31,8 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.log import app_log, access_log, gen_log
 import tornado.options
 from tornado import gen, web
+from tornado.platform.asyncio import AsyncIOMainLoop
+AsyncIOMainLoop().install()
 
 from traitlets import (
     Unicode, Integer, Dict, TraitError, List, Bool, Any,
@@ -1629,7 +1631,6 @@ class JupyterHub(Application):
     @classmethod
     def launch_instance(cls, argv=None):
         self = cls.instance()
-        IOLoop.configure('tornado.platform.asyncio.AsyncIOLoop')
         loop = IOLoop.current()
         loop.add_callback(self.launch_instance_async, argv)
         try:


### PR DESCRIPTION
This allowed me to use a library that used asyncio (asyncssh) to work with tornado. I'm not aware of any negative effects. This is one of two ways to use the asyncio event loop, maybe we would rather use the asyncio event loop instead as such:

```
     def launch_instance(cls, argv=None):
         self = cls.instance()
         AsyncIOMainLoop().install()
         loop = asyncio.get_event_loop()
         loop.add_callback(self.launch_instance_async, argv)
         try:
             loop.run_forever()
         except KeyboardInterrupt:
             print("\nInterrupted")
```

Any thoughts?