### PR TITLE
Update reverse proxy config examples

### DIFF
--- a/docs/source/reference/config-examples.md
+++ b/docs/source/reference/config-examples.md
@@ -117,6 +117,8 @@ The **`nginx` server config file** is fairly standard fare except for the two
 
 ```bash
 # top-level http config for websocket headers
+# If Upgrade is defined, Connection = upgrade
+# If Upgrade is empty, Connection = close
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
@@ -193,6 +195,7 @@ server {
     ssl on;
 
     # INSERT OTHER SSL PARAMETERS HERE AS ABOVE
+    # SSL cert may differ
 
     # Set the appropriate root directory
     root /var/www/html
@@ -224,7 +227,12 @@ First, we will need to enable the apache modules that we are going to need:
 a2enmod ssl rewrite proxy proxy_http proxy_wstunnel
 ```
 
-Our Apache configuration listes
+Our Apache configuration is equivalent to the nginx configuration above:
+
+- Redirect HTTP to HTTPS
+- Good SSL Configuration
+- Support for websockets on any proxied URL
+- JupyterHub is running locally at http://127.0.0.1:8000
 
 ```bash
 # redirect HTTP to HTTPS

--- a/docs/source/reference/config-examples.md
+++ b/docs/source/reference/config-examples.md
@@ -103,6 +103,13 @@ Let's start out with needed JupyterHub configuration in `jupyterhub_config.py`:
 c.JupyterHub.ip = '127.0.0.1'
 ```
 
+For high-quality SSL configuration, we also generate Diffie-Helman parameters.
+This can take a few minutes:
+
+```bash
+openssl dhparam -out /etc/ssl/certs/dhparam.pem 4096
+```
+
 The **`nginx` server config file** is fairly standard fare except for the two
 `location` blocks within the `HUB.DOMAIN.TLD` config file:
 

--- a/docs/source/reference/config-examples.md
+++ b/docs/source/reference/config-examples.md
@@ -109,24 +109,24 @@ The **`nginx` server config file** is fairly standard fare except for the two
 ```bash
 # HTTP server to redirect all 80 traffic to SSL/HTTPS
 server {
-	listen 80;
-	server_name HUB.DOMAIN.TLD;
+    listen 80;
+    server_name HUB.DOMAIN.TLD;
 
-	# Tell all requests to port 80 to be 302 redirected to HTTPS
-	return 302 https://$host$request_uri;
+    # Tell all requests to port 80 to be 302 redirected to HTTPS
+    return 302 https://$host$request_uri;
 }
 
 # HTTPS server to handle JupyterHub
 server {
-	listen 443;
-	ssl on;
+    listen 443;
+    ssl on;
 
-	server_name HUB.DOMAIN.TLD;
+    server_name HUB.DOMAIN.TLD;
 
-	ssl_certificate /etc/letsencrypt/live/HUB.DOMAIN.TLD/fullchain.pem;
-	ssl_certificate_key /etc/letsencrypt/live/HUB.DOMAIN.TLD/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/HUB.DOMAIN.TLD/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/HUB.DOMAIN.TLD/privkey.pem;
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/ssl/certs/dhparam.pem;
     ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
@@ -136,31 +136,31 @@ server {
     ssl_stapling_verify on;
     add_header Strict-Transport-Security max-age=15768000;
 
-	# Managing literal requests to the JupyterHub front end
-	location / {
-		proxy_pass https://127.0.0.1:8000;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header Host $host;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # Managing literal requests to the JupyterHub front end
+    location / {
+        proxy_pass https://127.0.0.1:8000;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-	# Managing WebHook/Socket requests between hub user servers and external proxy
+    # Managing WebHook/Socket requests between hub user servers and external proxy
     location ~* /(api/kernels/[^/]+/(channels|iopub|shell|stdin)|terminals/websocket)/? {
-		proxy_pass https://127.0.0.1:8000;
+        proxy_pass https://127.0.0.1:8000;
 
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header Host $host;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		# WebSocket support
-		proxy_http_version 1.1;
-		proxy_set_header Upgrade $http_upgrade;
-		proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
 
     }
 
-	# Managing requests to verify letsencrypt host
+    # Managing requests to verify letsencrypt host
     location ~ /.well-known {
-		allow all;
+        allow all;
     }
 
 
@@ -178,30 +178,30 @@ of the site as well as the applicable location call:
 
 ```bash
 server {
-	listen 80;
-	server_name NO_HUB.DOMAIN.TLD;
+    listen 80;
+    server_name NO_HUB.DOMAIN.TLD;
 
-	# Tell all requests to port 80 to be 302 redirected to HTTPS
-	return 302 https://$host$request_uri;
+    # Tell all requests to port 80 to be 302 redirected to HTTPS
+    return 302 https://$host$request_uri;
 }
 
 server {
-	listen 443;
-	ssl on;
+    listen 443;
+    ssl on;
 
-	# INSERT OTHER SSL PARAMETERS HERE AS ABOVE
+    # INSERT OTHER SSL PARAMETERS HERE AS ABOVE
 
-	# Set the appropriate root directory
-	root /var/www/html
+    # Set the appropriate root directory
+    root /var/www/html
 
-	# Set URI handling
-	location / {
-		try_files $uri $uri/ =404;
-	}
+    # Set URI handling
+    location / {
+        try_files $uri $uri/ =404;
+    }
 
-	# Managing requests to verify letsencrypt host
+    # Managing requests to verify letsencrypt host
     location ~ /.well-known {
-		allow all;
+        allow all;
     }
 
 }


### PR DESCRIPTION
- Strip some tab chars that had gotten into the nginx config
- Update nginx to simpler configuration that doesn't need to know which URLs will have websockets
- Add working Apache configuration, equivalent to the nginx config (minus NO_HUB bits)

cc @willingc