### PR TITLE
[doc] typo in auth_state structure

### DIFF
--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -190,7 +190,7 @@ class MyAuthenticator(Authenticator):
         username = yield identify_user(handler, data)
         upstream_token = yield token_for_user(username)
         return {
-            'username': username,
+            'name': username,
             'auth_state': {
                 'upstream_token': upstream_token,
             },


### PR DESCRIPTION
it's 'name' not 'username'