### PR TITLE
Change username input type to "text" to fix auto-filling

### DIFF
--- a/share/jupyter/hub/templates/login.html
+++ b/share/jupyter/hub/templates/login.html
@@ -35,7 +35,7 @@
     <label for="username_input">Username:</label>
     <input
       id="username_input"
-      type="username"
+      type="text"
       autocapitalize="off"
       autocorrect="off"
       class="form-control"


### PR DESCRIPTION
According to the [HTML spec](https://www.w3.org/TR/html5/forms.html#attr-input-type), `type="username"` isn't a valid type for an `<input>` element.

Because of this, Firefox doesn't recognize it when saving and auto-filling credentials - only the password field is saved.

I have changed it to `type="text"`, which fixes the issue.