### PR TITLE
Replace forward slashes in CILogon oauth id for cookie

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -402,7 +402,7 @@ class HubOAuth(HubAuth):
         because we don't want to use the same cookie name
         across OAuth clients.
         """
-        return self.oauth_client_id
+        return self.oauth_client_id.replace('/','')
 
     @property
     def state_cookie_name(self):


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/oauthenticator/issues/132

I mostly implemented this to check it really worked...

If you have a suggestion on a more general way to fix this, I can improve this patch.