### PR TITLE
[doc] Updated the rest docs to about change in 0.8

### DIFF
--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -114,10 +114,12 @@ r.raise_for_status()
 r.json()
 ```
 
-Note that the API token authorizes **JupyterHub** REST API requests. The same
-token does **not** authorize access to the [Jupyter Notebook REST API][]
-provided by notebook servers managed by JupyterHub. A different token is used
-to access the **Jupyter Notebook** API.
+The same API token can also authorize access to the [Jupyter Notebook REST API][]
+provided by notebook servers managed by JupyterHub.
+To do so, the following must be true:
+
+1. The token used is tied to an admin user or service
+2. `c.JupyterHub.admin_access` must be set to `True`
 
 ## Enabling users to spawn multiple named-servers via the API
 

--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -115,11 +115,10 @@ r.json()
 ```
 
 The same API token can also authorize access to the [Jupyter Notebook REST API][]
-provided by notebook servers managed by JupyterHub.
-To do so, the following must be true:
+provided by notebook servers managed by JupyterHub if one of the following is true:
 
-1. The token used is tied to an admin user or service
-2. `c.JupyterHub.admin_access` must be set to `True`
+1. The token is for the same user as the owner of the notebook
+2. The token is tied to an admin user or service **and** `c.JupyterHub.admin_access` is set to `True`
 
 ## Enabling users to spawn multiple named-servers via the API
 


### PR DESCRIPTION
In 0.8, the jupyterhub api token can also be used to make requests to
the jupyter notebook given some conditions. This PR updates that
documentation