### PR TITLE
add `jupyterhub --upgrade-db` to trigger upgrade on launch

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -103,7 +103,7 @@ flags = {
         """Automatically upgrade the database if needed on startup.
 
         Only safe if the database has been backed up.
-        sqlite database files will be backed up automatically.
+        Only SQLite database files will be backed up automatically.
         """
     ),
     'no-ssl': ({'JupyterHub': {'confirm_no_ssl': True}},
@@ -617,7 +617,7 @@ class JupyterHub(Application):
         help="""Upgrade the database automatically on start.
 
         Only safe if database is regularly backed up.
-        sqlite databases will be backed up to a local file automatically.
+        Only SQLite databases will be backed up to a local file automatically.
     """).tag(config=True)
     reset_db = Bool(False,
         help="Purge and reset the database."

--- a/jupyterhub/dbutil.py
+++ b/jupyterhub/dbutil.py
@@ -5,10 +5,16 @@
 # Based on pgcontents.utils.migrate, used under the Apache license.
 
 from contextlib import contextmanager
+from datetime import datetime
 import os
+import shutil
 from subprocess import check_call
 import sys
 from tempfile import TemporaryDirectory
+
+from sqlalchemy import create_engine
+
+from . import orm
 
 _here = os.path.abspath(os.path.dirname(__file__))
 
@@ -82,6 +88,46 @@ def upgrade(db_url, revision='head'):
         check_call(
             ['alembic', '-c', alembic_ini, 'upgrade', revision]
         )
+
+
+def backup_db_file(db_file, log=None):
+    """Backup a database file if it exists"""
+    timestamp = datetime.now().strftime('.%Y-%m-%d-%H%M%S')
+    backup_db_file = db_file + timestamp
+    for i in range(1, 10):
+        if not os.path.exists(backup_db_file):
+            break
+        backup_db_file = '{}.{}.{}'.format(db_file, timestamp, i)
+    #
+    if os.path.exists(backup_db_file):
+        raise OSError("backup db file already exists: %s" % backup_db_file)
+    if log:
+        log.info("Backing up %s => %s", db_file, backup_db_file)
+    shutil.copy(db_file, backup_db_file)
+
+
+def upgrade_if_needed(db_url, backup=True, log=None):
+    """Upgrade a database if needed
+
+    If the database is sqlite, a backup file will be created with a timestamp.
+    Other database systems should perform their own backups prior to calling this.
+    """
+    # run check-db-revision first
+    engine = create_engine(db_url)
+    try:
+        orm.check_db_revision(engine)
+    except orm.DatabaseSchemaMismatch:
+        # ignore mismatch error because that's what we are here for!
+        pass
+    else:
+        # nothing to do
+        return
+    log.info("Upgrading %s", db_url)
+    # we need to upgrade, backup the database
+    if backup and db_url.startswith('sqlite:///'):
+        db_file = db_url.split(':///', 1)[1]
+        backup_db_file(db_file, log=log)
+    upgrade(db_url)
 
 
 def _alembic(*args):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -24,7 +24,6 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.expression import bindparam
 from sqlalchemy import create_engine, Table
 
-from .dbutil import _temp_alembic_ini
 from .utils import (
     random_port,
     new_token, hash_token, compare_token,
@@ -462,6 +461,8 @@ def check_db_revision(engine):
     # Check database schema version
     current_table_names = set(engine.table_names())
     my_table_names = set(Base.metadata.tables.keys())
+
+    from .dbutil import _temp_alembic_ini
 
     with _temp_alembic_ini(engine.url) as ini:
         cfg = alembic.config.Config(ini)


### PR DESCRIPTION
Upgrades the database (if needed) on start.

This is opt-in, for uses like the helm chart where explicit 'upgrade-db' steps are hard to insert.

This ought to be safe for sqlite users, where an automatic backup file is created *if an upgrade will occur*.

closes #1506