### PR TITLE
Update docs and examples for the slash at the end of the prefix

### DIFF
--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -178,7 +178,13 @@ When you run a service that has a url, it will be accessible under a
 your service to route proxied requests properly, it must take
 `JUPYTERHUB_SERVICE_PREFIX` into account when routing requests. For example, a
 web service would normally service its root handler at `'/'`, but the proxied
-service would need to serve `JUPYTERHUB_SERVICE_PREFIX + '/'`.
+service would need to serve `JUPYTERHUB_SERVICE_PREFIX`.
+
+Note that `JUPYTERHUB_SERVICE_PREFIX` will contain a trailing slash. This must
+be taken into consideration when creating the service routes. If you include an
+extra slash you might get unexpected behavior. For example if your service has a
+`/foo` endpoint, the route would be `JUPYTERHUB_SERVICE_PREFIX + foo`, and
+`/foo/bar` would be `JUPYTERHUB_SERVICE_PREFIX + foo/bar`.
 
 ## Hub Authentication and Services
 
@@ -269,7 +275,7 @@ def authenticated(f):
     return decorated
 
 
-@app.route(prefix + '/')
+@app.route(prefix)
 @authenticated
 def whoami(user):
     return Response(

--- a/examples/service-whoami-flask/README.md
+++ b/examples/service-whoami-flask/README.md
@@ -8,7 +8,7 @@ Uses `jupyterhub.services.HubAuth` to authenticate requests with the Hub in a [f
 
         jupyterhub --ip=127.0.0.1
 
-2. Visit http://127.0.0.1:8000/services/whoami or http://127.0.0.1:8000/services/whoami-oauth
+2. Visit http://127.0.0.1:8000/services/whoami/ or http://127.0.0.1:8000/services/whoami-oauth/
 
 After logging in with your local-system credentials, you should see a JSON dump of your user info:
 

--- a/examples/service-whoami-flask/whoami-flask.py
+++ b/examples/service-whoami-flask/whoami-flask.py
@@ -43,7 +43,7 @@ def authenticated(f):
     return decorated
 
 
-@app.route(prefix + '/')
+@app.route(prefix)
 @authenticated
 def whoami(user):
     return Response(


### PR DESCRIPTION
As per a conversation in gitter, here is some updated docs and examples that reflect a change made to the `JUPYTERHUB_SERVICE_PREFIX` variable where it used to not have a trailing slash, but it now does.

If slashes were added in then sometimes the route would be broken. This makes it very clear to not to do that.