### PR TITLE
"Start All" button on admin page

### DIFF
--- a/share/jupyter/hub/static/js/admin.js
+++ b/share/jupyter/hub/static/js/admin.js
@@ -172,9 +172,25 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
         $("#stop-all-servers-dialog").modal();
     });
 
+    $("#start-all-servers").click(function () {
+        $("#start-all-servers-dialog").modal();
+    });
+
     $("#stop-all-servers-dialog").find(".stop-all-button").click(function () {
         // stop all clicks all the active stop buttons
         $('.stop-server').not('.hidden').click();
+    });
+
+    function start(el) {
+        return function(){
+            $(el).click();
+        }
+    }
+
+    $("#start-all-servers-dialog").find(".start-all-button").click(function () {
+        $('.start-server').not('.hidden').each(function(i){
+           setTimeout(start(this), i * 500);
+        });
     });
 
     $("#shutdown-hub").click(function () {

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -33,7 +33,10 @@
       <tr class="user-row add-user-row">
         <td colspan="12">
           <a id="add-users" role="button" class="col-xs-2 btn btn-default">Add Users</a>
-          <a id="stop-all-servers" role="button" class="col-xs-2 col-xs-offset-5 btn btn-danger">Stop All</a>
+          <span class="col-xs-offset-5 col-xs-2">
+            <a id="start-all-servers" role="button" class="btn btn-success" style="width: 100%; margin-bottom: 10px;">Start All</a>
+            <a id="stop-all-servers" role="button" class="btn btn-danger" style="width: 100%;">Stop All</a>
+          </span>
           <a id="shutdown-hub" role="button" class="col-xs-2 col-xs-offset-1 btn btn-danger">Shutdown Hub</a>
         </td>
       </tr>
@@ -74,6 +77,10 @@
 
 {% call modal('Stop All Servers', btn_label='Stop All', btn_class='btn-danger stop-all-button') %}
   Are you sure you want to stop all your users' servers? Kernels will be shutdown and unsaved data may be lost.
+{% endcall %}
+
+{% call modal('Start All Servers', btn_label='Start All', btn_class='btn-success start-all-button') %}
+  Are you sure you want to start all servers? This can slam your server resources.
 {% endcall %}
 
 {% call modal('Shutdown Hub', btn_label='Shutdown', btn_class='btn-danger shutdown-button') %}

--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -33,9 +33,9 @@
       <tr class="user-row add-user-row">
         <td colspan="12">
           <a id="add-users" role="button" class="col-xs-2 btn btn-default">Add Users</a>
-          <span class="col-xs-offset-5 col-xs-2">
-            <a id="start-all-servers" role="button" class="btn btn-success" style="width: 100%; margin-bottom: 10px;">Start All</a>
-            <a id="stop-all-servers" role="button" class="btn btn-danger" style="width: 100%;">Stop All</a>
+          <span class="col-xs-offset-4 col-xs-3">
+            <a id="start-all-servers" role="button" class="btn btn-success col-xs-5 col-xs-offset-1">Start All</a>
+            <a id="stop-all-servers" role="button" class="btn btn-danger col-xs-5 col-xs-offset-1">Stop All</a>
           </span>
           <a id="shutdown-hub" role="button" class="col-xs-2 col-xs-offset-1 btn btn-danger">Shutdown Hub</a>
         </td>


### PR DESCRIPTION
A companion to the "Stop All" button on the admin page. 

Our use case: an instructor uses this to turn on everyone's resources in advance of a workshop, so when a student logs in, their environment is set up, provisioned, and ready to go (this is especially important in our k8s case where we want to make sure to allocate via autoscaling, seed some material on to everyone's disks, etc.).

A couple points:
- The current implementation clicks all visible "Start" buttons (mirroring the "Stop All" implementation)
- It waits 500ms before clicking the next one, to mitigate server load. Should this be a configurable variable?*
- Visual feedback is provided as each "Start" button is clicked.
- HTML button layout: I left things janky so it's easier to play with, in case you guys have a better layout in mind (I'm not in love with the vertical stacking... maybe if I vertical-centered the buttons...)

*I guess I'd template it in to the HTML and have the JS pick it up or something?

As discussed with @yuvipanda 