### PR TITLE
fix headers for CORS

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -18,14 +18,14 @@ class APIHandler(BaseHandler):
         return '; '.join([super().content_security_policy, "default-src 'none'"])
 
     def set_default_headers(self):
-        self.set_header('Content-Type', 'application/json')
         super().set_default_headers()
+        self.set_header('Content-Type', 'application/json')
 
     def check_referer(self):
         """Check Origin for cross-site API requests.
-        
+
         Copied from WebSocket with changes:
-        
+
         - allow unspecified host/referer (e.g. scripts)
         """
         host = self.request.headers.get("Host")
@@ -39,7 +39,7 @@ class APIHandler(BaseHandler):
         if not referer:
             self.log.warning("Blocking API request with no referer")
             return False
-        
+
         host_path = url_path_join(host, self.hub.base_url)
         referer_path = referer.split('://', 1)[-1]
         if not (referer_path + '/').startswith(host_path):
@@ -47,7 +47,7 @@ class APIHandler(BaseHandler):
                 referer, host_path)
             return False
         return True
-    
+
     def get_current_user_cookie(self):
         """Override get_user_cookie to check Referer header"""
         cookie_user = super().get_current_user_cookie()
@@ -178,5 +178,4 @@ class APIHandler(BaseHandler):
 
 
     def options(self, *args, **kwargs):
-        self.set_header('Access-Control-Allow-Headers', 'accept, content-type')
         self.finish()

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from jinja2 import TemplateNotFound
 
 from tornado.log import app_log
-from tornado.httputil import url_concat
+from tornado.httputil import url_concat, HTTPHeaders
 from tornado.ioloop import IOLoop
 from tornado.web import RequestHandler
 from tornado import gen, web
@@ -131,12 +131,15 @@ class BaseHandler(RequestHandler):
 
         By default sets Content-Security-Policy of frame-ancestors 'self'.
         """
-        headers = self.settings.get('headers', {})
+        # wrap in HTTPHeaders for case-insensitivity
+        headers = HTTPHeaders(self.settings.get('headers', {}))
         headers.setdefault("X-JupyterHub-Version", __version__)
 
         for header_name, header_content in headers.items():
             self.set_header(header_name, header_content)
 
+        if 'Access-Control-Allow-Headers' not in headers:
+            self.set_header('Access-Control-Allow-Headers', 'accept, content-type, authorization')
         if 'Content-Security-Policy' not in headers:
             self.set_header('Content-Security-Policy', self.content_security_policy)
 


### PR DESCRIPTION
- add `authorization` to default `Access-Control-Allow-Headers`
- allow overriding `Access-Control-Allow-Headers` just like everything else
- ensure case-insensitive comparison for proper header checks

With this fix, config to enable token-authenticated cross-origin requests on both the Hub itself and running notebooks

```python
origin = 'http://localhost:9999'

c.Spawner.args = [f'--NotebookApp.allow_origin={origin}']
c.JupyterHub.tornado_settings = {
    'headers': {
        'Access-Control-Allow-Origin': origin,
    },
}
```

And [an example](https://gist.github.com/minrk/924ef40af06cae06116c1c7b60b963e3) of a page that does cross-origin access of both the notebook server and Hub, for testing.

cf #1087