### PR TITLE
allow override of cookie options

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -265,6 +265,8 @@ class BaseHandler(RequestHandler):
             kwargs['secure'] = True
         if self.subdomain_host:
             kwargs['domain'] = self.domain
+
+        kwargs.update(self.settings.get('cookie_options', {}))
         self.log.debug("Setting cookie for %s: %s, %s", user.name, server.cookie_name, kwargs)
         self.set_secure_cookie(
             server.cookie_name,


### PR DESCRIPTION
via `tornado_settings['cookie_options']`

for cases where default options are incorrect or insufficient (e.g. expiry or https detection fails)

@psyvision this is me punting on #1477, giving you an escape hatch for when the default cookie options are wrong, rather than coming up with a more robust detection for https.