### PR TITLE
add jupyter-alabaster-theme to doc requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 -r ../requirements.txt
 sphinx>=1.4
 recommonmark==0.4.0
+jupyter-alabaster-theme==0.4.0


### PR DESCRIPTION
Resolve missing requirement when attempting to build docs.   #1549 