### PR TITLE
Add super() calls to child script blocks

### DIFF
--- a/share/jupyter/hub/templates/admin.html
+++ b/share/jupyter/hub/templates/admin.html
@@ -118,6 +118,7 @@
 {% endblock %}
 
 {% block script %}
+{{ super() }}
 <script type="text/javascript">
 require(["admin"]);
 </script>

--- a/share/jupyter/hub/templates/home.html
+++ b/share/jupyter/hub/templates/home.html
@@ -21,6 +21,7 @@
 {% endblock %}
 
 {% block script %}
+{{ super() }}
 <script type="text/javascript">
 require(["home"]);
 </script>

--- a/share/jupyter/hub/templates/login.html
+++ b/share/jupyter/hub/templates/login.html
@@ -69,8 +69,7 @@
 {% endblock %}
 
 {% block script %}
-{{super()}}
-
+{{ super() }}
 <script>
 if (window.location.protocol === "http:") {
   // unhide http warning

--- a/share/jupyter/hub/templates/spawn_pending.html
+++ b/share/jupyter/hub/templates/spawn_pending.html
@@ -16,6 +16,7 @@
 {% endblock %}
 
 {% block script %}
+{{ super() }}
 <script type="text/javascript">
 require(["jquery"], function ($) {
   $("#refresh").click(function () {

--- a/share/jupyter/hub/templates/token.html
+++ b/share/jupyter/hub/templates/token.html
@@ -34,6 +34,7 @@
 {% endblock %}
 
 {% block script %}
+{{ super() }}
 <script type="text/javascript">
 require(["token"]);
 </script>


### PR DESCRIPTION
This helps to address https://github.com/jupyterhub/jupyterhub/issues/1481 by adding [`super()`](http://jinja.pocoo.org/docs/2.10/templates/#super-blocks) blocks to script blocks in child templates of `page.html`.