### PR TITLE
Allow Authenticators to return an `admin` flag for users.

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -235,6 +235,7 @@ class Authenticator(LoggingConfigurable):
                 'name': authenticated,
             }
         authenticated.setdefault('auth_state', None)
+        authenticated.setdefault('admin', None)
 
         # normalize the username
         authenticated['name'] = username = self.normalize_username(authenticated['name'])
@@ -269,10 +270,10 @@ class Authenticator(LoggingConfigurable):
         Returns:
             user (str or dict or None): The username of the authenticated user,
                 or None if Authentication failed.
-                If the Authenticator has state associated with the user,
-                it can return a dict with the keys 'name' and 'auth_state',
-                where 'name' is the username and 'auth_state' is a dictionary
-                of auth state that will be persisted.
+                The Authenticator may return a dict instead, which MUST have a
+                key 'name' holding the username, and may have two optional keys
+                set - 'auth_state', a dictionary of of auth state that will be
+                persisted; and 'admin', the admin setting value for the user.
         """
 
     def pre_spawn_start(self, user, spawner):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -336,7 +336,11 @@ class BaseHandler(RequestHandler):
         if authenticated:
             username = authenticated['name']
             auth_state = authenticated.get('auth_state')
+            admin = authenticated.get('admin')
             user = self.user_from_username(username)
+            # Only set `admin` if the authenticator returned an explicit value.
+            if admin is not None:
+                user.admin = admin
             # always set auth_state and commit,
             # because there could be key-rotation or clearing of previous values
             # going on.

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -339,8 +339,9 @@ class BaseHandler(RequestHandler):
             admin = authenticated.get('admin')
             user = self.user_from_username(username)
             # Only set `admin` if the authenticator returned an explicit value.
-            if admin is not None:
+            if admin is not None and admin != user.admin:
                 user.admin = admin
+                self.db.commit()
             # always set auth_state and commit,
             # because there could be key-rotation or clearing of previous values
             # going on.

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -138,6 +138,8 @@ class FormSpawner(MockSpawner):
 
 class MockPAMAuthenticator(PAMAuthenticator):
     auth_state = None
+    # If true, return admin users marked as admin.
+    return_admin = False
     @default('admin_users')
     def _admin_users_default(self):
         return {'admin'}
@@ -160,6 +162,11 @@ class MockPAMAuthenticator(PAMAuthenticator):
             return {
                 'name': username,
                 'auth_state': self.auth_state,
+            }
+        elif self.return_admin:
+            return {
+                'name': username,
+                'admin': username in self.admin_users,
             }
         else:
             return username


### PR DESCRIPTION
This lets an Authenticator control admin access without the use of the `admin_users` set (although that can still be used to grant admin access).

This would allow adding features like requested in #888 .

I specifically want this for an OAuth authenticator which would grant admin access to users in a particular OAuth group.