### PR TITLE
remove pytest-catchlog in favor of recent pytest

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,9 +2,8 @@
 mock
 codecov
 cryptography
-pytest-catchlog
 pytest-cov
 pytest-tornado
-pytest>=2.8
+pytest>=3.3
 notebook
 requests-mock


### PR DESCRIPTION
pytest-catchlog fixtures have been merged into pytest as of pytest 3.3

cc @willingc who asked about the recent addition of pytest-catchlog in #1560