### PR TITLE
add session-id cookie

### DIFF
--- a/jupyterhub/alembic/env.py
+++ b/jupyterhub/alembic/env.py
@@ -30,10 +30,7 @@ if 'jupyterhub' in sys.modules:
 else:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
+# add your model's MetaData object here for 'autogenerate' support
 from jupyterhub import orm
 target_metadata = orm.Base.metadata
 

--- a/jupyterhub/alembic/env.py
+++ b/jupyterhub/alembic/env.py
@@ -34,7 +34,8 @@ else:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = None
+from jupyterhub import orm
+target_metadata = orm.Base.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
+++ b/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
@@ -29,8 +29,8 @@ def add_column_if_table_exists(table, column):
         ctx = op.get_context()
         try:
             ctx.execute('SELECT 1 FROM {table} LIMIT 1'.format(table=table))
-        except (sa.exc.OperationalError, sa.exc.ProgrammingError) as e2:
-            if e.args == e2.args:
+        except Exception as e2:
+            if type(e) is type(e2) and e.args == e2.args:
                 # table doesn't exist, no need to upgrade
                 # because jupyterhub will create it on launch
                 logger.warning("Skipping upgrade of absent table: %s" % e)

--- a/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
+++ b/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
@@ -12,14 +12,37 @@ down_revision = '3ec6993fe20c'
 branch_labels = None
 depends_on = None
 
+import logging
+logger = logging.getLogger('alembic')
+
 from alembic import op
 import sqlalchemy as sa
 
 tables = ('oauth_access_tokens', 'oauth_codes')
 
+def add_column_if_table_exists(table, column):
+    try:
+        op.add_column(table, column)
+    except (sa.exc.OperationalError, sa.exc.ProgrammingError) as e:
+        # check if it failed because the table doesn't exist
+        # if that's the case, do nothing
+        ctx = op.get_context()
+        try:
+            ctx.execute('SELECT 1 FROM {table} LIMIT 1'.format(table=table))
+        except (sa.exc.OperationalError, sa.exc.ProgrammingError) as e2:
+            if e.args == e2.args:
+                # table doesn't exist, no need to upgrade
+                # because jupyterhub will create it on launch
+                logger.warning("Skipping upgrade of absent table: %s" % e)
+                return
+        # if we got here, adding column failed, but selecting from the table succeeded
+        # it was a real error
+        raise
+
 def upgrade():
+    ctx = op.get_context()
     for table in tables:
-        op.add_column(table, sa.Column('session_id', sa.Unicode(255)))
+        add_column_if_table_exists(table, sa.Column('session_id', sa.Unicode(255)))
 
 
 def downgrade():

--- a/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
+++ b/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
@@ -1,0 +1,28 @@
+"""Add session_id to auth tokens
+
+Revision ID: 1cebaf56856c
+Revises: 3ec6993fe20c
+Create Date: 2017-12-07 14:43:51.500740
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1cebaf56856c'
+down_revision = '3ec6993fe20c'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+tables = ('oauth_access_tokens', 'oauth_codes')
+
+def upgrade():
+    for table in tables:
+        op.add_column(table, sa.Column('session_id', sa.Unicode(255)))
+
+
+def downgrade():
+    # sqlite cannot downgrade because of limited ALTER TABLE support (no DROP COLUMN)
+    for table in tables:
+        op.drop_column(table, 'session_id')

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -264,7 +264,7 @@ class BaseHandler(RequestHandler):
         session_id = self.get_session_cookie()
         if session_id:
             # clear session id
-            self.clear_cookie(SESSION_COOKIE_NAME)
+            self.clear_cookie(SESSION_COOKIE_NAME, **kwargs)
 
             if user:
                 # user is logged in, clear any tokens associated with the current session
@@ -285,7 +285,8 @@ class BaseHandler(RequestHandler):
 
         # clear hub cookie
         self.clear_cookie(self.hub.cookie_name, path=self.hub.base_url, **kwargs)
-        self.clear_cookie('jupyterhub-services', path=url_path_join(self.base_url, 'services'))
+        # clear services cookie
+        self.clear_cookie('jupyterhub-services', path=url_path_join(self.base_url, 'services'), **kwargs)
 
     def _set_cookie(self, key, value, encrypted=True, **overrides):
         """Setting any cookie should go through here

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -412,10 +412,13 @@ class OAuthAccessToken(Hashed, Base):
     user = relationship(User)
     service = None # for API-equivalence with APIToken
 
+    # the browser session id associated with a given token
+    session_id = Column(Unicode(255))
+
     # from Hashed
     hashed = Column(Unicode(255), unique=True)
     prefix = Column(Unicode(16), index=True)
-    
+
     def __repr__(self):
         return "<{cls}('{prefix}...', user='{user}'>".format(
             cls=self.__class__.__name__,
@@ -431,6 +434,7 @@ class OAuthCode(Base):
     code = Column(Unicode(36))
     expires_at = Column(Integer)
     redirect_uri = Column(Unicode(1023))
+    session_id = Column(Unicode(255))
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -57,6 +57,17 @@ class _ExpiringDict(dict):
         self.timestamps[key] = time.monotonic()
         self.values[key] = value
 
+    def __repr__(self):
+        """include values and timestamps in repr"""
+        now = time.monotonic()
+        return repr({
+            key: '{value} (age={age:.0f}s)'.format(
+                value=repr(value)[:16] + '...',
+                age=now-self.timestamps[key],
+            )
+            for key, value in self.values.items()
+        })
+
     def _check_age(self, key):
         """Check timestamp for a key"""
         if key not in self.values:

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -29,7 +29,7 @@ from tornado.log import app_log
 from tornado.httputil import url_concat
 from tornado.web import HTTPError, RequestHandler
 
-from traitlets.config import Configurable
+from traitlets.config import SingletonConfigurable
 from traitlets import Unicode, Integer, Instance, default, observe, validate
 
 from ..utils import url_path_join
@@ -97,7 +97,7 @@ class _ExpiringDict(dict):
             return default
 
 
-class HubAuth(Configurable):
+class HubAuth(SingletonConfigurable):
     """A class for authenticating with JupyterHub
 
     This can be used by any application.
@@ -699,7 +699,7 @@ class HubAuthenticated(object):
     @property
     def hub_auth(self):
         if self._hub_auth is None:
-            self._hub_auth = self.hub_auth_class()
+            self._hub_auth = self.hub_auth_class.instance()
         return self._hub_auth
 
     @hub_auth.setter


### PR DESCRIPTION
session cookie is stored cleartext, domain-wide. It contains nothing but a UUID. All services can read the session ID. The session ID serves two purposes, which are related in purpose, but mostly unrelated technically (i.e. it's fine to use one without the other):

1. Hub-side, OAuth tokens are associated with a session id. When a user logs out with the Hub, all tokens with that session id are revoked, and the session id is cleared. This closes #1491.
2. service-side, session id, if present, is added to the auth cache key. If session id changes, even if the auth cookie doesn't, the Hub will be asked again. This should result in the above revocation taking immediate effect, rather than waiting for cache expiry.

If I have done this right, this should be implemented in a backward-compatible way in both directions. If single-user servers are v0.8.0 and do not have session-id cache keys, the only consequence is that revoked tokens take cache_max_age to expire (same as now). Similarly, if newer single-user servers are used with older Hubs, session id will always be empty and revoked tokens will take cache_max_age to expire.

A caveat: Right now, it is not possible for external services (i.e. those not on `/services/`) to use OAuth with the Hub. This is a mostly artificial limitation at this point (there is currently no way to register an oauth client with a URL outside the Hub's domain). However, the service-side part of this logic *cannot* be used by servers on other domains without third-party cookie shenanigans that I think we shouldn't attempt. They will always behave the same as now, where tokens take cache_max_age to expire and cannot be revoked immediately.

Closes #1491