### PR TITLE
remove , which was turning timestamp into tuple

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1308,7 +1308,7 @@ class JupyterHub(Application):
         if os.path.isdir(os.path.join(parent, '.git')):
             version_hash = ''
         else:
-            version_hash = datetime.now().strftime("%Y%m%d%H%M%S"),
+            version_hash = datetime.now().strftime("%Y%m%d%H%M%S")
 
         settings = dict(
             log_function=log_request,


### PR DESCRIPTION
I noticed that the browser was caching static files for Jupyterhub, and when I opened the chrome inspector I noticed that the timestamp that's supposed to prevent caching was getting set to something else `(%`.

![screen shot 2017-12-07 at 11 19 18 am](https://user-images.githubusercontent.com/12725384/33734713-24bf0ace-db42-11e7-9f60-34b2b9582ade.png)

It turns out that there was an extra `,` which was turning the timestamp into a tuple. With the fix:

![screen shot 2017-12-07 at 11 19 40 am](https://user-images.githubusercontent.com/12725384/33734762-3687ddf8-db42-11e7-976c-8bf813e5efec.png)