### PR TITLE
Add RED prometheus metrics for all requests

### DIFF
--- a/jupyterhub/handlers/__init__.py
+++ b/jupyterhub/handlers/__init__.py
@@ -1,8 +1,8 @@
 from .base import *
 from .login import *
 
-from . import base, pages, login
+from . import base, pages, login, metrics
 
 default_handlers = []
-for mod in (base, pages, login):
+for mod in (base, pages, login, metrics):
     default_handlers.extend(mod.default_handlers)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -390,7 +390,7 @@ class BaseHandler(RequestHandler):
     @gen.coroutine
     def spawn_single_user(self, user, server_name='', options=None):
         # in case of error, include 'try again from /hub/home' message
-        spawn_starttime = time.perf_counter()
+        spawn_start_time = time.perf_counter()
         self.extra_error_html = self.spawn_home_error
 
         user_server_name = user.name
@@ -403,7 +403,7 @@ class BaseHandler(RequestHandler):
             SPAWN_DURATION_SECONDS.labels(
                 status='already-pending'
             ).observe(
-                time.perf_counter() - spawn_starttime
+                time.perf_counter() - spawn_start_time
             )
             raise RuntimeError("%s pending %s" % (user_server_name, pending))
 
@@ -426,7 +426,7 @@ class BaseHandler(RequestHandler):
             SPAWN_DURATION_SECONDS.labels(
                 status='throttled'
             ).observe(
-                time.perf_counter() - spawn_starttime
+                time.perf_counter() - spawn_start_time
             )
             raise web.HTTPError(
                 429,
@@ -440,7 +440,7 @@ class BaseHandler(RequestHandler):
             SPAWN_DURATION_SECONDS.labels(
                 status='too-many-users'
             ).observe(
-                time.perf_counter() - spawn_starttime
+                time.perf_counter() - spawn_start_time
             )
             raise web.HTTPError(429, "Active user limit exceeded. Try again in a few minutes.")
 
@@ -477,9 +477,9 @@ class BaseHandler(RequestHandler):
             SPAWN_DURATION_SECONDS.labels(
                 status='success'
             ).observe(
-                time.perf_counter() - spawn_starttime
+                time.perf_counter() - spawn_start_time
             )
-            proxy_add_starttime = time.perf_counter()
+            proxy_add_start_time = time.perf_counter()
             spawner._proxy_pending = True
             try:
                 yield self.proxy.add_user(user, server_name)
@@ -487,7 +487,7 @@ class BaseHandler(RequestHandler):
                 PROXY_ADD_DURATION_SECONDS.labels(
                     status='success'
                 ).observe(
-                    time.perf_counter() - proxy_add_starttime
+                    time.perf_counter() - proxy_add_start_time
                 )
             except Exception:
                 self.log.exception("Failed to add %s to proxy!", user_server_name)
@@ -496,7 +496,7 @@ class BaseHandler(RequestHandler):
                 PROXY_ADD_DURATION_SECONDS.labels(
                     status='failure'
                 ).observe(
-                    time.perf_counter() - proxy_add_starttime
+                    time.perf_counter() - proxy_add_start_time
                 )
             else:
                 spawner.add_poll_callback(self.user_stopped, user, server_name)
@@ -537,7 +537,7 @@ class BaseHandler(RequestHandler):
                 SPAWN_DURATION_SECONDS.labels(
                     status='failed'
                 ).observe(
-                    time.perf_counter() - spawn_starttime
+                    time.perf_counter() - spawn_start_time
                 )
                 raise web.HTTPError(500, "Spawner failed to start [status=%s]. The logs for %s may contain details." % (
                     status, spawner._log_name))

--- a/jupyterhub/handlers/metrics.py
+++ b/jupyterhub/handlers/metrics.py
@@ -1,0 +1,17 @@
+from prometheus_client import REGISTRY, CONTENT_TYPE_LATEST, generate_latest
+from tornado import gen
+
+from .base import BaseHandler
+
+class MetricsHandler(BaseHandler):
+    """
+    Handler to serve Prometheus metrics
+    """
+    @gen.coroutine
+    def get(self):
+        self.set_header('Content-Type', CONTENT_TYPE_LATEST)
+        self.write(generate_latest(REGISTRY))
+
+default_handlers = [
+    (r'/metrics$', MetricsHandler)
+]

--- a/jupyterhub/log.py
+++ b/jupyterhub/log.py
@@ -69,6 +69,7 @@ def log_request(handler):
     - get proxied IP instead of proxy IP
     - log referer for redirect and failed requests
     - log user-agent for failed requests
+    - record per-request metrics in prometheus
     """
     status = handler.get_status()
     request = handler.request

--- a/jupyterhub/log.py
+++ b/jupyterhub/log.py
@@ -8,6 +8,7 @@ import traceback
 from tornado.log import LogFormatter, access_log
 from tornado.web import StaticFileHandler, HTTPError
 
+from .metrics import prometheus_log_method
 
 def coroutine_traceback(typ, value, tb):
     """Scrub coroutine frames from a traceback
@@ -120,3 +121,4 @@ def log_request(handler):
         if location:
             ns['location'] = ' → {}'.format(location)
     log_method(msg.format(**ns))
+    prometheus_log_method(handler)

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -9,6 +9,13 @@ REQUEST_DURATION_SECONDS = Histogram(
     ['method', 'handler', 'code']
 )
 
+SPAWN_DURATION_SECONDS = Histogram(
+    'spawn_duration_seconds',
+    'spawn duration for all server spawns',
+    ['status'],
+    buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")]
+)
+
 def prometheus_log_method(handler):
     """
     Tornado log handler for recording RED metrics

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -16,6 +16,8 @@ SPAWN_DURATION_SECONDS = Histogram(
     'spawn_duration_seconds',
     'spawn duration for all server spawns',
     ['status'],
+    # Use custom bucket sizes, since the default bucket ranges
+    # are meant for quick running processes. Spawns can take a while!
     buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")]
 )
 

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -24,7 +24,7 @@ PROXY_ADD_DURATION_SECONDS = Histogram(
 
 def prometheus_log_method(handler):
     """
-    Tornado log handler for recording RED metrics
+    Tornado log handler for recording RED metrics.
 
     We record the following metrics:
        Rate – the number of requests, per second, your services are serving.
@@ -33,6 +33,10 @@ def prometheus_log_method(handler):
 
     We use a fully qualified name of the handler as a label,
     rather than every url path to reduce cardinality.
+
+    This function should be either the value of or called from a function
+    that is the 'log_function' tornado setting. This makes it get called
+    at the end of every request, allowing us to record the metrics we need.
     """
     REQUEST_DURATION_SECONDS.labels(
         method=handler.request.method,

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -1,5 +1,8 @@
 """
 Prometheus metrics exported by JupyterHub
+
+Read https://prometheus.io/docs/practices/naming/ for naming
+conventions for metrics & labels.
 """
 from prometheus_client import Histogram
 

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -2,8 +2,21 @@
 Prometheus metrics exported by JupyterHub
 
 Read https://prometheus.io/docs/practices/naming/ for naming
-conventions for metrics & labels.
+conventions for metrics & labels. We generally prefer naming them
+`<noun>_<verb>_<type_suffix>`. So a histogram that's tracking
+the duration (in seconds) of servers spawning would be called
+SERVER_SPAWN_DURATION_SECONDS.
+
+We also create an Enum for each 'status' type label in every metric
+we collect. This is to make sure that the metrics exist regardless
+of the condition happening or not. For example, if we don't explicitly
+create them, the metric spawn_duration_seconds{status="failure"}
+will not actually exist until the first failure. This makes dashboarding
+and alerting difficult, so we explicitly list statuses and create
+them manually here.
 """
+from enum import Enum
+
 from prometheus_client import Histogram
 
 REQUEST_DURATION_SECONDS = Histogram(
@@ -12,20 +25,51 @@ REQUEST_DURATION_SECONDS = Histogram(
     ['method', 'handler', 'code']
 )
 
-SPAWN_DURATION_SECONDS = Histogram(
-    'spawn_duration_seconds',
-    'spawn duration for all server spawns',
+SERVER_SPAWN_DURATION_SECONDS = Histogram(
+    'server_spawn_duration_seconds',
+    'time taken for server spawning operation',
     ['status'],
     # Use custom bucket sizes, since the default bucket ranges
     # are meant for quick running processes. Spawns can take a while!
     buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")]
 )
 
+class ServerSpawnStatus(Enum):
+    """
+    Possible values for 'status' label of SERVER_SPAWN_DURATION_SECONDS
+    """
+    success = 'success'
+    failure = 'failure'
+    already_pending = 'already-pending'
+    throttled = 'throttled'
+    too_many_users = 'too-many-users'
+
+    def __str__(self):
+        return self.value
+
+for s in ServerSpawnStatus:
+    # Create empty metrics with the given status
+    SERVER_SPAWN_DURATION_SECONDS.labels(status=s)
+
+
 PROXY_ADD_DURATION_SECONDS = Histogram(
     'proxy_add_duration_seconds',
     'duration for adding user routes to proxy',
     ['status']
 )
+
+class ProxyAddStatus(Enum):
+    """
+    Possible values for 'status' label of PROXY_ADD_DURATION_SECONDS
+    """
+    success = 'success'
+    failure = 'failure'
+
+    def __str__(self):
+        return self.value
+
+for s in ProxyAddStatus:
+    PROXY_ADD_DURATION_SECONDS.labels(status=s)
 
 def prometheus_log_method(handler):
     """

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -16,6 +16,12 @@ SPAWN_DURATION_SECONDS = Histogram(
     buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")]
 )
 
+PROXY_ADD_DURATION_SECONDS = Histogram(
+    'proxy_add_duration_seconds',
+    'duration for adding user routes to proxy',
+    ['status']
+)
+
 def prometheus_log_method(handler):
     """
     Tornado log handler for recording RED metrics

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -1,0 +1,28 @@
+"""
+Prometheus metrics exported by JupyterHub
+"""
+from prometheus_client import Histogram
+
+REQUEST_DURATION_SECONDS = Histogram(
+    'request_duration_seconds',
+    'request duration for all HTTP requests',
+    ['method', 'handler', 'code']
+)
+
+def prometheus_log_method(handler):
+    """
+    Tornado log handler for recording RED metrics
+
+    We record the following metrics:
+       Rate – the number of requests, per second, your services are serving.
+       Errors – the number of failed requests per second.
+       Duration – The amount of time each request takes expressed as a time interval.
+
+    We use a fully qualified name of the handler as a label,
+    rather than every url path to reduce cardinality.
+    """
+    REQUEST_DURATION_SECONDS.labels(
+        method=handler.request.method,
+        handler='{}.{}'.format(handler.__class__.__module__, type(handler).__name__),
+        code=handler.get_status()
+    ).observe(handler.request.request_time())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pamela
 python-oauth2>=1.0
 SQLAlchemy>=1.1
 requests
-prometheus_client
+prometheus_client>=0.0.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pamela
 python-oauth2>=1.0
 SQLAlchemy>=1.1
 requests
+prometheus_client


### PR DESCRIPTION
This patch introduces Prometheus for exposing metrics
about JupyterHub's operation. We expose a standard /metrics
endpoint that can be queried without authentication. We
take on prometheus_client as an unconditional dependency
to both simplify code & because it is a pure python package
with no dependencies itself.

The first pass adds 'RED' style metrics for all HTTP requests.
http://rancher.com/red-method-for-prometheus-3-key-metrics-for-monitoring/
has some info on the RED method, but to summarize:

  For each request type, record at least the following metrics

   Rate – the number of requests, per second, your services are serving.
   Errors – the number of failed requests per second.
   Duration – The amount of time each request takes expressed as a time interval.

This instantly gives us a lot of useful metrics in a very
compact form.

Also adds following metrics:
- Spawn times
- Proxy addition times