### PR TITLE
Clarify resource limits/guarantees in docs and docstrings

### DIFF
--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -170,9 +170,12 @@ If you are interested in building a custom spawner, you can read [this tutorial]
 Some spawners of the single-user notebook servers allow setting limits or
 guarantees on resources, such as CPU and memory. To provide a consistent
 experience for sysadmins and users, we provide a standard way to set and
-discover these resource limits and guarantees, such as for memory and CPU. For
-the limits and guarantees to be useful, the spawner must implement support for
-them.
+discover these resource limits and guarantees, such as for memory and CPU.
+For the limits and guarantees to be useful, **the spawner must implement
+support for them**. For example, LocalProcessSpawner, the default
+spawner, does not support limits and guarantees. One of the spawners
+that supports limits and guarantees is the `systemdspawner`.
+
 
 ### Memory Limits & Guarantees
 

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -193,8 +193,8 @@ to provide a guarantee that at minimum this much memory will always be
 available for the single-user notebook server to use. The environment variable
 `MEM_GUARANTEE` will also be set in the single-user notebook server.
 
-The spawner's underlying system or cluster is responsible for enforcing these
-limits and providing these guarantees. If these values are set to `None`, no
+**The spawner's underlying system or cluster is responsible for enforcing these
+limits and providing these guarantees.** If these values are set to `None`, no
 limits or guarantees are provided, and no environment values are set.
 
 ### CPU Limits & Guarantees
@@ -211,6 +211,6 @@ higher priority applications might be taking up CPU.
 guarantee for CPU usage. The environment variable `CPU_GUARANTEE` will be set
 in the single-user notebook server when a guarantee is being provided.
 
-The spawner's underlying system or cluster is responsible for enforcing these
-limits and providing these guarantees. If these values are set to `None`, no
+**The spawner's underlying system or cluster is responsible for enforcing these
+limits and providing these guarantees.** If these values are set to `None`, no
 limits or guarantees are provided, and no environment values are set.

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -303,7 +303,7 @@ class Spawner(LoggingConfigurable):
           - The JupyterHub process' environment variables that are whitelisted in `env_keep`
           - Variables to establish contact between the single-user notebook and the hub (such as JUPYTERHUB_API_TOKEN)
 
-        The `enviornment` configurable should be set by JupyterHub administrators to add
+        The `environment` configurable should be set by JupyterHub administrators to add
         installation specific environment variables. It is a dict where the key is the name of the environment
         variable, and the value can be a string or a callable. If it is a callable, it will be called
         with one parameter (the spawner instance), and should return a string fairly quickly (no blocking
@@ -408,7 +408,10 @@ class Spawner(LoggingConfigurable):
         will be able to allocate this much memory - only that it can not
         allocate more than this.
 
-        This needs to be supported by your spawner for it to work.
+        **This is a configuration setting. Your spawner must implement support
+        for the limit to work.** The default spawner, `LocalProcessSpawner`,
+        does **not** implement this support. A custom spawner **must** add
+        support for this setting for it to be enforced.
         """
     ).tag(config=True)
 
@@ -424,7 +427,10 @@ class Spawner(LoggingConfigurable):
         use more cpu-cores than this. There is no guarantee that it can
         access this many cpu-cores.
 
-        This needs to be supported by your spawner for it to work.
+        **This is a configuration setting. Your spawner must implement support
+        for the limit to work.** The default spawner, `LocalProcessSpawner`,
+        does **not** implement this support. A custom spawner **must** add
+        support for this setting for it to be enforced.
         """
     ).tag(config=True)
 
@@ -438,7 +444,10 @@ class Spawner(LoggingConfigurable):
           - G -> Gigabytes
           - T -> Terabytes
 
-        This needs to be supported by your spawner for it to work.
+        **This is a configuration setting. Your spawner must implement support
+        for the limit to work.** The default spawner, `LocalProcessSpawner`,
+        does **not** implement this support. A custom spawner **must** add
+        support for this setting for it to be enforced.
         """
     ).tag(config=True)
 
@@ -450,7 +459,10 @@ class Spawner(LoggingConfigurable):
         If this value is set to 0.5, allows use of 50% of one CPU.
         If this value is set to 2, allows use of up to 2 CPUs.
 
-        Note that this needs to be supported by your spawner for it to work.
+        **This is a configuration setting. Your spawner must implement support
+        for the limit to work.** The default spawner, `LocalProcessSpawner`,
+        does **not** implement this support. A custom spawner **must** add
+        support for this setting for it to be enforced.
         """
     ).tag(config=True)
 
@@ -837,6 +849,8 @@ class LocalProcessSpawner(Spawner):
     Does not work on Windows.
 
     This is the default spawner for JupyterHub.
+
+    Note: This spawner does not implement CPU / memory guarantees and limits.
     """
 
     interrupt_timeout = Integer(10,


### PR DESCRIPTION
This PR clarifies that LocalProcessSpawner, the default spawner, does not enforce these limits. A custom spawner must implement the code to enforce the limits.

Closes: #1584 