### PR TITLE
Add a %DEFAULT% token to the template_paths parsing

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -265,7 +265,10 @@ class JupyterHub(Application):
     ).tag(config=True)
 
     template_paths = List(
-        help="Paths to search for jinja templates.",
+        help="""Paths to search for jinja templates.
+
+        Use the special string '%DEFAULT%' to include the default path in this list.
+        """
     ).tag(config=True)
 
     @default('template_paths')
@@ -1294,8 +1297,11 @@ class JupyterHub(Application):
             autoescape=True,
         )
         jinja_options.update(self.jinja_environment_options)
+        template_paths = [p if p != '%DEFAULT%'
+                            else self._template_paths_default()[0]
+                          for p in self.template_paths]
         jinja_env = Environment(
-            loader=FileSystemLoader(self.template_paths),
+            loader=FileSystemLoader(template_paths),
             **jinja_options
         )
 
@@ -1329,7 +1335,7 @@ class JupyterHub(Application):
             static_path=os.path.join(self.data_files_path, 'static'),
             static_url_prefix=url_path_join(self.hub.base_url, 'static/'),
             static_handler_class=CacheControlStaticFilesHandler,
-            template_path=self.template_paths,
+            template_path=template_paths,
             jinja2_env=jinja_env,
             version_hash=version_hash,
             subdomain_host=self.subdomain_host,


### PR DESCRIPTION
The idea here is to make it easier for the user to override one or two templates, leaving the rest as-is.  The user can already do that by including the literal path to the default templates in `c.JupyterHub.template_paths`, but since JupyterHub already knows that value, we can make it a bit easier.

In this commit, I chose to use the special string "%DEFAULT%" to indicate the default value.  I considered using `None` as a token, but the semantics didn't seem to match up in my mind.  I am not at all wedded to this particular string, so I'd be happy to change it to something more consistent with the rest of JupyterHub if this was a bad choice.

Another approach would be to automatically append the default path to the end of template_paths.  I didn't go that way, figuring that someone who wanted all the templates replaces would rather get an error message than have a default template silently subbed in.  But that would avoid the need for a special token.