### PR TITLE
Template messages

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -265,7 +265,10 @@ class JupyterHub(Application):
     ).tag(config=True)
 
     template_paths = List(
-        help="Paths to search for jinja templates.",
+        help="""Paths to search for jinja templates.
+
+        Use the special string '%DEFAULT%' to include the default path in this list.
+        """
     ).tag(config=True)
 
     @default('template_paths')
@@ -1294,8 +1297,11 @@ class JupyterHub(Application):
             autoescape=True,
         )
         jinja_options.update(self.jinja_environment_options)
+        template_paths = [p if p != '%DEFAULT%'
+                            else self._template_paths_default()[0]
+                          for p in self.template_paths]
         jinja_env = Environment(
-            loader=FileSystemLoader(self.template_paths),
+            loader=FileSystemLoader(template_paths),
             **jinja_options
         )
 
@@ -1329,7 +1335,7 @@ class JupyterHub(Application):
             static_path=os.path.join(self.data_files_path, 'static'),
             static_url_prefix=url_path_join(self.hub.base_url, 'static/'),
             static_handler_class=CacheControlStaticFilesHandler,
-            template_path=self.template_paths,
+            template_path=template_paths,
             jinja2_env=jinja_env,
             version_hash=version_hash,
             subdomain_host=self.subdomain_host,

--- a/share/jupyter/hub/templates/home.html
+++ b/share/jupyter/hub/templates/home.html
@@ -1,4 +1,5 @@
 {% extends "page.html" %}
+{% from "messages/home.html" import home_message %}
 
 {% block main %}
 
@@ -15,6 +16,9 @@
         My Server
       </a>
     </div>
+  </div>
+  <div class="row">
+    {{ home_message() }}
   </div>
 </div>
 

--- a/share/jupyter/hub/templates/messages/home.html
+++ b/share/jupyter/hub/templates/messages/home.html
@@ -1,0 +1,2 @@
+{% macro home_message() -%}
+{%- endmacro %}

--- a/share/jupyter/hub/templates/messages/spawn_pending.html
+++ b/share/jupyter/hub/templates/messages/spawn_pending.html
@@ -1,0 +1,4 @@
+{% macro spawn_pending_message() -%}
+<p>Your server is starting up.</p>
+<p>You will be redirected automatically when it's ready for you.</p>
+{%- endmacro %}

--- a/share/jupyter/hub/templates/spawn_pending.html
+++ b/share/jupyter/hub/templates/spawn_pending.html
@@ -1,12 +1,12 @@
 {% extends "page.html" %}
+{% from "messages/spawn_pending.html" import spawn_pending_message %}
 
 {% block main %}
 
 <div class="container">
   <div class="row">
     <div class="text-center">
-      <p>Your server is starting up.</p>
-      <p>You will be redirected automatically when it's ready for you.</p>
+      {{ spawn_pending_message() }}
       <p><i class="fa fa-spinner fa-pulse fa-fw fa-3x" aria-hidden="true"></i></p>
       <a role="button" id="refresh" class="btn btn-lg btn-primary" href="#">refresh</a>
     </div>


### PR DESCRIPTION
This builds on top of #1596, pulling out small bits of text as "messages" that a user may wish to override.  With these in place, all the user has to provide in the custom template directory are the relevant message templates.

This is done in the two places I was most interested in
1. On the home page (default empty)
2. On the spawn pending page (default to the existing text)

There are likely other places where this would make sense.  If you point the out, I'd be glad to set those up too.

After toying with a couple of other ideas, I ended up with the macro approach.  This seemed to give the most flexibility with the smallest amount of boilerplate.  Another approach would be to define a `base_home.html`, for example, with the content currently in `home.html` with a block added where the message would go.  Then the new (or customized) `home.html` would extend `base_home.html` and define the message block there.  While this might be a little more in line with the usual use of templates, it seemed to me to require a bit more commitment to making those various base files right now.  In contrast, the macro approach lets us easily add messages as desired.  I'd be happy to show what the other approach would look like, should you prefer.