### PR TITLE
Base template mechanism

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1298,7 +1298,7 @@ class JupyterHub(Application):
         if base_path not in self.template_paths:
             self.template_paths.append(base_path)
         loader = ChoiceLoader([
-            PrefixLoader({'BASE': FileSystemLoader([base_path])}, ':'),
+            PrefixLoader({'templates': FileSystemLoader([base_path])}, '/'),
             FileSystemLoader(self.template_paths)
         ])
         jinja_env = Environment(

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -265,16 +265,12 @@ class JupyterHub(Application):
     ).tag(config=True)
 
     template_paths = List(
-        help="Paths to search for jinja templates.",
+        help="Paths to search for jinja templates, before using the default templates.",
     ).tag(config=True)
 
     @default('template_paths')
     def _template_paths_default(self):
         return [os.path.join(self.data_files_path, 'templates')]
-
-    base_templates = Bool(False,
-        help="Allow tempates to extend the base versions, by referencing 'BASE:name.html'."
-    ).tag(config=True)
 
     confirm_no_ssl = Bool(False,
         help="""DEPRECATED: does nothing"""
@@ -1298,16 +1294,13 @@ class JupyterHub(Application):
             autoescape=True,
         )
         jinja_options.update(self.jinja_environment_options)
-        if self.base_templates:
-            base_path = self._template_paths_default()[0]
-            if base_path not in self.template_paths:
-                self.template_paths.append(base_path)
-            loader = ChoiceLoader([
-                PrefixLoader({'BASE': FileSystemLoader([base_path])}, ':'),
-                FileSystemLoader(self.template_paths)
-            ])
-        else:
-            loader = FileSystemLoader(self.template_paths)
+        base_path = self._template_paths_default()[0]
+        if base_path not in self.template_paths:
+            self.template_paths.append(base_path)
+        loader = ChoiceLoader([
+            PrefixLoader({'BASE': FileSystemLoader([base_path])}, ':'),
+            FileSystemLoader(self.template_paths)
+        ])
         jinja_env = Environment(
             loader=loader,
             **jinja_options

--- a/share/jupyter/hub/templates/spawn_pending.html
+++ b/share/jupyter/hub/templates/spawn_pending.html
@@ -5,8 +5,10 @@
 <div class="container">
   <div class="row">
     <div class="text-center">
+      {% block message %}
       <p>Your server is starting up.</p>
       <p>You will be redirected automatically when it's ready for you.</p>
+      {% endblock %}
       <p><i class="fa fa-spinner fa-pulse fa-fw fa-3x" aria-hidden="true"></i></p>
       <a role="button" id="refresh" class="btn btn-lg btn-primary" href="#">refresh</a>
     </div>


### PR DESCRIPTION
There are several places where I'd like to make slight changes to template for a JupyterHub deploy.  By using the `template_paths` variable, I can provide my own templates, but I'd rather not need to copy the existing versions over.  This provides a mechanism to let the user extend the base templates.

When `base_templates` is `True`, user templates can extend `BASE:name.html` to extend the base version of that template.  (The `BASE:` part is only necessary if the user is also providing a template `name.html`.)  This means that the user can provide a message on the home page by defining their own `home.html`:
```html
{% extends "BASE:home.html" %}

{% block main %}
{{ super() }}
<div class="container">
  <div class="row">
    <p>Hello there!</p>
  </div>
</div>
{% endblock %}
```

Most pages seem to already have enough flexibility to let the user override or add to relevant parts.  The one page I saw that didn't do this well was `spawn_pending.html`, so I added a block around the message there.

This effectively provides the capabilities of #1596 and #1597, and I think it's also a cleaner way to do #1598.