### PR TITLE
pin tornado requirement to less than 5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic
 traitlets>=4.3.2
-tornado>=4.1
+tornado>=4.1,<5.0
 jinja2
 pamela
 python-oauth2>=1.0


### PR DESCRIPTION
Travis is currently failing when Tornado 5.0a1 is installed. Pin Tornado until 5.0 changes can be investigated.