### PR TITLE
Fix spawner/service typo in proxy.py

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -352,7 +352,7 @@ class Proxy(LoggingConfigurable):
                 if route['target'] != service.server.host:
                     self.log.warning(
                         "Updating route for %s (%s → %s)",
-                        route['routespec'], route['target'], spawner.server.host,
+                        route['routespec'], route['target'], service.server.host,
                     )
                     futures.append(self.add_service(service))
 


### PR DESCRIPTION
I don't fully grasp the code in this file, but this must be a typo.

@minrk could you confirm this?