### PR TITLE
Fix unicode errors with extra_log_file

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -765,7 +765,7 @@ class JupyterHub(Application):
 
         if self.extra_log_file:
             self.extra_log_handlers.append(
-                logging.FileHandler(self.extra_log_file)
+                logging.FileHandler(self.extra_log_file, encoding='utf8')
             )
 
         _formatter = self._log_formatter_cls(


### PR DESCRIPTION
Should fix unicode issues in #1406

<del>
reverts #1620 
</del>

<del>
Should only be merged if extra_log_file is verified to be the cause.
</del>

Undid the revert of #1625, since this can't have been the source of error messages produced by jupyterhub-singleuser. It's still a known unicode bug in extra_log_file, so we should do that part, at least.

cc @ellisonbg