### PR TITLE
moved suggested configuration file to match canonical jupyter config paths

### DIFF
--- a/docs/source/getting-started/config-basics.md
+++ b/docs/source/getting-started/config-basics.md
@@ -25,7 +25,7 @@ jupyterhub --generate-config
 This default `jupyterhub_config.py` file contains comments and guidance for all
 configuration variables and their default values. We recommend storing
 configuration files in the standard UNIX filesystem location, i.e.
-`/etc/jupyterhub`.
+`/etc/jupyter/jupyterhub`.
 
 ## Start with a specific config file
 
@@ -36,11 +36,11 @@ jupyterhub -f /path/to/jupyterhub_config.py
 ```
 
 If you have stored your configuration file in the recommended UNIX filesystem
-location, `/etc/jupyterhub`, the following command will start JupyterHub using
+location, `/etc/jupyter/jupyterhub`, the following command will start JupyterHub using
 the configuration file:
 
 ```bash
-jupyterhub -f /etc/jupyterhub/jupyterhub_config.py
+jupyterhub -f /etc/jupyter/jupyterhub/jupyterhub_config.py
 ```
 
 The IPython documentation provides additional information on the


### PR DESCRIPTION
This modifies the docs to suggest a new location for configuration files. Specifically this will be found by any utilities using jupyter standard configuration paths to perform their functionality (this includes [`jupyter_conf_search`](https://github.com/mpacer/jupyter_conf_search)).

This still uses the standard Unix filesystem location, it just adheres to the recommendations described in: https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html#configuration-files

specifically, `etc/jupyter/`:
<table border="0" class="table">
<colgroup>
<col width="52%">
<col width="48%">
</colgroup>
<thead valign="bottom">
<tr class="row-odd"><th class="head">Unix</th>
<th class="head">Windows</th>
</tr>
</thead>
<tbody valign="top">
<tr class="row-even"><td colspan="2"><span class="target" id="index-0"></span><a class="reference internal" href="#envvar-JUPYTER_CONFIG_DIR"><code class="xref std std-envvar docutils literal"><span class="pre">JUPYTER_CONFIG_DIR</span></code></a></td>
</tr>
<tr class="row-odd"><td colspan="2"><code class="docutils literal"><span class="pre">{sys.prefix}/etc/jupyter/</span></code></td>
</tr>
<tr class="row-even"><td><code class="docutils literal"><span class="pre">/usr/local/etc/jupyter/</span></code>
<code class="docutils literal"><span class="pre">/etc/jupyter/</span></code></td>
<td><code class="docutils literal"><span class="pre">%PROGRAMDATA%\jupyter\</span></code></td>
</tr>
</tbody>
</table>

This originally came to my attention while looking into https://github.com/jupyterlab/jupyterlab-latex/issues/49.