### PR TITLE
Fixes for tests with tornado 5

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -31,7 +31,6 @@ from tornado.log import app_log, access_log, gen_log
 import tornado.options
 from tornado import gen, web
 from tornado.platform.asyncio import AsyncIOMainLoop
-AsyncIOMainLoop().install()
 
 from traitlets import (
     Unicode, Integer, Dict, TraitError, List, Bool, Any,
@@ -1643,6 +1642,7 @@ class JupyterHub(Application):
     @classmethod
     def launch_instance(cls, argv=None):
         self = cls.instance()
+        AsyncIOMainLoop().install()
         loop = IOLoop.current()
         loop.add_callback(self.launch_instance_async, argv)
         try:

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -45,9 +45,7 @@ def io_loop(request):
 
     def _close():
         io_loop.clear_current()
-        if (not ioloop.IOLoop.initialized() or
-                io_loop is not ioloop.IOLoop.instance()):
-            io_loop.close(all_fds=True)
+        io_loop.close(all_fds=True)
 
     request.addfinalizer(_close)
     return io_loop

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -1,5 +1,6 @@
 """mock utilities for testing"""
 
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import os
 import sys
@@ -235,6 +236,7 @@ class MockHub(JupyterHub):
         # to avoid multiple eventloops in the same thread errors from asyncio
 
         def cleanup():
+            asyncio.set_event_loop(asyncio.new_event_loop())
             loop = IOLoop.current()
             loop.run_sync(self.cleanup)
             loop.close()

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -1,3 +1,4 @@
+import asyncio
 from binascii import hexlify
 import copy
 import json
@@ -125,6 +126,7 @@ def test_hub_authenticated(request):
     port = 50505
     q = Queue()
     def run():
+        asyncio.set_event_loop(asyncio.new_event_loop())
         app = Application([
             ('/*', TestHandler),
         ], login_url=auth.login_url)


### PR DESCRIPTION
I believe these are *not* compatibility fixes for tornado in JupyterHub in general, as they only affect the tests.

Things started failing because until recently, the tests were never running with asyncio. This was because importing the singleuser server triggered a pyzmq registration which overrode the asyncio registration we have at the module level (which occurred earlier than the notebook import). pyzmq 17 prerelease no longer does this, so asyncio was really being used, revealing a couple of small bugs. These are only in testing utilities involving background threads and cleanup.