### PR TITLE
avoid instantiating idle Spawner objects during startup

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -96,31 +96,22 @@ class APIHandler(BaseHandler):
 
     def user_model(self, user):
         """Get the JSON model for a User object"""
-        orm_only = False
         if isinstance(user, orm.User):
-            # we've already built the wrapper, use it.
-            if user.id in self.users:
-                user = self.users[user.id]
-            else:
-                orm_only = True
+            user = self.users[user.id]
 
         model = {
             'kind': 'user',
             'name': user.name,
             'admin': user.admin,
             'groups': [ g.name for g in user.groups ],
-            'server': None,
+            'server': user.url if user.running else None,
             'pending': None,
             'last_activity': user.last_activity.isoformat(),
         }
-        if not orm_only:
-            model['server'] = user.url if user.running else None
-            if '' in user.spawners:
-                model['pending'] = user.spawners[''].pending or None
-            else:
-                model['pending'] = None
+        if '' in user.spawners:
+            model['pending'] = user.spawners[''].pending or None
 
-        if self.allow_named_servers and not orm_only:
+        if self.allow_named_servers:
             servers = model['servers'] = {}
             for name, spawner in user.spawners.items():
                 if spawner.ready:

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -104,7 +104,10 @@ class APIHandler(BaseHandler):
             'pending': None,
             'last_activity': user.last_activity.isoformat(),
         }
-        model['pending'] = user.spawners[''].pending or None
+        if '' in user.spawners:
+            model['pending'] = user.spawners[''].pending or None
+        else:
+            model['pending'] = False
 
         if self.allow_named_servers:
             servers = model['servers'] = {}

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -31,8 +31,7 @@ class SelfAPIHandler(APIHandler):
 class UserListAPIHandler(APIHandler):
     @admin_only
     def get(self):
-        users = [ self._user_from_orm(u) for u in self.db.query(orm.User) ]
-        data = [ self.user_model(u) for u in users ]
+        data = [ self.user_model(u) for u in self.db.query(orm.User) ]
         self.write(json.dumps(data))
     
     @admin_only

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -81,7 +81,7 @@ class UserListAPIHandler(APIHandler):
                 yield gen.maybe_future(self.authenticator.add_user(user))
             except Exception as e:
                 self.log.error("Failed to create user: %s" % name, exc_info=True)
-                del self.users[user]
+                self.users.delete(user)
                 raise web.HTTPError(400, "Failed to create user %s: %s" % (name, str(e)))
             else:
                 created.append(user)
@@ -132,12 +132,12 @@ class UserAPIHandler(APIHandler):
         except Exception:
             self.log.error("Failed to create user: %s" % name, exc_info=True)
             # remove from registry
-            del self.users[user]
+            self.users.delete(user)
             raise web.HTTPError(400, "Failed to create user: %s" % name)
-        
+
         self.write(json.dumps(self.user_model(user)))
         self.set_status(201)
-    
+
     @admin_only
     @gen.coroutine
     def delete(self, name):
@@ -152,10 +152,10 @@ class UserAPIHandler(APIHandler):
             yield self.stop_single_user(user)
             if user.spawner._stop_pending:
                 raise web.HTTPError(400, "%s's server is in the process of stopping, please wait." % name)
-        
+
         yield gen.maybe_future(self.authenticator.delete_user(user))
         # remove from registry
-        del self.users[user]
+        self.users.delete(user)
 
         self.set_status(204)
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1034,8 +1034,6 @@ class JupyterHub(Application):
                     without notifying JupyterHub.
                     """))
         db.commit()
-        # expunge User objects from the db session
-        db.expunge_all()
 
         # The whitelist set and the users in the db are now the same.
         # From this point on, any user changes should be done simultaneously
@@ -1062,8 +1060,6 @@ class JupyterHub(Application):
                     db.add(user)
                 group.users.append(user)
         db.commit()
-        # expunge Group objects from the db session
-        db.expunge_all()
 
     @gen.coroutine
     def _add_tokens(self, token_dict, kind):
@@ -1275,15 +1271,6 @@ class JupyterHub(Application):
 
         # await checks after submitting them all
         yield gen.multi(check_futures)
-        to_expunge = []
-        for user in self.users.values():
-            if not user.active:
-                to_expunge.append(user)
-        if to_expunge:
-            self.log.debug("expunging users from db session: %s",
-                           ', '.join(u.name for u in to_expunge))
-            for user in to_expunge:
-                del self.users[user.id]
 
         db.commit()
         # only perform this query if we are going to log it

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1431,7 +1431,7 @@ class JupyterHub(Application):
             self.log.info("Cleaning up single-user servers...")
             # request (async) process termination
             for uid, user in self.users.items():
-                for name, spawner in user.spawners.items():
+                for name, spawner in list(user.spawners.items()):
                     if spawner.active:
                         futures.append(user.stop(name))
         else:

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1265,9 +1265,11 @@ class JupyterHub(Application):
             orm_user = orm_spawner.user
             user = self.users.add(orm_user)
             self.log.debug("Loading state for %s from db", user.name)
-            for name, spawner in user.spawners.items():
-                f = check_spawner(user, name, spawner)
-                check_futures.append(f)
+            for name, orm_spawner in user.orm_spawners.items():
+                if orm_spawner.server is not None:
+                    spawner = user.spawners[name]
+                    f = check_spawner(user, name, spawner)
+                    check_futures.append(f)
 
         # await checks after submitting them all
         yield gen.multi(check_futures)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -258,7 +258,6 @@ class BaseHandler(RequestHandler):
             self.db.add(u)
             self.db.commit()
             user = self._user_from_orm(u)
-            self.authenticator.add_user(user)
         return user
 
     def clear_login_cookie(self, name=None):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -410,7 +410,10 @@ class BaseHandler(RequestHandler):
             username = authenticated['name']
             auth_state = authenticated.get('auth_state')
             admin = authenticated.get('admin')
+            new_user = username not in self.users
             user = self.user_from_username(username)
+            if new_user:
+                yield gen.maybe_future(self.authenticator.add_user(user))
             # Only set `admin` if the authenticator returned an explicit value.
             if admin is not None and admin != user.admin:
                 user.admin = admin

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -42,9 +42,10 @@ def test_server(db):
 
 
 def test_user(db):
-    user = User(orm.User(name='kaylee'))
-    db.add(user)
+    orm_user = orm.User(name='kaylee')
+    db.add(orm_user)
     db.commit()
+    user = User(orm_user)
     spawner = user.spawners['']
     spawner.orm_spawner.state = {'pid': 4234}
     assert user.name == 'kaylee'
@@ -164,13 +165,13 @@ def test_spawn_fails(db):
         @gen.coroutine
         def start(self):
             raise RuntimeError("Split the party")
-    
+
     user = User(orm_user, {
         'spawner_class': BadSpawner,
         'config': None,
         'statsd': EmptyClass(),
     })
-    
+
     with pytest.raises(RuntimeError) as exc:
         yield user.spawn()
     assert user.spawners[''].server is None
@@ -194,15 +195,16 @@ def test_groups(db):
 
 @pytest.mark.gen_test
 def test_auth_state(db):
-    user = User(orm.User(name='eve'))
-    db.add(user.orm_user)
+    orm_user = orm.User(name='eve')
+    db.add(orm_user)
     db.commit()
-    
+    user = User(orm_user)
+
     ck = crypto.CryptKeeper.instance()
 
     # starts empty
     assert user.encrypted_auth_state is None
-    
+
     # can't set auth_state without keys
     state = {'key': 'value'}
     ck.keys = []

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -290,6 +290,9 @@ def test_spawner_reuse_api_token(db, app):
     assert found.user.name == user.name
     assert user.api_tokens == [found]
     yield user.stop()
+    # stop now deletes unused spawners.
+    # put back the mock spawner!
+    user.spawners[''] = spawner
     # second start: should reuse the token
     yield user.spawn()
     # verify re-use of API token

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -136,13 +136,10 @@ class User:
     log = app_log
     settings = None
 
-    def __init__(self, orm_user, settings=None, **kwargs):
-        self.orm_user = orm_user
-        self.db = inspect(orm_user).session
+    def __init__(self, orm_user, settings=None, db=None):
+        self.db = db or inspect(orm_user).session
         self.settings = settings or {}
-        for key, attr in kwargs:
-            print('setting', key, attr)
-            setattr(self, key, attr)
+        self.orm_user = orm_user
 
 
         self.allow_named_servers = self.settings.get('allow_named_servers', False)
@@ -225,7 +222,7 @@ class User:
     @property
     def spawner(self):
         return self.spawners['']
-    
+
     @spawner.setter
     def spawner(self, spawner):
         self.spawners[''] = spawner


### PR DESCRIPTION
only instantiate Spawners when they are requested.

This changes startup time on my laptop with 5k users of whom 500 are running from 3 minutes to less than 3 seconds. With no running users, startup completes in <del>200ms</del> 8 seconds (also down from 3 minutes). I'll post startup perf tests soon.

<del>
This is a WIP because I think we need to investigate other times to avoid instantiating the objects prematurely before this is helpful. My current suspicion is that the entire startup delay will just be inherited by the first call to the /users API (e.g. by the culler), which might be worse than having it consistently at startup.
</del>

Related to #1633

Follow-up to #1639 which only solves the case where Spawner.poll spends a significant amount of time waiting.