### PR TITLE
Add option to redirect to running Jupyter server

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -249,6 +249,9 @@ class JupyterHub(Application):
         Default is two weeks.
         """
     ).tag(config=True)
+    redirect_to_server = Bool(True,
+        help="Redirect user to server (if running), instead of control panel."
+    ).tag(config=True)
     last_activity_interval = Integer(300,
         help="Interval (in seconds) at which to update last-activity timestamps."
     ).tag(config=True)
@@ -1326,6 +1329,7 @@ class JupyterHub(Application):
             base_url=self.base_url,
             cookie_secret=self.cookie_secret,
             cookie_max_age_days=self.cookie_max_age_days,
+            redirect_to_server=self.redirect_to_server,
             login_url=login_url,
             logout_url=logout_url,
             static_path=os.path.join(self.data_files_path, 'static'),

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -165,6 +165,10 @@ class BaseHandler(RequestHandler):
     def cookie_max_age_days(self):
         return self.settings.get('cookie_max_age_days', None)
 
+    @property
+    def redirect_to_server(self):
+        return self.settings.get('redirect_to_server', True)
+
     def get_auth_token(self):
         """Get the authorization token from Authorization header"""
         auth_header = self.request.headers.get('Authorization', '')
@@ -394,7 +398,7 @@ class BaseHandler(RequestHandler):
         if not next_url.startswith('/'):
             next_url = ''
         if not next_url:
-            if user and user.running:
+            if user and user.running and self.redirect_to_server:
                 next_url = user.url
             else:
                 next_url = self.hub.base_url

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -45,12 +45,13 @@ class RootHandler(BaseHandler):
             return
         user = self.get_current_user()
         if user:
+            url = url_path_join(self.hub.base_url, 'home')
             if user.running:
-                url = user.url
-                self.log.debug("User is running: %s", url)
+                if self.redirect_to_server:
+                    url = user.url
+                self.log.debug("User is running: %s", user.url)
                 self.set_login_cookie(user) # set cookie
             else:
-                url = url_path_join(self.hub.base_url, 'home')
                 self.log.debug("User is not running: %s", url)
         else:
             url = self.settings['login_url']


### PR DESCRIPTION
Currently, on login or `/hub`, users get redirected to their server, if it is running.  This is the desired behavior in most cases, but we are using the control panel as a central store of information and would like to have users always go through there.  This adds a redirect_to_server option, which defaults to True.  If it is set to False, the user will not get redirected to a running server in these cases.