### PR TITLE
expand admin[-access] support

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -702,9 +702,11 @@ class BaseHandler(RequestHandler):
         return self.settings['jinja2_env'].get_template(name)
 
     def render_template(self, name, **ns):
-        ns.update(self.template_namespace)
+        template_ns = {}
+        template_ns.update(self.template_namespace)
+        template_ns.update(ns)
         template = self.get_template(name)
-        return template.render(**ns)
+        return template.render(**template_ns)
 
     @property
     def template_namespace(self):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -818,7 +818,7 @@ class UserSpawnHandler(BaseHandler):
             admin_spawn = False
             # For non-admins, we should spawn if the user matches
             # otherwise redirect users to their own server
-            should_spawn = (current_user.name == name)
+            should_spawn = (current_user and current_user.name == name)
 
 
         if should_spawn:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -885,7 +885,11 @@ class UserSpawnHandler(BaseHandler):
             # server is not running, trigger spawn
             if status is not None:
                 if spawner.options_form:
-                    self.redirect(url_concat(url_path_join(self.hub.base_url, 'spawn'),
+                    url_parts = [self.hub.base_url, 'spawn']
+                    if current_user.name != user.name:
+                        # spawning on behalf of another user
+                        url_parts.append(user.name)
+                    self.redirect(url_concat(url_path_join(*url_parts),
                                              {'next': self.request.uri}))
                     return
                 else:

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -89,7 +89,7 @@ class SpawnHandler(BaseHandler):
     """
     @gen.coroutine
     def _render_form(self, message='', for_user=None):
-        user = self.get_current_user()
+        user = for_user or self.get_current_user()
         spawner_options_form = yield user.spawner.get_options_form()
         return self.render_template('spawn.html',
             for_user=for_user,

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -139,7 +139,9 @@ class SpawnHandler(BaseHandler):
         if for_user is not None and for_user != user.name:
             if not user.admin:
                 raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
-            user = self.user_from_username(for_user)
+            user = self.find_user(for_user)
+            if user is None:
+                raise web.HTTPError(404, "No such user: %s" % for_user)
         if not self.allow_named_servers and user.running:
             url = user.url
             self.log.warning("User is already running: %s", url)

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -88,11 +88,11 @@ class SpawnHandler(BaseHandler):
     Only enabled when Spawner.options_form is defined.
     """
     @gen.coroutine
-    def _render_form(self, message=''):
+    def _render_form(self, message='', for_user=None):
         user = self.get_current_user()
         spawner_options_form = yield user.spawner.get_options_form()
         return self.render_template('spawn.html',
-            user=user,
+            for_user=for_user,
             spawner_options_form=spawner_options_form,
             error_message=message,
             url=self.request.uri,
@@ -105,7 +105,7 @@ class SpawnHandler(BaseHandler):
 
         or triggers spawn via redirect if there is no form.
         """
-        user = self.get_current_user()
+        user = current_user = self.get_current_user()
         if for_user is not None and for_user != user.name:
             if not user.admin:
                 raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
@@ -120,7 +120,7 @@ class SpawnHandler(BaseHandler):
             self.redirect(url)
             return
         if user.spawner.options_form:
-            form = yield self._render_form()
+            form = yield self._render_form(for_user=user)
             self.finish(form)
         else:
             # Explicit spawn request: clear _spawn_future
@@ -135,7 +135,7 @@ class SpawnHandler(BaseHandler):
     @gen.coroutine
     def post(self, for_user=None):
         """POST spawns with user-specified options"""
-        user = self.get_current_user()
+        user = current_user = self.get_current_user()
         if for_user is not None and for_user != user.name:
             if not user.admin:
                 raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
@@ -161,9 +161,11 @@ class SpawnHandler(BaseHandler):
             yield self.spawn_single_user(user, options=options)
         except Exception as e:
             self.log.error("Failed to spawn single-user server with form", exc_info=True)
-            self.finish(self._render_form(str(e)))
+            form = yield self._render_form(message=str(e), for_usr=user)
+            self.finish(form)
             return
-        self.set_login_cookie(user)
+        if current_user is user:
+            self.set_login_cookie(user)
         url = user.url
 
         next_url = self.get_argument('next', '')

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -34,7 +34,7 @@ class RootHandler(BaseHandler):
             next_url = ''
         if next_url and next_url.startswith(url_path_join(self.base_url, 'user/')):
             # add /hub/ prefix, to ensure we redirect to the right user's server.
-            # The next request will be handled by UserSpawnHandler,
+            # The next request will be handled by SpawnHandler,
             # ultimately redirecting to the logged-in user's server.
             without_prefix = next_url[len(self.base_url):]
             next_url = url_path_join(self.hub.base_url, without_prefix)
@@ -100,12 +100,20 @@ class SpawnHandler(BaseHandler):
 
     @web.authenticated
     @gen.coroutine
-    def get(self):
+    def get(self, for_user=None):
         """GET renders form for spawning with user-specified options
 
         or triggers spawn via redirect if there is no form.
         """
         user = self.get_current_user()
+        if for_user is not None and for_user != user.name:
+            if not user.admin:
+                raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
+
+            user = self.find_user(for_user)
+            if user is None:
+                raise web.HTTPError(404, "No such user: %s" % for_user)
+
         if not self.allow_named_servers and user.running:
             url = user.url
             self.log.debug("User is running: %s", url)
@@ -125,9 +133,13 @@ class SpawnHandler(BaseHandler):
 
     @web.authenticated
     @gen.coroutine
-    def post(self):
+    def post(self, for_user=None):
         """POST spawns with user-specified options"""
         user = self.get_current_user()
+        if for_user is not None and for_user != user.name:
+            if not user.admin:
+                raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
+            user = self.user_from_username(for_user)
         if not self.allow_named_servers and user.running:
             url = user.url
             self.log.warning("User is already running: %s", url)
@@ -159,6 +171,7 @@ class SpawnHandler(BaseHandler):
             url = next_url
 
         self.redirect(url)
+
 
 class AdminHandler(BaseHandler):
     """Render the admin page."""
@@ -268,6 +281,7 @@ default_handlers = [
     (r'/home', HomeHandler),
     (r'/admin', AdminHandler),
     (r'/spawn', SpawnHandler),
+    (r'/spawn/([^/]+)', SpawnHandler),
     (r'/token', TokenPageHandler),
     (r'/error/(\d+)', ProxyErrorHandler),
 ]

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -139,7 +139,7 @@ def no_patience(app):
 @fixture
 def slow_spawn(app):
     """Fixture enabling SlowSpawner"""
-    with mock.patch.dict(app.tornado_settings,
+    with mock.patch.dict(app.users.settings,
                          {'spawner_class': mocking.SlowSpawner}):
         yield
 
@@ -147,7 +147,7 @@ def slow_spawn(app):
 @fixture
 def never_spawn(app):
     """Fixture enabling NeverSpawner"""
-    with mock.patch.dict(app.tornado_settings,
+    with mock.patch.dict(app.users.settings,
                          {'spawner_class': mocking.NeverSpawner}):
         yield
 
@@ -155,7 +155,7 @@ def never_spawn(app):
 @fixture
 def bad_spawn(app):
     """Fixture enabling BadSpawner"""
-    with mock.patch.dict(app.tornado_settings,
+    with mock.patch.dict(app.users.settings,
                          {'spawner_class': mocking.BadSpawner}):
         yield
 
@@ -163,7 +163,7 @@ def bad_spawn(app):
 @fixture
 def slow_bad_spawn(app):
     """Fixture enabling SlowBadSpawner"""
-    with mock.patch.dict(app.tornado_settings,
+    with mock.patch.dict(app.users.settings,
                          {'spawner_class': mocking.SlowBadSpawner}):
         yield
 
@@ -171,6 +171,6 @@ def slow_bad_spawn(app):
 @fixture
 def admin_access(app):
     """Grant admin-access with this fixture"""
-    with mock.patch.dict(app.tornado_settings,
+    with mock.patch.dict(app.users.settings,
                          {'admin_access': True}):
         yield

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -130,7 +130,7 @@ def mockservice_url(request, app):
 @fixture
 def no_patience(app):
     """Set slow-spawning timeouts to zero"""
-    with mock.patch.dict(app.tornado_application.settings,
+    with mock.patch.dict(app.tornado_settings,
                          {'slow_spawn_timeout': 0,
                           'slow_stop_timeout': 0}):
         yield
@@ -139,7 +139,7 @@ def no_patience(app):
 @fixture
 def slow_spawn(app):
     """Fixture enabling SlowSpawner"""
-    with mock.patch.dict(app.users.settings,
+    with mock.patch.dict(app.tornado_settings,
                          {'spawner_class': mocking.SlowSpawner}):
         yield
 
@@ -147,7 +147,7 @@ def slow_spawn(app):
 @fixture
 def never_spawn(app):
     """Fixture enabling NeverSpawner"""
-    with mock.patch.dict(app.users.settings,
+    with mock.patch.dict(app.tornado_settings,
                          {'spawner_class': mocking.NeverSpawner}):
         yield
 
@@ -155,7 +155,7 @@ def never_spawn(app):
 @fixture
 def bad_spawn(app):
     """Fixture enabling BadSpawner"""
-    with mock.patch.dict(app.users.settings,
+    with mock.patch.dict(app.tornado_settings,
                          {'spawner_class': mocking.BadSpawner}):
         yield
 
@@ -163,7 +163,7 @@ def bad_spawn(app):
 @fixture
 def slow_bad_spawn(app):
     """Fixture enabling SlowBadSpawner"""
-    with mock.patch.dict(app.users.settings,
+    with mock.patch.dict(app.tornado_settings,
                          {'spawner_class': mocking.SlowBadSpawner}):
         yield
 
@@ -171,6 +171,6 @@ def slow_bad_spawn(app):
 @fixture
 def admin_access(app):
     """Grant admin-access with this fixture"""
-    with mock.patch.dict(app.users.settings,
+    with mock.patch.dict(app.tornado_settings,
                          {'admin_access': True}):
         yield

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -50,6 +50,7 @@ def io_loop(request):
     request.addfinalizer(_close)
     return io_loop
 
+
 @fixture(scope='module')
 def app(request, io_loop):
     """Mock a jupyterhub app for testing"""
@@ -166,3 +167,10 @@ def slow_bad_spawn(app):
                          {'spawner_class': mocking.SlowBadSpawner}):
         yield
 
+
+@fixture
+def admin_access(app):
+    """Grant admin-access with this fixture"""
+    with mock.patch.dict(app.tornado_settings,
+                         {'admin_access': True}):
+        yield

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -218,7 +218,7 @@ class MockHub(JupyterHub):
         """Instantiate the tornado Application object"""
         super().init_tornado_application()
         # reconnect tornado_settings so that mocks can update the real thing
-        self.tornado_settings = self.tornado_application.settings
+        self.tornado_settings = self.users.settings = self.tornado_application.settings
 
     @gen.coroutine
     def initialize(self, argv=None):

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -214,6 +214,11 @@ class MockHub(JupyterHub):
 
     def load_config_file(self, *args, **kwargs):
         pass
+    def init_tornado_application(self):
+        """Instantiate the tornado Application object"""
+        super().init_tornado_application()
+        # reconnect tornado_settings so that mocks can update the real thing
+        self.tornado_settings = self.tornado_application.settings
 
     @gen.coroutine
     def initialize(self, argv=None):

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -67,8 +67,7 @@ def add_user(db, app=None, **kwargs):
             setattr(orm_user, attr, value)
     db.commit()
     if app:
-        user = app.users[orm_user.id] = User(orm_user, app.tornado_settings)
-        return user
+        return app.users[orm_user.id]
     else:
         return orm_user
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -518,7 +518,6 @@ def test_never_spawn(app, no_patience, never_spawn):
 
 @mark.gen_test
 def test_bad_spawn(app, no_patience, bad_spawn):
-    settings = app.tornado_application.settings
     db = app.db
     name = 'prim'
     user = add_user(db, app=app, name=name)
@@ -529,7 +528,6 @@ def test_bad_spawn(app, no_patience, bad_spawn):
 
 @mark.gen_test
 def test_slow_bad_spawn(app, no_patience, slow_bad_spawn):
-    settings = app.tornado_application.settings
     db = app.db
     name = 'zaphod'
     user = add_user(db, app=app, name=name)
@@ -545,11 +543,10 @@ def test_slow_bad_spawn(app, no_patience, slow_bad_spawn):
 @mark.gen_test
 def test_spawn_limit(app, no_patience, slow_spawn, request):
     db = app.db
-    settings = app.tornado_application.settings
-    settings['concurrent_spawn_limit'] = 2
-    def _restore_limit():
-        settings['concurrent_spawn_limit'] = 100
-    request.addfinalizer(_restore_limit)
+    p = mock.patch.dict(app.tornado_settings,
+                   {'concurrent_spawn_limit': 2})
+    p.start()
+    request.addfinalizer(p.stop)
 
     # start two pending spawns
     names = ['ykka', 'hjarka']
@@ -597,11 +594,10 @@ def test_spawn_limit(app, no_patience, slow_spawn, request):
 @mark.gen_test
 def test_active_server_limit(app, request):
     db = app.db
-    settings = app.tornado_application.settings
-    settings['active_server_limit'] = 2
-    def _restore_limit():
-        settings['active_server_limit'] = 0
-    request.addfinalizer(_restore_limit)
+    p = mock.patch.dict(app.tornado_settings,
+                   {'active_server_limit': 2})
+    p.start()
+    request.addfinalizer(p.stop)
 
     # start two pending spawns
     names = ['ykka', 'hjarka']

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -1,4 +1,6 @@
 """Tests for named servers"""
+from unittest import mock
+
 import pytest
 
 from ..utils import url_path_join
@@ -9,12 +11,9 @@ from .utils import async_requests
 
 @pytest.fixture
 def named_servers(app):
-    key = 'allow_named_servers'
-    app.tornado_application.settings[key] = app.tornado_settings[key] = True
-    try:
-        yield True
-    finally:
-        app.tornado_application.settings[key] = app.tornado_settings[key] = False
+    with mock.patch.dict(app.tornado_settings,
+                         {'allow_named_servers': True}):
+        yield
 
 
 @pytest.mark.gen_test

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -209,7 +209,7 @@ def test_spawn_form(app):
 
 @pytest.mark.gen_test
 def test_spawn_form_admin_access(app, admin_access):
-    with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
+    with mock.patch.dict(app.tornado_settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.base_url)
         cookies = yield app.login_user('admin')
         u = add_user(app.db, app=app, name='martha')
@@ -232,7 +232,7 @@ def test_spawn_form_admin_access(app, admin_access):
 
 @pytest.mark.gen_test
 def test_spawn_form_with_file(app):
-    with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
+    with mock.patch.dict(app.tornado_settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.base_url)
         cookies = yield app.login_user('jones')
         orm_u = orm.User.find(app.db, 'jones')
@@ -386,7 +386,7 @@ def test_auto_login(app, request):
     authenticator = Authenticator(auto_login=True)
     authenticator.login_url = lambda base_url: ujoin(base_url, 'dummy')
 
-    with mock.patch.dict(app.tornado_application.settings, {
+    with mock.patch.dict(app.tornado_settings, {
         'authenticator': authenticator,
     }):
         r = yield async_requests.get(base_url)
@@ -397,7 +397,7 @@ def test_auto_login_logout(app):
     name = 'burnham'
     cookies = yield app.login_user(name)
 
-    with mock.patch.dict(app.tornado_application.settings, {
+    with mock.patch.dict(app.tornado_settings, {
         'authenticator': Authenticator(auto_login=True),
     }):
         r = yield async_requests.get(public_host(app) + app.tornado_settings['logout_url'], cookies=cookies)

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -154,7 +154,7 @@ def test_spawn_admin_access(app, admin_access):
     app.db.commit()
     r = yield get_page('user/' + name, app, cookies=cookies)
     r.raise_for_status()
-    assert (r.url + '/').startswith(public_url(app, user))
+    assert (r.url.split('?')[0] + '/').startswith(public_url(app, user))
     r = yield get_page('user/{}/env'.format(name), app, hub=False, cookies=cookies)
     r.raise_for_status()
     env = r.json()
@@ -175,7 +175,7 @@ def test_spawn_page(app):
 
 
 @pytest.mark.gen_test
-def test_spawn_page_admin(app):
+def test_spawn_page_admin(app, admin_access):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         cookies = yield app.login_user('admin')
         u = add_user(app.db, app=app, name='melanie')

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -175,6 +175,17 @@ def test_spawn_page(app):
 
 
 @pytest.mark.gen_test
+def test_spawn_page_admin(app):
+    with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
+        cookies = yield app.login_user('admin')
+        u = add_user(app.db, app=app, name='melanie')
+        r = yield get_page('spawn/' + u.name, app, cookies=cookies)
+        assert r.url.endswith('/spawn/' + u.name)
+        assert FormSpawner.options_form in r.text
+        assert "Spawning server for {}".format(u.name) in r.text
+
+
+@pytest.mark.gen_test
 def test_spawn_form(app):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.base_url)

--- a/share/jupyterhub/static/js/admin.js
+++ b/share/jupyterhub/static/js/admin.js
@@ -6,6 +6,8 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
 
     var base_url = window.jhdata.base_url;
     var prefix = window.jhdata.prefix;
+    var admin_access = window.jhdata.admin_access;
+    var options_form = window.jhdata.options_form;
 
     var api = new JHAPI(base_url);
 
@@ -73,26 +75,38 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
         });
     });
 
-    $(".access-server").click(function () {
-        var el = $(this);
-        var row = get_row(el);
-        var user = row.data('user');
-        var w = window.open(utils.url_path_join(prefix, 'user', user) + '/');
+    $(".access-server").map(function (i, el) {
+        el = $(el);
+        var user = get_row(el).data('user');
+        el.attr('href', utils.url_path_join(prefix, 'user', user) + '/');
     });
 
-    $(".start-server").click(function () {
-        var el = $(this);
-        var row = get_row(el);
-        var user = row.data('user');
-        el.text("starting...");
-        api.start_server(user, {
-            success: function () {
-                el.text('start server').addClass('hidden');
-                row.find('.stop-server').removeClass('hidden');
-                row.find('.access-server').removeClass('hidden');
-            }
+    if (admin_access && options_form) {
+        // if admin access and options form are enabled
+        // link to spawn page instead of making API requests
+        $('.start-server').map(function (i, el) {
+            el = $(el);
+            var user = get_row(el).data('user');
+            el.attr('href', utils.url_path_join(prefix, 'hub/spawn', user));
+        })
+        // cannot start all servers in this case
+        // since it would mean opening a bunch of tabs
+        $('#start-all-servers').addClass('hidden');
+    } else {
+        $(".start-server").click(function () {
+            var el = $(this);
+            var row = get_row(el);
+            var user = row.data('user');
+            el.text("starting...");
+            api.start_server(user, {
+                success: function () {
+                    el.text('start server').addClass('hidden');
+                    row.find('.stop-server').removeClass('hidden');
+                    row.find('.access-server').removeClass('hidden');
+                }
+            });
         });
-    });
+    }
 
     $(".edit-user").click(function () {
         var el = $(this);
@@ -120,7 +134,6 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
             }
         });
     });
-
 
     $(".delete-user").click(function () {
         var el = $(this);

--- a/share/jupyterhub/templates/admin.html
+++ b/share/jupyterhub/templates/admin.html
@@ -47,20 +47,20 @@
       <td class="admin-col col-sm-2">{% if u.admin %}admin{% endif %}</td>
       <td class="time-col col-sm-3">{{u.last_activity.isoformat() + 'Z'}}</td>
       <td class="server-col col-sm-2 text-center">
-        <span role="button" class="stop-server btn btn-xs btn-danger {% if not u.running %}hidden{% endif %}">stop server</span>
-        <span role="button" class="start-server btn btn-xs btn-success {% if u.running %}hidden{% endif %}">start server</span>
+        <a role="button" class="stop-server btn btn-xs btn-danger {% if not u.running %}hidden{% endif %}">stop server</span>
+        <a role="button" class="start-server btn btn-xs btn-success {% if u.running %}hidden{% endif %}">start server</span>
       </td>
       <td class="server-col col-sm-1 text-center">
         {% if admin_access %}
-        <span role="button" class="access-server btn btn-xs btn-success {% if not u.running %}hidden{% endif %}">access server</span>
+        <a role="button" class="access-server btn btn-xs btn-success {% if not u.running %}hidden{% endif %}">access server</span>
         {% endif %}
       </td>
       <td class="edit-col col-sm-1 text-center">
-        <span role="button" class="edit-user btn btn-xs btn-primary">edit</span>
+        <a role="button" class="edit-user btn btn-xs btn-primary">edit</span>
       </td>
       <td class="edit-col col-sm-1 text-center">
         {% if u.name != user.name %}
-        <span role="button" class="delete-user btn btn-xs btn-danger">delete</span>
+        <a role="button" class="delete-user btn btn-xs btn-danger">delete</span>
         {% endif %}
       </td>
       {% endblock user_row %}

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -65,6 +65,16 @@
         {% if user %}
         user: "{{user.name}}",
         {% endif %}
+        {% if admin_access %}
+        admin_access: true,
+        {% else %}
+        admin_access: false,
+        {% endif %}
+        {% if user and user.spawner.options_form %}
+        options_form: true,
+        {% else %}
+        options_form: false,
+        {% endif %}
       }
     </script>
 

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -7,11 +7,14 @@
     <h1>Spawner options</h1>
   </div>
   <div class="row col-sm-offset-2 col-sm-8">
-      {% if error_message %}
-        <p class="spawn-error-msg text-danger">
-          Error: {{error_message}}
-        </p>
-      {% endif %}
+    {% if for_user and user.name != for_user.name -%}
+      <p>Spawning server for {{ for_user.name }}</p>
+    {% endif -%}
+    {% if error_message -%}
+      <p class="spawn-error-msg text-danger">
+        Error: {{error_message}}
+      </p>
+    {% endif %}
     <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
       {{spawner_options_form | safe}}
       <br>


### PR DESCRIPTION
- [x] admin request for /user/:name spawns user's server, not redirecting to admin's server
- [x] admins can see/submit spawn form for users (if admin access is enabled)
- [x] spawn links in admin panel should trigger spawn form if defined

closes #1629