### PR TITLE
Add blocks for navbar components in the page template

### DIFF
--- a/share/jupyter/hub/templates/page.html
+++ b/share/jupyter/hub/templates/page.html
@@ -82,7 +82,8 @@
   </div>
 </noscript>
 
-<nav class="navbar navbar-default">
+{% block nav_bar %}
+  <nav class="navbar navbar-default">
     <div class="container-fluid">
       <div class="navbar-header">
         <span id="jupyterhub-logo" class="pull-left"><a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
@@ -97,32 +98,37 @@
       <div class="collapse navbar-collapse" id="thenavbar">
         {% if user %}
         <ul class="nav navbar-nav">
-          <li><a href="{{base_url}}home">Home</a></li>
-          <li><a href="{{base_url}}token">Token</a></li>
-          {% if user.admin %}
-          <li><a href="{{base_url}}admin">Admin</a></li>
-          {% endif %}
+          {% block nav_bar_left_items %}
+            <li><a href="{{base_url}}home">Home</a></li>
+            <li><a href="{{base_url}}token">Token</a></li>
+            {% if user.admin %}
+            <li><a href="{{base_url}}admin">Admin</a></li>
+            {% endif %}
+          {% endblock %}
         </ul>
         {% endif %}
         <ul class="nav navbar-nav navbar-right">
-          <li>
-            {% block login_widget %}
-              <span id="login_widget">
-                {% if user %}
-                  <a id="logout" role="button" class="navbar-btn btn-sm btn btn-default" href="{{logout_url}}"> <i aria-hidden="true" class="fa fa-sign-out"></i> Logout</a>
-                {% else %}
-                  <a id="login" role="button" class="btn-sm btn navbar-btn btn-default" href="{{login_url}}">Login</a>
-                {% endif %}
-              </span>
+          {% block nav_bar_right_items %}
+            <li>
+              {% block login_widget %}
+                <span id="login_widget">
+                  {% if user %}
+                    <a id="logout" role="button" class="navbar-btn btn-sm btn btn-default" href="{{logout_url}}"> <i aria-hidden="true" class="fa fa-sign-out"></i> Logout</a>
+                  {% else %}
+                    <a id="login" role="button" class="btn-sm btn navbar-btn btn-default" href="{{login_url}}">Login</a>
+                  {% endif %}
+                </span>
               {% endblock %}
-          </li>
+            </li>
+          {% endblock %}
         </ul>
       </div>
 
-  {% block header %}
-  {% endblock %}
-  </div>
-</nav>
+      {% block header %}
+      {% endblock %}
+    </div>
+  </nav>
+{% endblock %}
 
 {% block main %}
 {% endblock %}


### PR DESCRIPTION
This makes one block containing the whole nav bar, one containing the elements of the left list, and one containing the elements of the right list.  I hope this gives enough flexibility without cluttering the markup too much, but I'm not married to any of these ideas.

See also #1663, #1481, #1502.