### PR TITLE
fix stop of singleuser with tornado 5

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -304,7 +304,7 @@ class SingleUserNotebookApp(NotebookApp):
 
     def _confirm_exit(self):
         # disable the exit confirmation for background notebook processes
-        ioloop.IOLoop.instance().stop()
+        self.io_loop.add_callback_from_signal(self.io_loop.stop)
 
     def migrate_config(self):
         if self.disable_user_config:


### PR DESCRIPTION
Updates call to match notebook application itself

calling IOLoop.instance() is deprecated, and won't work from a background thread with tornado 5.