### PR TITLE
Add `Spawner.get_options_form` for async support.

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -87,16 +87,19 @@ class SpawnHandler(BaseHandler):
 
     Only enabled when Spawner.options_form is defined.
     """
+    @gen.coroutine
     def _render_form(self, message=''):
         user = self.get_current_user()
+        spawner_options_form = yield user.spawner.get_options_form()
         return self.render_template('spawn.html',
             user=user,
-            spawner_options_form=user.spawner.options_form,
+            spawner_options_form=spawner_options_form,
             error_message=message,
             url=self.request.uri,
         )
 
     @web.authenticated
+    @gen.coroutine
     def get(self):
         """GET renders form for spawning with user-specified options
 
@@ -109,7 +112,8 @@ class SpawnHandler(BaseHandler):
             self.redirect(url)
             return
         if user.spawner.options_form:
-            self.finish(self._render_form())
+            form = yield self._render_form()
+            self.finish(form)
         else:
             # Explicit spawn request: clear _spawn_future
             # which may have been saved to prevent implicit spawns

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -266,7 +266,7 @@ class Spawner(LoggingConfigurable):
           (Future(str)): the content of the options form presented to the user
           prior to starting a Spawner.
 
-        .. versionchanged:: 0.8.2
+        .. versionadded:: 0.9.0
             Introduced.
         """
         if callable(self.options_form):

--- a/jupyterhub/traitlets.py
+++ b/jupyterhub/traitlets.py
@@ -4,7 +4,7 @@ Traitlets that are used in JupyterHub
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import List, Unicode, Integer, TraitError
+from traitlets import List, Unicode, Integer, TraitType, TraitError
 
 
 class URLPrefix(Unicode):
@@ -74,3 +74,20 @@ class ByteSpecification(Integer):
             raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
         else:
             return int(float(num) * self.UNIT_SUFFIXES[suffix])
+
+
+class Callable(TraitType):
+    """
+    A trait which is callable.
+
+    Classes are callable, as are instances
+    with a __call__() method.
+    """
+
+    info_text = 'a callable'
+
+    def validate(self, obj, value):
+        if callable(value):
+           return value
+        else:
+            self.error(obj, value)


### PR DESCRIPTION
Fixes #1681. The implementation is heavily influenced by some patterns in the kubespawner, specifically: `Union([Unicode(), Callable()])`, and supporting sync or async callables.

I have locally run these changes, but I've not yet added any tests. I found no existing tests for the `Spawner.options_form`, so I would appreciate any guidance about how to approach testing this change (e.g., are there any examples of similar tests I can draw from? which file should the tests go in?).