### PR TITLE
add SIGINFO handler

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -57,6 +57,7 @@ from .traitlets import URLPrefix, Command
 from .utils import (
     url_path_join,
     ISO8601_ms, ISO8601_s,
+    print_stacks, print_ps_info,
 )
 # classes for config
 from .auth import Authenticator, PAMAuthenticator
@@ -1675,6 +1676,14 @@ class JupyterHub(Application):
 
     def init_signal(self):
         signal.signal(signal.SIGTERM, self.sigterm)
+        if hasattr(signal, 'SIGINFO'):
+            signal.signal(signal.SIGINFO, self.log_status)
+
+    def log_status(self, signum, frame):
+        """Log current status, triggered by SIGINFO (^T in many terminals)"""
+        self.log.debug("Received signal %s[%s]", signum, signal.getsignal(signum))
+        print_ps_info()
+        print_stacks()
 
     def sigterm(self, signum, frame):
         self.log.critical("Received SIGTERM, shutting down")

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -375,6 +375,7 @@ def print_stacks(file=sys.stderr):
     """
     # local imports because these will not be used often,
     # no need to add them to startup
+    import asyncio
     import resource
     import traceback
     from .log import coroutine_frames
@@ -402,4 +403,13 @@ def print_stacks(file=sys.stderr):
                 continue
 
         print(''.join(['\n'] + traceback.format_list(stack)), file=file)
+
+    # also show asyncio tasks, if any
+    # this will increase over time as we transition from tornado
+    # coroutines to native `async def`
+    tasks = asyncio.Task.all_tasks()
+    if tasks:
+        print("AsyncIO tasks: %i" % len(tasks))
+        for task in tasks:
+            task.print_stack(file=file)
 


### PR DESCRIPTION
various programs allow sending SIGINFO (ctrl-T in many terminals) to print some diagnostic info. In this case, it prints some basic stats from psutil (if available) and the current stacks of all non-idle threads.

In a subsequent PR, I'll explore transitioning from tornado coroutines to asyncio `async def` functions, which will get us better diagnostics in the 'current task stacks'. I *believe* this will be transparent to developers of custom Spawners and Authenticators as tornado accepts both asyncio and tornado coroutines, but we'll have to be careful to test both tornado coroutines calling asyncio methods and vice versa, with both tornado 4 and 5. I know tornado is happy to `yield` asyncio Futures, but I'm not certain that asyncio is always happy to `await` tornado Futures, at least with 4.x.