### PR TITLE
async/await syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ sudo: false
 cache:
   - pip
 python:
-  - nightly
   - 3.6
   - 3.5
-  - 3.4
+  - nightly
 env:
   global:
     - ASYNC_TEST_TIMEOUT=15

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -38,15 +38,14 @@ class TokenAPIHandler(APIHandler):
         self.db.commit()
         self.write(json.dumps(model))
 
-    @gen.coroutine
-    def post(self):
+    async def post(self):
         requester = user = self.get_current_user()
         if user is None:
             # allow requesting a token with username and password
             # for authenticators where that's possible
             data = self.get_json_body()
             try:
-                requester = user = yield self.login_user(data)
+                requester = user = await self.login_user(data)
             except Exception as e:
                 self.log.error("Failure trying to authenticate with form data: %s" % e)
                 user = None

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -51,8 +51,7 @@ class GroupAPIHandler(_GroupAPIHandler):
         self.write(json.dumps(self.group_model(group)))
 
     @admin_only
-    @gen.coroutine
-    def post(self, name):
+    async def post(self, name):
         """POST creates a group by name"""
         model = self.get_json_body()
         if model is None:
@@ -109,9 +108,8 @@ class GroupUsersAPIHandler(_GroupAPIHandler):
         self.db.commit()
         self.write(json.dumps(self.group_model(group)))
 
-    @gen.coroutine
     @admin_only
-    def delete(self, name):
+    async def delete(self, name):
         """DELETE removes users from a group"""
         group = self.find_group(name)
         data = self.get_json_body()

--- a/jupyterhub/apihandlers/proxy.py
+++ b/jupyterhub/apihandlers/proxy.py
@@ -14,52 +14,48 @@ from .base import APIHandler
 
 
 class ProxyAPIHandler(APIHandler):
-    
+
     @admin_only
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         """GET /api/proxy fetches the routing table
 
         This is the same as fetching the routing table directly from the proxy,
         but without clients needing to maintain separate
         """
-        routes = yield self.proxy.get_all_routes()
+        routes = await self.proxy.get_all_routes()
         self.write(json.dumps(routes))
 
     @admin_only
-    @gen.coroutine
-    def post(self):
+    async def post(self):
         """POST checks the proxy to ensure that it's up to date.
 
         Can be used to jumpstart a newly launched proxy
         without waiting for the check_routes interval.
         """
-        yield self.proxy.check_routes(self.users, self.services)
-    
+        await self.proxy.check_routes(self.users, self.services)
+
     @admin_only
-    @gen.coroutine
-    def patch(self):
+    async def patch(self):
         """PATCH updates the location of the proxy
-        
+
         Can be used to notify the Hub that a new proxy is in charge
         """
         if not self.request.body:
             raise web.HTTPError(400, "need JSON body")
-        
+
         try:
             model = json.loads(self.request.body.decode('utf8', 'replace'))
         except ValueError:
             raise web.HTTPError(400, "Request body must be JSON dict")
         if not isinstance(model, dict):
             raise web.HTTPError(400, "Request body must be JSON dict")
-        
+
         if 'api_url' in model:
             self.proxy.api_url = model['api_url']
         if 'auth_token' in model:
             self.proxy.auth_token = model['auth_token']
         self.log.info("Updated proxy at %s", self.proxy)
-        yield self.proxy.check_routes(self.users, self.services)
-        
+        await self.proxy.check_routes(self.users, self.services)
 
 
 default_handlers = [

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -35,8 +35,7 @@ class UserListAPIHandler(APIHandler):
         self.write(json.dumps(data))
     
     @admin_only
-    @gen.coroutine
-    def post(self):
+    async def post(self):
         data = self.get_json_body()
         if not data or not isinstance(data, dict) or not data.get('usernames'):
             raise web.HTTPError(400, "Must specify at least one user to create")
@@ -59,17 +58,17 @@ class UserListAPIHandler(APIHandler):
                 self.log.warning("User %s already exists" % name)
             else:
                 to_create.append(name)
-        
+
         if invalid_names:
             if len(invalid_names) == 1:
                 msg = "Invalid username: %s" % invalid_names[0]
             else:
                 msg = "Invalid usernames: %s" % ', '.join(invalid_names)
             raise web.HTTPError(400, msg)
-        
+
         if not to_create:
             raise web.HTTPError(400, "All %i users already exist" % len(usernames))
-        
+
         created = []
         for name in to_create:
             user = self.user_from_username(name)
@@ -77,14 +76,14 @@ class UserListAPIHandler(APIHandler):
                 user.admin = True
                 self.db.commit()
             try:
-                yield gen.maybe_future(self.authenticator.add_user(user))
+                await gen.maybe_future(self.authenticator.add_user(user))
             except Exception as e:
                 self.log.error("Failed to create user: %s" % name, exc_info=True)
                 self.users.delete(user)
                 raise web.HTTPError(400, "Failed to create user %s: %s" % (name, str(e)))
             else:
                 created.append(user)
-        
+
         self.write(json.dumps([ self.user_model(u) for u in created ]))
         self.set_status(201)
 
@@ -105,29 +104,28 @@ def admin_or_self(method):
     return m
 
 class UserAPIHandler(APIHandler):
-    
+
     @admin_or_self
     def get(self, name):
         user = self.find_user(name)
         self.write(json.dumps(self.user_model(user)))
-    
+
     @admin_only
-    @gen.coroutine
-    def post(self, name):
+    async def post(self, name):
         data = self.get_json_body()
         user = self.find_user(name)
         if user is not None:
             raise web.HTTPError(400, "User %s already exists" % name)
-        
+
         user = self.user_from_username(name)
         if data:
             self._check_user_model(data)
             if 'admin' in data:
                 user.admin = data['admin']
                 self.db.commit()
-        
+
         try:
-            yield gen.maybe_future(self.authenticator.add_user(user))
+            await gen.maybe_future(self.authenticator.add_user(user))
         except Exception:
             self.log.error("Failed to create user: %s" % name, exc_info=True)
             # remove from registry
@@ -138,8 +136,7 @@ class UserAPIHandler(APIHandler):
         self.set_status(201)
 
     @admin_only
-    @gen.coroutine
-    def delete(self, name):
+    async def delete(self, name):
         user = self.find_user(name)
         if user is None:
             raise web.HTTPError(404)
@@ -148,11 +145,11 @@ class UserAPIHandler(APIHandler):
         if user.spawner._stop_pending:
             raise web.HTTPError(400, "%s's server is in the process of stopping, please wait." % name)
         if user.running:
-            yield self.stop_single_user(user)
+            await self.stop_single_user(user)
             if user.spawner._stop_pending:
                 raise web.HTTPError(400, "%s's server is in the process of stopping, please wait." % name)
 
-        yield gen.maybe_future(self.authenticator.delete_user(user))
+        await gen.maybe_future(self.authenticator.delete_user(user))
         # remove from registry
         self.users.delete(user)
 
@@ -178,9 +175,8 @@ class UserAPIHandler(APIHandler):
 class UserServerAPIHandler(APIHandler):
     """Start and stop single-user servers"""
 
-    @gen.coroutine
     @admin_or_self
-    def post(self, name, server_name=''):
+    async def post(self, name, server_name=''):
         user = self.find_user(name)
         if server_name and not self.allow_named_servers:
             raise web.HTTPError(400, "Named servers are not enabled.")
@@ -198,21 +194,20 @@ class UserServerAPIHandler(APIHandler):
             # set _spawn_pending flag to prevent races while we wait
             spawner._spawn_pending = True
             try:
-                state = yield spawner.poll_and_notify()
+                state = await spawner.poll_and_notify()
             finally:
                 spawner._spawn_pending = False
             if state is None:
                 raise web.HTTPError(400, "%s is already running" % spawner._log_name)
 
         options = self.get_json_body()
-        yield self.spawn_single_user(user, server_name, options=options)
+        await self.spawn_single_user(user, server_name, options=options)
         status = 202 if spawner.pending == 'spawn' else 201
         self.set_header('Content-Type', 'text/plain')
         self.set_status(status)
 
-    @gen.coroutine
     @admin_or_self
-    def delete(self, name, server_name=''):
+    async def delete(self, name, server_name=''):
         user = self.find_user(name)
         if server_name:
             if not self.allow_named_servers:
@@ -233,10 +228,10 @@ class UserServerAPIHandler(APIHandler):
                 (spawner._log_name, '(pending: %s)' % spawner.pending if spawner.pending else '')
             )
         # include notify, so that a server that died is noticed immediately
-        status = yield spawner.poll_and_notify()
+        status = await spawner.poll_and_notify()
         if status is not None:
             raise web.HTTPError(400, "%s is not running" % spawner._log_name)
-        yield self.stop_single_user(user, server_name)
+        await self.stop_single_user(user, server_name)
         status = 202 if spawner._stop_pending else 204
         self.set_header('Content-Type', 'text/plain')
         self.set_status(status)
@@ -244,7 +239,7 @@ class UserServerAPIHandler(APIHandler):
 
 class UserAdminAccessAPIHandler(APIHandler):
     """Grant admins access to single-user servers
-    
+
     This handler sets the necessary cookie for an admin to login to a single-user server.
     """
     @admin_only

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -8,7 +8,7 @@ import json
 from tornado import gen, web
 
 from .. import orm
-from ..utils import admin_only, awaitable
+from ..utils import admin_only, maybe_future
 from .base import APIHandler
 
 
@@ -76,7 +76,7 @@ class UserListAPIHandler(APIHandler):
                 user.admin = True
                 self.db.commit()
             try:
-                await awaitable(self.authenticator.add_user(user))
+                await maybe_future(self.authenticator.add_user(user))
             except Exception as e:
                 self.log.error("Failed to create user: %s" % name, exc_info=True)
                 self.users.delete(user)
@@ -125,7 +125,7 @@ class UserAPIHandler(APIHandler):
                 self.db.commit()
 
         try:
-            await awaitable(self.authenticator.add_user(user))
+            await maybe_future(self.authenticator.add_user(user))
         except Exception:
             self.log.error("Failed to create user: %s" % name, exc_info=True)
             # remove from registry
@@ -149,7 +149,7 @@ class UserAPIHandler(APIHandler):
             if user.spawner._stop_pending:
                 raise web.HTTPError(400, "%s's server is in the process of stopping, please wait." % name)
 
-        await awaitable(self.authenticator.delete_user(user))
+        await maybe_future(self.authenticator.delete_user(user))
         # remove from registry
         self.users.delete(user)
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -4,6 +4,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 import atexit
 import binascii
 from datetime import datetime
@@ -1286,7 +1287,7 @@ class JupyterHub(Application):
                     # spawner should be running
                     # instantiate Spawner wrapper and check if it's still alive
                     spawner = user.spawners[name]
-                    f = check_spawner(user, name, spawner)
+                    f = asyncio.ensure_future(check_spawner(user, name, spawner))
                     check_futures.append(f)
 
         # await checks after submitting them all
@@ -1477,7 +1478,7 @@ class JupyterHub(Application):
         if managed_services:
             self.log.info("Cleaning up %i services...", len(managed_services))
             for service in managed_services:
-                futures.append(service.stop())
+                futures.append(asyncio.ensure_future(service.stop()))
 
         if self.cleanup_servers:
             self.log.info("Cleaning up single-user servers...")
@@ -1485,7 +1486,7 @@ class JupyterHub(Application):
             for uid, user in self.users.items():
                 for name, spawner in list(user.spawners.items()):
                     if spawner.active:
-                        futures.append(user.stop(name))
+                        futures.append(asyncio.ensure_future(user.stop(name)))
         else:
             self.log.info("Leaving single-user servers running")
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -7,6 +7,7 @@
 import asyncio
 import atexit
 import binascii
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from getpass import getuser
 import logging
@@ -151,7 +152,10 @@ class NewToken(Application):
         hub = JupyterHub(parent=self)
         hub.load_config_file(hub.config_file)
         hub.init_db()
-        hub.init_users()
+        def init_users():
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(hub.init_users())
+        ThreadPoolExecutor(1).submit(init_users).result()
         user = orm.User.find(hub.db, self.name)
         if user is None:
             print("No such user: %s" % self.name, file=sys.stderr)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -57,7 +57,7 @@ from .log import CoroutineLogFormatter, log_request
 from .proxy import Proxy, ConfigurableHTTPProxy
 from .traitlets import URLPrefix, Command
 from .utils import (
-    awaitable,
+    maybe_future,
     url_path_join,
     ISO8601_ms, ISO8601_s,
     print_stacks, print_ps_info,
@@ -1052,7 +1052,7 @@ class JupyterHub(Application):
         # and persist across sessions.
         for user in db.query(orm.User):
             try:
-                await awaitable(self.authenticator.add_user(user))
+                await maybe_future(self.authenticator.add_user(user))
             except Exception:
                 self.log.exception("Error adding user %s already in db", user.name)
                 if self.authenticator.delete_invalid_users:
@@ -1083,7 +1083,7 @@ class JupyterHub(Application):
                 db.add(group)
             for username in usernames:
                 username = self.authenticator.normalize_username(username)
-                if not (await awaitable(self.authenticator.check_whitelist(username))):
+                if not (await maybe_future(self.authenticator.check_whitelist(username))):
                     raise ValueError("Username %r is not in whitelist" % username)
                 user = orm.User.find(db, name=username)
                 if user is None:
@@ -1107,7 +1107,7 @@ class JupyterHub(Application):
         for token, name in token_dict.items():
             if kind == 'user':
                 name = self.authenticator.normalize_username(name)
-                if not (await awaitable(self.authenticator.check_whitelist(name))):
+                if not (await maybe_future(self.authenticator.check_whitelist(name))):
                     raise ValueError("Token name %r is not in whitelist" % name)
                 if not self.authenticator.validate_username(name):
                     raise ValueError("Token name %r is not valid" % name)
@@ -1497,7 +1497,7 @@ class JupyterHub(Application):
         # clean up proxy while single-user servers are shutting down
         if self.cleanup_proxy:
             if self.proxy.should_start:
-                await awaitable(self.proxy.stop())
+                await maybe_future(self.proxy.stop())
             else:
                 self.log.info("I didn't start the proxy, I can't clean it up")
         else:

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -23,7 +23,7 @@ from traitlets.config import LoggingConfigurable
 from traitlets import Bool, Set, Unicode, Dict, Any, default, observe
 
 from .handlers.login import LoginHandler
-from .utils import awaitable, url_path_join
+from .utils import maybe_future, url_path_join
 from .traitlets import Command
 
 
@@ -244,7 +244,7 @@ class Authenticator(LoggingConfigurable):
             self.log.warning("Disallowing invalid username %r.", username)
             return
 
-        whitelist_pass = await awaitable(self.check_whitelist(username))
+        whitelist_pass = await maybe_future(self.check_whitelist(username))
         if whitelist_pass:
             return authenticated
         else:
@@ -481,14 +481,14 @@ class LocalAuthenticator(Authenticator):
 
         If self.create_system_users, the user will attempt to be created if it doesn't exist.
         """
-        user_exists = await awaitable(self.system_user_exists(user))
+        user_exists = await maybe_future(self.system_user_exists(user))
         if not user_exists:
             if self.create_system_users:
-                await awaitable(self.add_system_user(user))
+                await maybe_future(self.add_system_user(user))
             else:
                 raise KeyError("User %s does not exist." % user.name)
 
-        await awaitable(super().add_user(user))
+        await maybe_future(super().add_user(user))
 
     @staticmethod
     def system_user_exists(user):

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -23,7 +23,7 @@ from traitlets.config import LoggingConfigurable
 from traitlets import Bool, Set, Unicode, Dict, Any, default, observe
 
 from .handlers.login import LoginHandler
-from .utils import url_path_join
+from .utils import awaitable, url_path_join
 from .traitlets import Command
 
 
@@ -244,7 +244,7 @@ class Authenticator(LoggingConfigurable):
             self.log.warning("Disallowing invalid username %r.", username)
             return
 
-        whitelist_pass = await gen.maybe_future(self.check_whitelist(username))
+        whitelist_pass = await awaitable(self.check_whitelist(username))
         if whitelist_pass:
             return authenticated
         else:
@@ -481,14 +481,14 @@ class LocalAuthenticator(Authenticator):
 
         If self.create_system_users, the user will attempt to be created if it doesn't exist.
         """
-        user_exists = await gen.maybe_future(self.system_user_exists(user))
+        user_exists = await awaitable(self.system_user_exists(user))
         if not user_exists:
             if self.create_system_users:
-                await gen.maybe_future(self.add_system_user(user))
+                await awaitable(self.add_system_user(user))
             else:
                 raise KeyError("User %s does not exist." % user.name)
 
-        await gen.maybe_future(super().add_user(user))
+        await awaitable(super().add_user(user))
 
     @staticmethod
     def system_user_exists(user):

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -27,7 +27,6 @@ from .utils import url_path_join
 from .traitlets import Command
 
 
-
 def getgrnam(name):
     """Wrapper function to protect against `grp` not being available
     on Windows
@@ -206,8 +205,7 @@ class Authenticator(LoggingConfigurable):
             return True
         return username in self.whitelist
 
-    @gen.coroutine
-    def get_authenticated_user(self, handler, data):
+    async def get_authenticated_user(self, handler, data):
         """Authenticate the user who is attempting to log in
 
         Returns user dict if successful, None otherwise.
@@ -223,11 +221,11 @@ class Authenticator(LoggingConfigurable):
          - `authenticate` turns formdata into a username
          - `normalize_username` normalizes the username
          - `check_whitelist` checks against the user whitelist
-        
+
         .. versionchanged:: 0.8
             return dict instead of username
         """
-        authenticated = yield self.authenticate(handler, data)
+        authenticated = await self.authenticate(handler, data)
         if authenticated is None:
             return
         if isinstance(authenticated, dict):
@@ -246,15 +244,14 @@ class Authenticator(LoggingConfigurable):
             self.log.warning("Disallowing invalid username %r.", username)
             return
 
-        whitelist_pass = yield gen.maybe_future(self.check_whitelist(username))
+        whitelist_pass = await gen.maybe_future(self.check_whitelist(username))
         if whitelist_pass:
             return authenticated
         else:
             self.log.warning("User %r not in whitelist.", username)
             return
 
-    @gen.coroutine
-    def authenticate(self, handler, data):
+    async def authenticate(self, handler, data):
         """Authenticate a user with login form data
 
         This must be a tornado gen.coroutine.
@@ -479,20 +476,19 @@ class LocalAuthenticator(Authenticator):
                 return True
         return False
 
-    @gen.coroutine
-    def add_user(self, user):
+    async def add_user(self, user):
         """Hook called whenever a new user is added
 
         If self.create_system_users, the user will attempt to be created if it doesn't exist.
         """
-        user_exists = yield gen.maybe_future(self.system_user_exists(user))
+        user_exists = await gen.maybe_future(self.system_user_exists(user))
         if not user_exists:
             if self.create_system_users:
-                yield gen.maybe_future(self.add_system_user(user))
+                await gen.maybe_future(self.add_system_user(user))
             else:
                 raise KeyError("User %s does not exist." % user.name)
 
-        yield gen.maybe_future(super().add_user(user))
+        await gen.maybe_future(super().add_user(user))
 
     @staticmethod
     def system_user_exists(user):

--- a/jupyterhub/crypto.py
+++ b/jupyterhub/crypto.py
@@ -19,7 +19,7 @@ except ImportError:
     class InvalidToken(Exception):
         pass
 
-from .utils import awaitable
+from .utils import maybe_future
 
 KEY_ENV = 'JUPYTERHUB_CRYPT_KEY'
 
@@ -133,7 +133,7 @@ class CryptKeeper(SingletonConfigurable):
     def encrypt(self, data):
         """Encrypt an object with cryptography"""
         self.check_available()
-        return awaitable(self.executor.submit(self._encrypt, data))
+        return maybe_future(self.executor.submit(self._encrypt, data))
 
     def _decrypt(self, encrypted):
         decrypted = self.fernet.decrypt(encrypted)
@@ -142,7 +142,7 @@ class CryptKeeper(SingletonConfigurable):
     def decrypt(self, encrypted):
         """Decrypt an object with cryptography"""
         self.check_available()
-        return awaitable(self.executor.submit(self._decrypt, encrypted))
+        return maybe_future(self.executor.submit(self._decrypt, encrypted))
 
 
 def encrypt(data):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -23,7 +23,7 @@ from .. import __version__
 from .. import orm
 from ..objects import Server
 from ..spawner import LocalProcessSpawner
-from ..utils import awaitable, url_path_join
+from ..utils import maybe_future, url_path_join
 from ..metrics import (
     SERVER_SPAWN_DURATION_SECONDS, ServerSpawnStatus,
     PROXY_ADD_DURATION_SECONDS, ProxyAddStatus
@@ -387,7 +387,7 @@ class BaseHandler(RequestHandler):
             self.set_hub_cookie(user)
 
     def authenticate(self, data):
-        return awaitable(self.authenticator.get_authenticated_user(self, data))
+        return maybe_future(self.authenticator.get_authenticated_user(self, data))
 
     def get_next_url(self, user=None):
         """Get the next_url for login redirect
@@ -421,7 +421,7 @@ class BaseHandler(RequestHandler):
             new_user = username not in self.users
             user = self.user_from_username(username)
             if new_user:
-                await awaitable(self.authenticator.add_user(user))
+                await maybe_future(self.authenticator.add_user(user))
             # Only set `admin` if the authenticator returned an explicit value.
             if admin is not None and admin != user.admin:
                 user.admin = admin
@@ -577,7 +577,7 @@ class BaseHandler(RequestHandler):
 
         # hook up spawner._spawn_future so that other requests can await
         # this result
-        finish_spawn_future = spawner._spawn_future = awaitable(finish_user_spawn())
+        finish_spawn_future = spawner._spawn_future = maybe_future(finish_user_spawn())
         def _clear_spawn_future(f):
             # clear spawner._spawn_future when it's done
             # keep an exception around, though, to prevent repeated implicit spawns

--- a/jupyterhub/handlers/metrics.py
+++ b/jupyterhub/handlers/metrics.py
@@ -7,8 +7,7 @@ class MetricsHandler(BaseHandler):
     """
     Handler to serve Prometheus metrics
     """
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         self.set_header('Content-Type', CONTENT_TYPE_LATEST)
         self.write(generate_latest(REGISTRY))
 

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -337,8 +337,7 @@ class SingleUserNotebookApp(NotebookApp):
             path = list(_exclude_home(path))
         return path
 
-    @gen.coroutine
-    def check_hub_version(self):
+    async def check_hub_version(self):
         """Test a connection to my Hub
 
         - exit if I can't connect at all
@@ -348,11 +347,11 @@ class SingleUserNotebookApp(NotebookApp):
         RETRIES = 5
         for i in range(1, RETRIES+1):
             try:
-                resp = yield client.fetch(self.hub_api_url)
+                resp = await client.fetch(self.hub_api_url)
             except Exception:
                 self.log.exception("Failed to connect to my Hub at %s (attempt %i/%i). Is it running?",
                 self.hub_api_url, i, RETRIES)
-                yield gen.sleep(min(2**i, 16))
+                await gen.sleep(min(2**i, 16))
             else:
                 break
         else:

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -28,7 +28,7 @@ from traitlets import (
 
 from .objects import Server
 from .traitlets import Command, ByteSpecification, Callable
-from .utils import awaitable, random_port, url_path_join, exponential_backoff
+from .utils import maybe_future, random_port, url_path_join, exponential_backoff
 
 
 class Spawner(LoggingConfigurable):
@@ -269,7 +269,7 @@ class Spawner(LoggingConfigurable):
             Introduced.
         """
         if callable(self.options_form):
-            options_form = await awaitable(self.options_form(self))
+            options_form = await maybe_future(self.options_form(self))
         else:
             options_form = self.options_form
 
@@ -783,7 +783,7 @@ class Spawner(LoggingConfigurable):
 
         for callback in callbacks:
             try:
-                await awaitable(callback())
+                await maybe_future(callback())
             except Exception:
                 self.log.exception("Unhandled error in poll callback for %s", self)
         return status

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -28,7 +28,7 @@ from traitlets import (
 
 from .objects import Server
 from .traitlets import Command, ByteSpecification, Callable
-from .utils import random_port, url_path_join, exponential_backoff
+from .utils import awaitable, random_port, url_path_join, exponential_backoff
 
 
 class Spawner(LoggingConfigurable):
@@ -269,7 +269,7 @@ class Spawner(LoggingConfigurable):
             Introduced.
         """
         if callable(self.options_form):
-            options_form = await gen.maybe_future(self.options_form(self))
+            options_form = await awaitable(self.options_form(self))
         else:
             options_form = self.options_form
 
@@ -783,7 +783,7 @@ class Spawner(LoggingConfigurable):
 
         for callback in callbacks:
             try:
-                await gen.maybe_future(callback())
+                await awaitable(callback())
             except Exception:
                 self.log.exception("Unhandled error in poll callback for %s", self)
         return status

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -103,7 +103,8 @@ def _mockservice(request, app, url=False):
             service.start()
         io_loop.run_sync(start)
         def cleanup():
-            service.stop()
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(service.stop())
             app.services[:] = []
             app._service_map.clear()
         request.addfinalizer(cleanup)

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -132,8 +132,8 @@ def mockservice_url(request, app):
 def no_patience(app):
     """Set slow-spawning timeouts to zero"""
     with mock.patch.dict(app.tornado_settings,
-                         {'slow_spawn_timeout': 0,
-                          'slow_stop_timeout': 0}):
+                         {'slow_spawn_timeout': 0.1,
+                          'slow_stop_timeout': 0.1}):
         yield
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -586,7 +586,7 @@ def test_spawn_limit(app, no_patience, slow_spawn, request):
     for u in users:
         u.spawner.delay = 0
         r = yield api_request(app, 'users', u.name, 'server', method='delete')
-        yield r.raise_for_status()
+        r.raise_for_status()
     while any(u.spawner.active for u in users):
         yield gen.sleep(0.1)
 

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -132,16 +132,16 @@ def test_add_system_user():
     authenticator = auth.PAMAuthenticator(whitelist={'mal'})
     authenticator.create_system_users = True
     authenticator.add_user_cmd = ['echo', '/home/USERNAME']
-    
+
     record = {}
     class DummyPopen:
         def __init__(self, cmd, *args, **kwargs):
             record['cmd'] = cmd
             self.returncode = 0
-        
+
         def wait(self):
             return
-    
+
     with mock.patch.object(auth, 'Popen', DummyPopen):
         yield authenticator.add_user(user)
     assert record['cmd'] == ['echo', '/home/lioness4321', 'lioness4321']
@@ -151,9 +151,9 @@ def test_add_system_user():
 def test_delete_user():
     user = orm.User(name='zoe')
     a = MockPAMAuthenticator(whitelist={'mal'})
-    
+
     assert 'zoe' not in a.whitelist
-    a.add_user(user)
+    yield a.add_user(user)
     assert 'zoe' in a.whitelist
     a.delete_user(user)
     assert 'zoe' not in a.whitelist

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -88,8 +88,8 @@ def test_external_service(app):
             'url': env['JUPYTERHUB_SERVICE_URL'],
             'api_token': env['JUPYTERHUB_API_TOKEN'],
         }]
-        app.init_services()
-        app.init_api_tokens()
+        yield app.init_services()
+        yield app.init_api_tokens()
         yield app.proxy.add_all_services(app._service_map)
 
         service = app._service_map[name]

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -12,7 +12,7 @@ from tornado import gen
 from tornado.log import app_log
 from traitlets import HasTraits, Any, Dict, default
 
-from .utils import awaitable, url_path_join
+from .utils import maybe_future, url_path_join
 
 from . import orm
 from ._version import _check_version, __version__
@@ -378,14 +378,14 @@ class User:
         # trigger pre-spawn hook on authenticator
         authenticator = self.authenticator
         if (authenticator):
-            await awaitable(authenticator.pre_spawn_start(self, spawner))
+            await maybe_future(authenticator.pre_spawn_start(self, spawner))
 
         spawner._start_pending = True
         # wait for spawner.start to return
         try:
             # run optional preparation work to bootstrap the notebook
-            await awaitable(spawner.run_pre_spawn_hook())
-            f = awaitable(spawner.start())
+            await maybe_future(spawner.run_pre_spawn_hook())
+            f = maybe_future(spawner.start())
             # commit any changes in spawner.start (always commit db changes before yield)
             db.commit()
             ip_port = await gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
@@ -533,7 +533,7 @@ class User:
             auth = spawner.authenticator
             try:
                 if auth:
-                    await awaitable(
+                    await maybe_future(
                         auth.post_spawn_stop(self, spawner)
                     )
             except Exception:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -12,7 +12,7 @@ from tornado import gen
 from tornado.log import app_log
 from traitlets import HasTraits, Any, Dict, default
 
-from .utils import url_path_join
+from .utils import awaitable, url_path_join
 
 from . import orm
 from ._version import _check_version, __version__
@@ -378,13 +378,13 @@ class User:
         # trigger pre-spawn hook on authenticator
         authenticator = self.authenticator
         if (authenticator):
-            await gen.maybe_future(authenticator.pre_spawn_start(self, spawner))
+            await awaitable(authenticator.pre_spawn_start(self, spawner))
 
         spawner._start_pending = True
         # wait for spawner.start to return
         try:
             # run optional preparation work to bootstrap the notebook
-            await gen.maybe_future(spawner.run_pre_spawn_hook())
+            await awaitable(spawner.run_pre_spawn_hook())
             f = spawner.start()
             # commit any changes in spawner.start (always commit db changes before yield)
             db.commit()
@@ -533,7 +533,7 @@ class User:
             auth = spawner.authenticator
             try:
                 if auth:
-                    await gen.maybe_future(
+                    await awaitable(
                         auth.post_spawn_stop(self, spawner)
                     )
             except Exception:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -157,23 +157,21 @@ class User:
     def spawner_class(self):
         return self.settings.get('spawner_class', LocalProcessSpawner)
 
-    @gen.coroutine
-    def save_auth_state(self, auth_state):
+    async def save_auth_state(self, auth_state):
         """Encrypt and store auth_state"""
         if auth_state is None:
             self.encrypted_auth_state = None
         else:
-            self.encrypted_auth_state = yield encrypt(auth_state)
+            self.encrypted_auth_state = await encrypt(auth_state)
         self.db.commit()
 
-    @gen.coroutine
-    def get_auth_state(self):
+    async def get_auth_state(self):
         """Retrieve and decrypt auth_state for the user"""
         encrypted = self.encrypted_auth_state
         if encrypted is None:
             return None
         try:
-            auth_state = yield decrypt(encrypted)
+            auth_state = await decrypt(encrypted)
         except (ValueError, InvalidToken, EncryptionUnavailable) as e:
             self.log.warning("Failed to retrieve encrypted auth_state for %s because %s",
                 self.name, e,
@@ -183,7 +181,7 @@ class User:
         if auth_state:
             # Crypt has multiple keys, store again with new key for rotation.
             if len(CryptKeeper.instance().keys) > 1:
-                yield self.save_auth_state(auth_state)
+                await self.save_auth_state(auth_state)
         return auth_state
 
     def _new_spawner(self, name, spawner_class=None, **kwargs):
@@ -322,16 +320,15 @@ class User:
         else:
             return self.base_url
 
-    @gen.coroutine
-    def spawn(self, server_name='', options=None):
+    async def spawn(self, server_name='', options=None):
         """Start the user's spawner
-        
+
         depending from the value of JupyterHub.allow_named_servers
-        
+
         if False:
         JupyterHub expects only one single-server per user
         url of the server will be /user/:name
-        
+
         if True:
         JupyterHub expects more than one single-server per user
         url of the server will be /user/:name/:server_name
@@ -381,17 +378,17 @@ class User:
         # trigger pre-spawn hook on authenticator
         authenticator = self.authenticator
         if (authenticator):
-            yield gen.maybe_future(authenticator.pre_spawn_start(self, spawner))
+            await gen.maybe_future(authenticator.pre_spawn_start(self, spawner))
 
         spawner._start_pending = True
         # wait for spawner.start to return
         try:
             # run optional preparation work to bootstrap the notebook
-            yield gen.maybe_future(spawner.run_pre_spawn_hook())
+            await gen.maybe_future(spawner.run_pre_spawn_hook())
             f = spawner.start()
             # commit any changes in spawner.start (always commit db changes before yield)
             db.commit()
-            ip_port = yield gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
+            ip_port = await gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
             if ip_port:
                 # get ip, port info from return value of start()
                 server.ip, server.port = ip_port
@@ -448,7 +445,7 @@ class User:
                 self.settings['statsd'].incr('spawner.failure.error')
                 e.reason = 'error'
             try:
-                yield self.stop()
+                await self.stop()
             except Exception:
                 self.log.error("Failed to cleanup {user}'s server that failed to start".format(
                     user=self.name,
@@ -466,7 +463,7 @@ class User:
         db.commit()
         spawner._waiting_for_response = True
         try:
-            resp = yield server.wait_up(http=True, timeout=spawner.http_timeout)
+            resp = await server.wait_up(http=True, timeout=spawner.http_timeout)
         except Exception as e:
             if isinstance(e, TimeoutError):
                 self.log.warning(
@@ -486,7 +483,7 @@ class User:
                 ))
                 self.settings['statsd'].incr('spawner.failure.http_error')
             try:
-                yield self.stop()
+                await self.stop()
             except Exception:
                 self.log.error("Failed to cleanup {user}'s server that failed to start".format(
                     user=self.name,
@@ -504,8 +501,7 @@ class User:
             spawner._start_pending = False
         return self
 
-    @gen.coroutine
-    def stop(self, server_name=''):
+    async def stop(self, server_name=''):
         """Stop the user's spawner
 
         and cleanup after it.
@@ -517,9 +513,9 @@ class User:
         spawner._stop_pending = True
         try:
             api_token = spawner.api_token
-            status = yield spawner.poll()
+            status = await spawner.poll()
             if status is None:
-                yield spawner.stop()
+                await spawner.stop()
             spawner.clear_state()
             spawner.orm_spawner.state = spawner.get_state()
             self.last_activity = spawner.orm_spawner.last_activity = datetime.utcnow()
@@ -537,7 +533,7 @@ class User:
             auth = spawner.authenticator
             try:
                 if auth:
-                    yield gen.maybe_future(
+                    await gen.maybe_future(
                         auth.post_spawn_stop(self, spawner)
                     )
             except Exception:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -385,7 +385,7 @@ class User:
         try:
             # run optional preparation work to bootstrap the notebook
             await awaitable(spawner.run_pre_spawn_hook())
-            f = spawner.start()
+            f = awaitable(spawner.start())
             # commit any changes in spawner.start (always commit db changes before yield)
             db.commit()
             ip_port = await gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -20,7 +20,7 @@ import uuid
 import warnings
 
 from tornado import gen, ioloop, web
-from tornado.concurrent import to_asyncio_future
+from tornado.platform.asyncio import to_asyncio_future
 from tornado.httpclient import AsyncHTTPClient, HTTPError
 from tornado.log import app_log
 
@@ -123,7 +123,7 @@ async def exponential_backoff(
         deadline = random.uniform(deadline - tol, deadline + tol)
     scale = 1
     while True:
-        ret = await gen.maybe_future(pass_func(*args, **kwargs))
+        ret = await awaitable(pass_func(*args, **kwargs))
         # Truthy!
         if ret:
             return ret
@@ -428,8 +428,8 @@ def awaitable(obj):
     - asyncio Future (works both ways)
     """
     if inspect.isawaitable(obj):
-        # return obj that's already awaitable
-        return obj
+        # already awaitable, use ensure_future
+        return asyncio.ensure_future(obj)
     elif isinstance(obj, concurrent.futures.Future):
         return asyncio.wrap_future(obj)
     else:

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -123,7 +123,7 @@ async def exponential_backoff(
         deadline = random.uniform(deadline - tol, deadline + tol)
     scale = 1
     while True:
-        ret = await awaitable(pass_func(*args, **kwargs))
+        ret = await maybe_future(pass_func(*args, **kwargs))
         # Truthy!
         if ret:
             return ret
@@ -414,16 +414,17 @@ def print_stacks(file=sys.stderr):
             task.print_stack(file=file)
 
 
-def awaitable(obj):
-    """Wrap an object in something that's awaitable
+def maybe_future(obj):
+    """Return an asyncio Future
 
     Use instead of gen.maybe_future
 
     For our compatibility, this must accept:
 
-    - asyncio coroutine (gen.maybe_future doesn't work)
+    - asyncio coroutine (gen.maybe_future doesn't work in tornado < 5)
     - tornado coroutine (asyncio.ensure_future doesn't work)
     - scalar (asyncio.ensure_future doesn't work)
+    - concurrent.futures.Future (asyncio.ensure_future doesn't work)
     - tornado Future (works both ways)
     - asyncio Future (works both ways)
     """

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ import shutil
 import sys
 
 v = sys.version_info
-if v[:2] < (3,4):
-    error = "ERROR: JupyterHub requires Python version 3.4 or above."
+if v[:2] < (3, 5):
+    error = "ERROR: JupyterHub requires Python version 3.5 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -100,7 +100,7 @@ setup_args = dict(
     license             = "BSD",
     platforms           = "Linux, Mac OS X",
     keywords            = ['Interactive', 'Interpreter', 'Shell', 'Web'],
-    python_requires     = ">=3.4",
+    python_requires     = ">=3.5",
     classifiers         = [
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
Sets minimum Python version to 3.5

while working on #1694 I discovered an extremely useful asyncio feature: you can print the (nice, not-boilerplate-filled) stack of all running coroutines. Caveat: they must be 'real' asyncio coroutines, not tornado's like we are using.

This makes the case for adopting asyncio syntax pretty strong for debugging benefits. There are also minor performance benefits, but I don't think they will make much difference for us. That combined with 0.9 being a bit later than expected makes me feel okay requiring Python 3.5.

Python 3.4 is still supported by Python itself for one more year, so this is a bit earlier than we've usually dropped support for a given Python. By the time we release 0.9, Python 3.5 ought to be available in the last two Ubuntu LTS (16.04, 18.04 next month), the last two CentOS releases (6, 7), and Debian stable (stretch). Python 3.5 has been out ~2.5 years. Plus, anyone stuck in an older environment can always use conda/pyenv to get Python, so I'm not too bothered. Double plus, running the Hub in a container which is increasingly the standard way to do it eliminates all of the possible platform-python support issues.

This PR is mostly a big find/replace of `@gen.coroutine` -> `async def` and `yield` -> `await`. I also [investigated tornado/asyncio compatibility](https://gist.github.com/minrk/095b8eb5e115839b12abba1d4badd92e), and found that `yield` and `await` are almost perfectly interchangeable. Everying yieldable is awaitable (except concurrent.futures) and everything awaitable is yieldable. The one sticking point is `gen.maybe_future`, which accepts everything *except* asyncio coroutines in tornado 4. This is fixed in tornado 5, but I've replaced the use of `maybe_future` with our own utility which does the same thing, wrapping asyncio awaitables in `asyncio.ensure_future` and `concurrent.Futures` in `asyncio.wrap_future`. The result is that any user-defined method in a custom Spawner or Authenticator can start using `async def` now with jupyterhub 0.8, with one exception: 'maybe-future' APIs. Any `async def` coroutine that gets passed through `gen.maybe_future` won't work until tornado 5 is released later this month.

closes #1118