### PR TITLE
cleanup some cookie names

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -89,7 +89,7 @@ check if the cookie corresponds to the right user. This request is logged.
 If everything is working, the response logged will be similar to this:
 
 ```
-200 GET /hub/api/authorizations/cookie/jupyter-hub-token-name/[secret] (@10.0.1.4) 6.10ms
+200 GET /hub/api/authorizations/cookie/jupyterhub-token-name/[secret] (@10.0.1.4) 6.10ms
 ```
 
 You should see a similar 200 message, as above, in the Hub log when you first
@@ -99,7 +99,7 @@ may mean that your single-user notebook server isn't connecting to your Hub.
 If you see 403 (forbidden) like this, it's a token problem:
 
 ```
-403 GET /hub/api/authorizations/cookie/jupyter-hub-token-name/[secret] (@10.0.1.4) 4.14ms
+403 GET /hub/api/authorizations/cookie/jupyterhub-token-name/[secret] (@10.0.1.4) 4.14ms
 ```
 
 Check the logs of the single-user notebook server, which may have more detailed

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -152,7 +152,7 @@ class Hub(Server):
     of the server base_url.
     """
 
-    cookie_name = 'jupyter-hub-token'
+    cookie_name = 'jupyterhub-hub-login'
 
     @property
     def server(self):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -205,7 +205,7 @@ class User:
 
         # use fully quoted name for client_id because it will be used in cookie-name
         # self.escaped_name may contain @ which is legal in URLs but not cookie keys
-        client_id = 'user-%s' % quote(self.name)
+        client_id = 'jupyterhub-user-%s' % quote(self.name)
         if name:
             client_id = '%s-%s' % (client_id, quote(name))
         spawn_kwargs = dict(


### PR DESCRIPTION
In part to cleanup a few remnants of early design where jupyterhub was ‘jupyter-hub’ instead of ‘jupyterhub’. Should also clarify to some degree what the cookies are for.

- hub login cookie is now ‘jupyterhub-hub-login’ instead of ‘jupyter-hub-token’
- user server cookie is now ‘jupyterhub-user-<name>’ instead of ‘user-name’ to keep jupyterhub prefix on all cookies

All cookies at this point:

- jupyterhub-session-id on / : random key, doesn't identify users. Used for invalidating cookies on /user/:name via /hub/logout. Unencrypted, default expiry: Session
- jupyterhub-hub-login on /hub/ : the main login cookie, contains uuid mapped to hub username.
- jupyterhub-services on /services/ : same as hub-login but on /services/ path
- jupyterhub-user-<name> on /user/:name contains oauth token, used to authenticate requests to the single-user server /user/:name
- jupyterhub-user-<name>-oauth-state on /user/:name : short-lived token for oauth state during single-user server oauth with the hub. Default expiry: 10 minutes. If OAuth succeeds, cleared immediately after use.
- \_xsrf : used by notebook server for cross-origin protections (Hub uses a different scheme for CSRF)

Unless otherwise specified, all cookies are set via tornado's `set_secure_cookie`, which means they are encrypted and have a default expiry of 30 days.