### PR TITLE
Simplify root/login redirect behavior

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -82,15 +82,9 @@ class LoginHandler(BaseHandler):
         auth_timer.stop(send=False)
 
         if user:
-            already_running = False
-            if user.spawner.ready:
-                status = await user.spawner.poll()
-                already_running = (status is None)
-            if not already_running and not user.spawner.options_form \
-                    and not user.spawner.pending:
-                # logging in triggers spawn
-                await self.spawn_single_user(user)
-            self.redirect(self.get_next_url())
+            # register current user for subsequent requests to user (e.g. logging the request)
+            self.get_current_user = lambda: user
+            self.redirect(self.get_next_url(user))
         else:
             html = self._render(
                 login_error='Invalid username or password',

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -143,10 +143,6 @@ def test_referer_check(app):
     if user is None:
         user = add_user(app.db, name='admin', admin=True)
     cookies = yield app.login_user('admin')
-    app_user = app.users[user]
-    # stop the admin's server so we don't mess up future tests
-    yield app.proxy.delete_user(app_user)
-    yield app_user.stop()
 
     r = yield api_request(app, 'users',
         headers={

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -99,13 +99,13 @@ def test_create_named_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
-        'server': user.url,
+        'server': None,
         'servers': {
-            name: {
+            servername: {
                 'name': name,
                 'url': url_path_join(user.url, name, '/'),
             }
-            for name in ['', servername]
+            for name in [servername]
         },
     }
 
@@ -127,7 +127,7 @@ def test_delete_named_server(app, named_servers):
 
     r = yield api_request(app, 'users', username)
     r.raise_for_status()
-    
+
     user_model = r.json()
     user_model.pop('last_activity')
     assert user_model == {
@@ -136,13 +136,13 @@ def test_delete_named_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
-        'server': user.url,
+        'server': None,
         'servers': {
             name: {
                 'name': name,
                 'url': url_path_join(user.url, name, '/'),
             }
-            for name in ['']
+            for name in []
         },
     }
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -38,7 +38,7 @@ def test_root_auth(app):
     cookies = yield app.login_user('river')
     r = yield async_requests.get(public_url(app), cookies=cookies)
     r.raise_for_status()
-    assert r.url == public_url(app, app.users['river'])
+    assert r.url.startswith(public_url(app, app.users['river']))
 
 
 @pytest.mark.gen_test
@@ -341,7 +341,7 @@ def test_login_strip(app):
             data=form_data,
             allow_redirects=False,
         )
-    
+
     assert called_with == [form_data]
 
 
@@ -361,7 +361,7 @@ def test_login_redirect(app):
     r = yield get_page('login', app, cookies=cookies, allow_redirects=False)
     r.raise_for_status()
     assert r.status_code == 302
-    assert '/hub/' in r.headers['Location']
+    assert '/user/river' in r.headers['Location']
 
     # next URL given, use it
     r = yield get_page('login?next=/hub/admin', app, cookies=cookies, allow_redirects=False)


### PR DESCRIPTION
- ignore spawner state when determining redirect destination
- remove implicit spawn from login handler (rely on redirect to user.url for spawn)
- settings.redirect_to_server determines if login sends users to /user/:name vs /hub/home
- visiting `/hub/` should result in the same destination regardless of login state or spawner state

closes #1721