### PR TITLE
Allow checking PAM account stack during PAM auth

### DIFF
--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -26,7 +26,7 @@ from .utils import async_requests
 
 from pamela import PAMError
 
-def mock_authenticate(username, password, service='login'):
+def mock_authenticate(username, password, service, encoding):
     # just use equality for testing
     if password == username:
         return True
@@ -34,7 +34,14 @@ def mock_authenticate(username, password, service='login'):
         raise PAMError("Fake")
 
 
-def mock_open_session(username, service):
+def mock_check_account(username, service, encoding):
+    if username.startswith('notallowed'):
+        raise PAMError("Fake")
+    else:
+        return True
+
+
+def mock_open_session(username, service, encoding):
     pass
 
 
@@ -156,6 +163,7 @@ class MockPAMAuthenticator(PAMAuthenticator):
                 authenticate=mock_authenticate,
                 open_session=mock_open_session,
                 close_session=mock_open_session,
+                check_account=mock_check_account,
                 ):
             username = yield super(MockPAMAuthenticator, self).authenticate(*args, **kwargs)
         if username is None:

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -29,6 +29,29 @@ def test_pam_auth():
     })
     assert authorized is None
 
+    # Account check is on by default for increased security
+    authorized = yield authenticator.get_authenticated_user(None, {
+        'username': 'notallowedmatch',
+        'password': 'notallowedmatch',
+    })
+    assert authorized is None
+
+
+@pytest.mark.gen_test
+def test_pam_auth_account_check_disabled():
+    authenticator = MockPAMAuthenticator(check_account=False)
+    authorized = yield authenticator.get_authenticated_user(None, {
+        'username': 'allowedmatch',
+        'password': 'allowedmatch',
+    })
+    assert authorized['name'] == 'allowedmatch'
+
+    authorized = yield authenticator.get_authenticated_user(None, {
+        'username': 'notallowedmatch',
+        'password': 'notallowedmatch',
+    })
+    assert authorized['name'] == 'notallowedmatch'
+
 
 @pytest.mark.gen_test
 def test_pam_auth_whitelist():


### PR DESCRIPTION
Hello everybody, this patch lets the PAM authenticator do an optional account check during auth, which enables JH to respect PAM-accessible user access management. The current PAM auth pipeline checks that a user is __authenticated__, not whether they are __authorized__ for the given service.

If you have something AD/LDAP/SSO-like configured at the system level that speaks PAM and has service access restrictions (e.g. students in a department or single course may use the machine), JH's PAM authenticator won't enforce them, as it stops at authentication.

One workaround is to maintain a separate user whitelist and enforce that in the auth stack via pam_listfile.so, but it's a nasty hack as the file containing whitelisted usernames has to be constantly updated instead of relying on the preexisting, external, PAM-able system. The option to open a session on login does not trigger authorization checks, and that setting turns itself off when it fails anyway.

JH does have whitelisting features and LDAP plugins, but they add additional configuration and points of failure on systems where PAM already provides authentication and authorization.

This patch adds the configuration setting c.PAMAuthenticator.check_account to enable the check, and it is disabled by default. I've tested this patch out in the wild and also added a test, and all relevant tests are passing. 2 non-auth tests (one proxy and one app I believe) consistently failed on this branch and master, but that's probably docker's fault.

On a related note, I noticed that c.PAMAuthenticator.encoding is never used, is that a mistake? I forwarded the encoding to pamela for the account check as that seemed like the intended purpose. I can fix the missing encoding uses, or remove my own, depending on whether we're supposed to use the encoding setting or not.