### PR TITLE
Scheme part of SQLite database url is `sqlite://`

### DIFF
--- a/jupyterhub/check_db
+++ b/jupyterhub/check_db
@@ -952,8 +952,8 @@ class JupyterHub(Application):
         except OperationalError as e:
             self.log.error("Failed to connect to db: %s", self.db_url)
             self.log.debug("Database error was:", exc_info=True)
-            if self.db_url.startswith('sqlite:///'):
-                self._check_db_path(self.db_url.split(':///', 1)[1])
+            if self.db_url.startswith('sqlite://'):
+                self._check_db_path(self.db_url.split('://', 1)[1])
             self.log.critical('\n'.join([
                 "If you recently upgraded JupyterHub, try running",
                 "    jupyterhub upgrade-db",


### PR DESCRIPTION
The current implementation assumes the scheme part of a SQLite database url to be `sqlite:///`, it swallows the root path slash when a user config the `c.JupyterHub.db_url` item using an absolute path. In this case, `_check_db_path` will get a wrong relative path and report file missing. eg,

> [JupyterHub] INFO @app.py:init_secrets(834) Loading cookie_secret from /Volumes/Users/anonym/Work.localized/py/jupyterhub/config/jupyterhub_cookie_secret
[JupyterHub] ERROR @app.py:init_db(899) Failed to connect to db: sqlite:///Volumes/Users/anonym/Work.localized/py/jupyterhub/config/jupyterhub.sqlite
[JupyterHub] ERROR @app.py:_check_db_path(811) Directory /Volumes/Users/anonym/Work.localized/py/jupyterhub/config/Volumes/Users/anonym/Work.localized/py/jupyterhub/config does not exist
[JupyterHub] CRITICAL @app.py:init_db(906) If you recently upgraded JupyterHub, try running
        jupyterhub upgrade-db
    to upgrade your JupyterHub database schema