### PR TITLE
[MRG] Expose `auth_state` via /api/users/<name>

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -18,14 +18,14 @@ from .base import BaseHandler, APIHandler
 
 class TokenAPIHandler(APIHandler):
     @token_authenticated
-    async def get(self, token):
+    def get(self, token):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             orm_token = orm.OAuthAccessToken.find(self.db, token)
         if orm_token is None:
             raise web.HTTPError(404)
         if orm_token.user:
-            model = await self.user_model(self.users[orm_token.user])
+            model = self.user_model(self.users[orm_token.user])
         elif orm_token.service:
             model = self.service_model(orm_token.service)
         else:
@@ -71,13 +71,13 @@ class TokenAPIHandler(APIHandler):
         api_token = user.new_api_token(note=note)
         self.write(json.dumps({
             'token': api_token,
-            'user': await self.user_model(user),
+            'user': self.user_model(user),
         }))
 
 
 class CookieAPIHandler(APIHandler):
     @token_authenticated
-    async def get(self, cookie_name, cookie_value=None):
+    def get(self, cookie_name, cookie_value=None):
         cookie_name = quote(cookie_name, safe='')
         if cookie_value is None:
             self.log.warning("Cookie values in request body is deprecated, use `/cookie_name/cookie_value`")
@@ -87,7 +87,7 @@ class CookieAPIHandler(APIHandler):
         user = self._user_for_cookie(cookie_name, cookie_value)
         if user is None:
             raise web.HTTPError(404)
-        self.write(json.dumps(await self.user_model(user)))
+        self.write(json.dumps(self.user_model(user)))
 
 
 class OAuthHandler(BaseHandler, OAuth2Handler):

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -18,14 +18,14 @@ from .base import BaseHandler, APIHandler
 
 class TokenAPIHandler(APIHandler):
     @token_authenticated
-    def get(self, token):
+    async def get(self, token):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             orm_token = orm.OAuthAccessToken.find(self.db, token)
         if orm_token is None:
             raise web.HTTPError(404)
         if orm_token.user:
-            model = self.user_model(self.users[orm_token.user])
+            model = await self.user_model(self.users[orm_token.user])
         elif orm_token.service:
             model = self.service_model(orm_token.service)
         else:
@@ -71,13 +71,13 @@ class TokenAPIHandler(APIHandler):
         api_token = user.new_api_token(note=note)
         self.write(json.dumps({
             'token': api_token,
-            'user': self.user_model(user),
+            'user': await self.user_model(user),
         }))
 
 
 class CookieAPIHandler(APIHandler):
     @token_authenticated
-    def get(self, cookie_name, cookie_value=None):
+    async def get(self, cookie_name, cookie_value=None):
         cookie_name = quote(cookie_name, safe='')
         if cookie_value is None:
             self.log.warning("Cookie values in request body is deprecated, use `/cookie_name/cookie_value`")
@@ -87,12 +87,12 @@ class CookieAPIHandler(APIHandler):
         user = self._user_for_cookie(cookie_name, cookie_value)
         if user is None:
             raise web.HTTPError(404)
-        self.write(json.dumps(self.user_model(user)))
+        self.write(json.dumps(await self.user_model(user)))
 
 
 class OAuthHandler(BaseHandler, OAuth2Handler):
     """Implement OAuth provider handlers
-    
+
     OAuth2Handler sets `self.provider` in initialize,
     but we are already passing the Provider object via settings.
     """

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -142,6 +142,7 @@ class APIHandler(BaseHandler):
         'name': str,
         'admin': bool,
         'groups': list,
+        'auth_state': dict,
     }
 
     _group_model_types = {

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -71,7 +71,7 @@ class APIHandler(BaseHandler):
             self.log.error("Couldn't parse JSON", exc_info=True)
             raise web.HTTPError(400, 'Invalid JSON in body of request')
         return model
-    
+
     def write_error(self, status_code, **kwargs):
         """Write JSON errors instead of HTML"""
         exc_info = kwargs.get('exc_info')
@@ -94,7 +94,7 @@ class APIHandler(BaseHandler):
             'message': message or status_message,
         }))
 
-    def user_model(self, user):
+    async def user_model(self, user):
         """Get the JSON model for a User object"""
         if isinstance(user, orm.User):
             user = self.users[user.id]
@@ -107,6 +107,7 @@ class APIHandler(BaseHandler):
             'server': user.url if user.running else None,
             'pending': None,
             'last_activity': user.last_activity.isoformat(),
+            'auth_state': await user.get_auth_state(),
         }
         if '' in user.spawners:
             model['pending'] = user.spawners[''].pending or None
@@ -151,7 +152,7 @@ class APIHandler(BaseHandler):
 
     def _check_model(self, model, model_types, name):
         """Check a model provided by a REST API request
-        
+
         Args:
             model (dict): user-provided model
             model_types (dict): dict of key:type used to validate types and keys

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -94,7 +94,7 @@ class APIHandler(BaseHandler):
             'message': message or status_message,
         }))
 
-    async def user_model(self, user):
+    def user_model(self, user):
         """Get the JSON model for a User object"""
         if isinstance(user, orm.User):
             user = self.users[user.id]
@@ -107,7 +107,6 @@ class APIHandler(BaseHandler):
             'server': user.url if user.running else None,
             'pending': None,
             'last_activity': user.last_activity.isoformat(),
-            'auth_state': await user.get_auth_state(),
         }
         if '' in user.spawners:
             model['pending'] = user.spawners[''].pending or None

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -170,7 +170,10 @@ class UserAPIHandler(APIHandler):
             if self.find_user(data['name']):
                 raise web.HTTPError(400, "User %s already exists, username must be unique" % data['name'])
         for key, value in data.items():
-            setattr(user, key, value)
+            if key == 'auth_state':
+                await user.save_auth_state(value)
+            else:
+                setattr(user, key, value)
         self.db.commit()
         user_ = self.user_model(user)
         user_['auth_state'] = await user.get_auth_state()

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -112,7 +112,8 @@ class UserAPIHandler(APIHandler):
         # this means users can't see their own auth state unless they
         # are admins, Hub admins often are also marked as admins so they
         # will see their auth state but normal users won't
-        if user.admin:
+        requestor = self.get_current_user()
+        if requestor.admin:
             user_['auth_state'] = await user.get_auth_state()
         self.write(json.dumps(user_))
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -24,9 +24,7 @@ class SelfAPIHandler(APIHandler):
             user = self.get_current_user_oauth_token()
         if user is None:
             raise web.HTTPError(403)
-        user_ = self.user_model(user)
-        user_['auth_state'] = await user.get_auth_state()
-        self.write(json.dumps(user_))
+        self.write(json.dumps(self.user_model(user)))
 
 
 class UserListAPIHandler(APIHandler):

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -110,7 +110,12 @@ class UserAPIHandler(APIHandler):
     async def get(self, name):
         user = self.find_user(name)
         user_ = self.user_model(user)
-        user_['auth_state'] = await user.get_auth_state()
+        # auth state will only be shown if the requestor is an admin
+        # this means users can't see their own auth state unless they
+        # are admins, Hub admins often are also marked as admins so they
+        # will see their auth state but normal users won't
+        if user.admin:
+            user_['auth_state'] = await user.get_auth_state()
         self.write(json.dumps(user_))
 
     @admin_only

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -18,7 +18,6 @@ import jupyterhub
 from .. import orm
 from ..user import User
 from ..utils import url_path_join as ujoin
-from ..utils import maybe_future
 from . import mocking
 from .mocking import public_host, public_url
 from .utils import async_requests

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -201,6 +201,7 @@ def test_get_users(app):
             'admin': True,
             'server': None,
             'pending': None,
+            'auth_state': None,
         },
         {
             'kind': 'user',
@@ -209,6 +210,7 @@ def test_get_users(app):
             'admin': False,
             'server': None,
             'pending': None,
+            'auth_state': None,
         }
     ]
 
@@ -280,6 +282,7 @@ def test_get_user(app):
         'admin': False,
         'server': None,
         'pending': None,
+        'auth_state': None,
     }
 
 
@@ -593,7 +596,7 @@ def test_spawn_limit(app, no_patience, slow_spawn, request):
     user.spawner._start_future = Future()
     r = yield api_request(app, 'users', name, 'server', method='post')
     assert r.status_code == 429
-    
+
     # allow ykka to start
     users[0].spawner._start_future.set_result(None)
     # wait for ykka to finish

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -421,6 +421,31 @@ def test_make_admin(app):
     assert user.admin
 
 
+@mark.user
+@mark.gen_test
+def test_set_auth_state(app):
+    auth_state = {'secret': 'hello'}
+    db = app.db
+    name = 'admin'
+    user = find_user(db, name)
+    assert user is not None
+
+    r = yield api_request(app, 'users', name, method='patch',
+        data=json.dumps({'auth_state': auth_state})
+    )
+    assert r.status_code == 200
+    user = find_user(db, name)
+    assert user is not None
+    assert user.name == name
+    encrypted_auth = user.encrypted_auth_state
+    assert encrypted_auth is not None
+
+    r = yield api_request(app, 'users', name)
+    assert r.status_code == 200
+    assert user.name == name
+    assert r.json()['auth_state'] == auth_state
+
+
 @mark.gen_test
 def test_spawn(app):
     db = app.db

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -201,7 +201,6 @@ def test_get_users(app):
             'admin': True,
             'server': None,
             'pending': None,
-            'auth_state': None,
         },
         {
             'kind': 'user',
@@ -210,7 +209,6 @@ def test_get_users(app):
             'admin': False,
             'server': None,
             'pending': None,
-            'auth_state': None,
         }
     ]
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -284,6 +284,8 @@ def test_get_user(app):
         'admin': False,
         'server': None,
         'pending': None,
+        # auth state is present because requestor is an admin
+        'auth_state': None
     }
 
 
@@ -495,7 +497,8 @@ def test_user_get_auth_state(app, auth_state_enabled):
     assert user.name == name
     yield user.save_auth_state(auth_state)
 
-    r = yield api_request(app, 'users', name)
+    r = yield api_request(app, 'users', name,
+                          headers=auth_header(app.db, name))
 
     assert r.status_code == 200
     assert 'auth_state' not in r.json()

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -455,8 +455,10 @@ def test_user_set_auth_state(app, auth_state_enabled):
     user_auth_state = yield user.get_auth_state()
     assert user_auth_state is None
 
-    r = yield api_request(app, 'users', name, method='patch',
-        data=json.dumps({'auth_state': auth_state})
+    r = yield api_request(
+        app, 'users', name, method='patch',
+        data=json.dumps({'auth_state': auth_state}),
+        headers=auth_header(app.db, name),
     )
 
     assert r.status_code == 403

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -22,7 +22,7 @@ def test_pam_auth():
         'password': 'match',
     })
     assert authorized['name'] == 'match'
-    
+
     authorized = yield authenticator.get_authenticated_user(None, {
         'username': 'match',
         'password': 'nomatch',
@@ -61,13 +61,13 @@ def test_pam_auth_whitelist():
         'password': 'kaylee',
     })
     assert authorized['name'] == 'kaylee'
-    
+
     authorized = yield authenticator.get_authenticated_user(None, {
         'username': 'wash',
         'password': 'nomatch',
     })
     assert authorized is None
-    
+
     authorized = yield authenticator.get_authenticated_user(None, {
         'username': 'mal',
         'password': 'mal',
@@ -85,9 +85,9 @@ def test_pam_auth_group_whitelist():
     g = MockGroup('kaylee')
     def getgrnam(name):
         return g
-    
+
     authenticator = MockPAMAuthenticator(group_whitelist={'group'})
-    
+
     with mock.patch.object(auth, 'getgrnam', getgrnam):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'kaylee',
@@ -128,21 +128,21 @@ def test_cant_add_system_user():
     authenticator = auth.PAMAuthenticator(whitelist={'mal'})
     authenticator.add_user_cmd = ['jupyterhub-fake-command']
     authenticator.create_system_users = True
-    
+
     class DummyFile:
         def read(self):
             return b'dummy error'
-    
+
     class DummyPopen:
         def __init__(self, *args, **kwargs):
             self.args = args
             self.kwargs = kwargs
             self.returncode = 1
             self.stdout = DummyFile()
-        
+
         def wait(self):
             return
-    
+
     with mock.patch.object(auth, 'Popen', DummyPopen):
         with pytest.raises(RuntimeError) as exc:
             yield authenticator.add_user(user)
@@ -194,23 +194,6 @@ def test_handlers(app):
     a = auth.PAMAuthenticator()
     handlers = a.get_handlers(app)
     assert handlers[0][0] == '/login'
-
-
-@pytest.fixture
-def auth_state_enabled(app):
-    app.authenticator.auth_state = {
-        'who': 'cares',
-    }
-    app.authenticator.enable_auth_state = True
-    ck = crypto.CryptKeeper.instance()
-    before_keys = ck.keys
-    ck.keys = [os.urandom(32)]
-    try:
-        yield
-    finally:
-        ck.keys = before_keys
-        app.authenticator.enable_auth_state = False
-        app.authenticator.auth_state = None
 
 
 @pytest.mark.gen_test
@@ -270,7 +253,7 @@ def test_auth_admin_retained_if_unset(app):
 @pytest.fixture
 def auth_state_unavailable(auth_state_enabled):
     """auth_state enabled at the Authenticator level,
-    
+
     but unavailable due to no crypto keys.
     """
     crypto.CryptKeeper.instance().keys = []
@@ -343,5 +326,3 @@ def test_validate_names():
     a = auth.PAMAuthenticator(username_pattern='w.*')
     assert not a.validate_username('xander')
     assert a.validate_username('willow')
-
-

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -36,6 +36,7 @@ def test_default_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
+        'auth_state': None,
         'server': user.url,
         'servers': {
             '': {
@@ -63,6 +64,7 @@ def test_default_server(app, named_servers):
         'pending': None,
         'server': None,
         'servers': {},
+        'auth_state': None,
     }
 
 
@@ -99,6 +101,7 @@ def test_create_named_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
+        'auth_state': None,
         'server': None,
         'servers': {
             servername: {
@@ -136,6 +139,7 @@ def test_delete_named_server(app, named_servers):
         'kind': 'user',
         'admin': False,
         'pending': None,
+        'auth_state': None,
         'server': None,
         'servers': {
             name: {


### PR DESCRIPTION
Closes #1724.

This let's you get the auth state via the hub's API. It required making several methods async and adds a new key.

I would also like to modify the POST method so that users (admins) can modify their own (a user's) auth state.

The use case is allowing a service to refresh the auth tokens obtained during login to the hub and store the fresh tokens in the auth state so that newly spawned user servers pick them up.

---

When running the tests I noticed that one of them (`test_app.py::test_load_groups`) creates a `jupyterhub.sqlite` in the root directory. As a result it gets confused if there already is one there that has the wrong schema version. Is this on purpose or hard to fix?