### PR TITLE
expand user activity timestamps

### DIFF
--- a/jupyterhub/alembic/versions/56cc5a70207e_token_tracking.py
+++ b/jupyterhub/alembic/versions/56cc5a70207e_token_tracking.py
@@ -18,6 +18,7 @@ import sqlalchemy as sa
 
 def upgrade():
     tables = op.get_bind().engine.table_names()
+    op.add_column('users', sa.Column('created', sa.DateTime(), nullable=True))
     op.add_column('api_tokens', sa.Column('created', sa.DateTime(), nullable=True))
     op.add_column('api_tokens', sa.Column('last_activity', sa.DateTime(), nullable=True))
     op.add_column('api_tokens', sa.Column('note', sa.Unicode(length=1023), nullable=True))
@@ -31,6 +32,7 @@ def upgrade():
 def downgrade():
     op.drop_constraint(None, 'oauth_codes', type_='foreignkey')
     op.drop_constraint(None, 'oauth_access_tokens', type_='foreignkey')
+    op.add_column('users', 'created')
     op.drop_column('oauth_access_tokens', 'last_activity')
     op.drop_column('oauth_access_tokens', 'created')
     op.drop_column('api_tokens', 'note')

--- a/jupyterhub/alembic/versions/56cc5a70207e_token_tracking.py
+++ b/jupyterhub/alembic/versions/56cc5a70207e_token_tracking.py
@@ -18,7 +18,6 @@ import sqlalchemy as sa
 
 def upgrade():
     tables = op.get_bind().engine.table_names()
-    op.add_column('users', sa.Column('created', sa.DateTime(), nullable=True))
     op.add_column('api_tokens', sa.Column('created', sa.DateTime(), nullable=True))
     op.add_column('api_tokens', sa.Column('last_activity', sa.DateTime(), nullable=True))
     op.add_column('api_tokens', sa.Column('note', sa.Unicode(length=1023), nullable=True))
@@ -32,7 +31,6 @@ def upgrade():
 def downgrade():
     op.drop_constraint(None, 'oauth_codes', type_='foreignkey')
     op.drop_constraint(None, 'oauth_access_tokens', type_='foreignkey')
-    op.add_column('users', 'created')
     op.drop_column('oauth_access_tokens', 'last_activity')
     op.drop_column('oauth_access_tokens', 'created')
     op.drop_column('api_tokens', 'note')

--- a/jupyterhub/alembic/versions/99a28a4418e1_user_created.py
+++ b/jupyterhub/alembic/versions/99a28a4418e1_user_created.py
@@ -1,0 +1,47 @@
+"""user.created and spawner.started
+
+Revision ID: 99a28a4418e1
+Revises: 56cc5a70207e
+Create Date: 2018-03-21 14:27:17.466841
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '99a28a4418e1'
+down_revision = '56cc5a70207e'
+branch_labels = None
+depends_on = None
+
+
+from alembic import op
+import sqlalchemy as sa
+
+from datetime import datetime
+
+def upgrade():
+    op.add_column('users', sa.Column('created', sa.DateTime, nullable=True))
+    c = op.get_bind()
+    # fill created date with current time
+    now = datetime.utcnow()
+    c.execute("""
+        UPDATE users
+        SET created='%s'
+        """ % (now,)
+    )
+
+    tables = c.engine.table_names()
+
+    if 'spawners' in tables:
+        op.add_column('spawners', sa.Column('started', sa.DateTime, nullable=True))
+        # fill started value with now for running servers
+        c.execute("""
+            UPDATE spawners
+            SET started='%s'
+            WHERE server_id NOT NULL
+            """ % (now,)
+        )
+
+
+def downgrade():
+    op.drop_column('users', 'created')
+    op.drop_column('spawners', 'started')

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -8,7 +8,7 @@ import json
 from urllib.parse import quote
 
 from oauth2.web.tornado import OAuth2Handler
-from tornado import web, gen
+from tornado import web
 
 from .. import orm
 from ..user import User

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -24,7 +24,11 @@ class TokenAPIHandler(APIHandler):
             orm_token = orm.OAuthAccessToken.find(self.db, token)
         if orm_token is None:
             raise web.HTTPError(404)
+
+        # record activity whenever we see a token
+        now = orm_token.last_activity = datetime.utcnow()
         if orm_token.user:
+            orm_token.user.last_activity = now
             model = self.user_model(self.users[orm_token.user])
         elif orm_token.service:
             model = self.service_model(orm_token.service)
@@ -33,8 +37,6 @@ class TokenAPIHandler(APIHandler):
             self.db.delete(orm_token)
             self.db.commit()
             raise web.HTTPError(404)
-        # record activity whenever we see a token
-        orm_token.last_activity = datetime.utcnow()
         self.db.commit()
         self.write(json.dumps(model))
 

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -10,7 +10,7 @@ from tornado import web
 
 from .. import orm
 from ..handlers import BaseHandler
-from ..utils import url_path_join
+from ..utils import isoformat, url_path_join
 
 class APIHandler(BaseHandler):
 
@@ -103,7 +103,7 @@ class APIHandler(BaseHandler):
         last_activity = user.last_activity
         # don't call isoformat if last_activity is None
         if last_activity:
-            last_activity = last_activity.isoformat()
+            last_activity = isoformat(last_activity)
 
         model = {
             'kind': 'user',
@@ -122,7 +122,7 @@ class APIHandler(BaseHandler):
             for name, spawner in user.spawners.items():
                 last_activity = spawner.orm_spawner.last_activity
                 if last_activity:
-                    last_activity = last_activity.isoformat()
+                    last_activity = isoformat(last_activity)
                 if spawner.ready:
                     servers[name] = s = {
                         'name': name,

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -119,16 +119,16 @@ class APIHandler(BaseHandler):
         if '' in user.spawners:
             spawner = user.spawners['']
             model['pending'] = spawner.pending or None
-            if spawner.active and spawner.started:
-                model['started'] = isoformat(spawner.started)
+            if spawner.active and spawner.orm_spawner.started:
+                model['started'] = isoformat(spawner.orm_spawner.started)
 
         if self.allow_named_servers:
             servers = model['servers'] = {}
             for name, spawner in user.spawners.items():
-                last_activity = spawner.orm_spawner.last_activity
-                if last_activity:
-                    last_activity = isoformat(last_activity)
                 if spawner.ready:
+                    last_activity = spawner.orm_spawner.last_activity
+                    if last_activity:
+                        last_activity = isoformat(last_activity)
                     servers[name] = s = {
                         'name': name,
                         'last_activity': last_activity,

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -99,6 +99,12 @@ class APIHandler(BaseHandler):
         if isinstance(user, orm.User):
             user = self.users[user.id]
 
+
+        last_activity = user.last_activity
+        # don't call isoformat if last_activity is None
+        if last_activity:
+            last_activity = last_activity.isoformat()
+
         model = {
             'kind': 'user',
             'name': user.name,
@@ -106,7 +112,7 @@ class APIHandler(BaseHandler):
             'groups': [ g.name for g in user.groups ],
             'server': user.url if user.running else None,
             'pending': None,
-            'last_activity': user.last_activity.isoformat(),
+            'last_activity': last_activity,
         }
         if '' in user.spawners:
             model['pending'] = user.spawners[''].pending or None
@@ -114,8 +120,14 @@ class APIHandler(BaseHandler):
         if self.allow_named_servers:
             servers = model['servers'] = {}
             for name, spawner in user.spawners.items():
+                last_activity = spawner.orm_spawner.last_activity
+                if last_activity:
+                    last_activity = last_activity.isoformat()
                 if spawner.ready:
-                    servers[name] = s = {'name': name}
+                    servers[name] = s = {
+                        'name': name,
+                        'last_activity': last_activity,
+                    }
                     if spawner.pending:
                         s['pending'] = spawner.pending
                     if spawner.server:

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -112,10 +112,15 @@ class APIHandler(BaseHandler):
             'groups': [ g.name for g in user.groups ],
             'server': user.url if user.running else None,
             'pending': None,
+            'created': isoformat(user.created),
             'last_activity': last_activity,
+            'started': None,
         }
         if '' in user.spawners:
-            model['pending'] = user.spawners[''].pending or None
+            spawner = user.spawners['']
+            model['pending'] = spawner.pending or None
+            if spawner.active and spawner.started:
+                model['started'] = isoformat(spawner.started)
 
         if self.allow_named_servers:
             servers = model['servers'] = {}
@@ -127,6 +132,7 @@ class APIHandler(BaseHandler):
                     servers[name] = s = {
                         'name': name,
                         'last_activity': last_activity,
+                        'started': isoformat(spawner.orm_spawner.started),
                     }
                     if spawner.pending:
                         s['pending'] = spawner.pending

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1067,6 +1067,12 @@ class JupyterHub(Application):
                     such as when user accounts are deleted from the external system
                     without notifying JupyterHub.
                     """))
+            else:
+                # handle database upgrades where user.created is undefined.
+                # we don't want to allow user.created to be undefined,
+                # so initialize it to last_activity (if defined) or now.
+                if not user.created:
+                    user.created = user.last_activity or datetime.utcnow()
         db.commit()
 
         # The whitelist set and the users in the db are now the same.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1579,8 +1579,14 @@ class JupyterHub(Application):
                 dt = datetime.strptime(route_data['last_activity'], ISO8601_ms)
             except Exception:
                 dt = datetime.strptime(route_data['last_activity'], ISO8601_s)
-            user.last_activity = max(user.last_activity, dt)
-            spawner.last_activity = max(spawner.last_activity, dt)
+            if user.last_activity:
+                user.last_activity = max(user.last_activity, dt)
+            else:
+                user.last_activity = dt
+            if spawner.last_activity:
+                spawner.last_activity = max(spawner.last_activity, dt)
+            else:
+                spawner.last_activity = dt
             # FIXME: Make this configurable duration. 30 minutes for now!
             if (now - user.last_activity).total_seconds() < 30 * 60:
                 active_users_count += 1

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -26,7 +26,7 @@ from ..spawner import LocalProcessSpawner
 from ..utils import maybe_future, url_path_join
 from ..metrics import (
     SERVER_SPAWN_DURATION_SECONDS, ServerSpawnStatus,
-    PROXY_ADD_DURATION_SECONDS, ProxyAddStatus
+    PROXY_ADD_DURATION_SECONDS, ProxyAddStatus,
 )
 
 # pattern for the authentication token header

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -191,7 +191,8 @@ class BaseHandler(RequestHandler):
         if orm_token is None:
             return None
         else:
-            orm_token.last_activity = datetime.utcnow()
+            orm_token.last_activity = \
+                orm_token.user.last_activity = datetime.utcnow()
             self.db.commit()
             return self._user_from_orm(orm_token.user)
 
@@ -205,7 +206,11 @@ class BaseHandler(RequestHandler):
             return None
         else:
             # record token activity
-            orm_token.last_activity = datetime.utcnow()
+            now = datetime.utcnow()
+            orm_token.last_activity = now
+            if orm_token.user:
+                orm_token.user.last_activity = now
+
             self.db.commit()
             return orm_token.service or self._user_from_orm(orm_token.user)
 
@@ -231,6 +236,10 @@ class BaseHandler(RequestHandler):
             self.log.warning("Invalid cookie token")
             # have cookie, but it's not valid. Clear it and start over.
             clear()
+            return
+        # update user activity
+        user.last_activity = datetime.utcnow()
+        self.db.commit()
         return user
 
     def _user_from_orm(self, orm_user):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -134,7 +134,8 @@ class User(Base):
         return {s.name: s for s in self._orm_spawners}
 
     admin = Column(Boolean, default=False)
-    last_activity = Column(DateTime, default=datetime.utcnow)
+    created = Column(DateTime, default=datetime.utcnow)
+    last_activity = Column(DateTime, nullable=True)
 
     api_tokens = relationship("APIToken", backref="user")
     cookie_id = Column(Unicode(255), default=new_token, nullable=False, unique=True)
@@ -182,7 +183,7 @@ class Spawner(Base):
     state = Column(JSONDict)
     name = Column(Unicode(255))
 
-    last_activity = Column(DateTime, default=datetime.utcnow)
+    last_activity = Column(DateTime, nullable=True)
 
 
 class Service(Base):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -183,6 +183,7 @@ class Spawner(Base):
     state = Column(JSONDict)
     name = Column(Unicode(255))
 
+    started = Column(DateTime)
     last_activity = Column(DateTime, nullable=True)
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -115,7 +115,7 @@ def test_auth_api(app):
     assert r.status_code == 404
 
     # make a new cookie token
-    user = db.query(orm.User).first()
+    user = find_user(db, 'admin')
     api_token = user.new_api_token()
 
     # check success:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -380,7 +380,10 @@ class User:
             await maybe_future(authenticator.pre_spawn_start(self, spawner))
 
         spawner._start_pending = True
-        spawner.started = datetime.utcnow()
+        # update spawner start time, and activity for both spawner and user
+        self.last_activity = \
+            spawner.orm_spawner.started = \
+            spawner.orm_spawner.last_activity = datetime.utcnow()
         db.commit()
         # wait for spawner.start to return
         try:
@@ -529,7 +532,7 @@ class User:
                     self.db.delete(orm_token)
             self.db.commit()
         finally:
-            spawner.started = None
+            spawner.orm_spawner.started = None
             self.db.commit()
             # trigger post-spawner hook on authenticator
             auth = spawner.authenticator

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -459,7 +459,6 @@ class User:
         if self.state is None:
             self.state = {}
         spawner.orm_spawner.state = spawner.get_state()
-        self.last_activity = spawner.orm_spawner.last_activity = datetime.utcnow()
         db.commit()
         spawner._waiting_for_response = True
         try:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -380,6 +380,8 @@ class User:
             await maybe_future(authenticator.pre_spawn_start(self, spawner))
 
         spawner._start_pending = True
+        spawner.started = datetime.utcnow()
+        db.commit()
         # wait for spawner.start to return
         try:
             # run optional preparation work to bootstrap the notebook
@@ -527,6 +529,8 @@ class User:
                     self.db.delete(orm_token)
             self.db.commit()
         finally:
+            spawner.started = None
+            self.db.commit()
             # trigger post-spawner hook on authenticator
             auth = spawner.authenticator
             try:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -10,7 +10,6 @@ from oauth2.error import ClientNotFoundError
 from sqlalchemy import inspect
 from tornado import gen
 from tornado.log import app_log
-from traitlets import HasTraits, Any, Dict, default
 
 from .utils import maybe_future, url_path_join
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -6,6 +6,7 @@
 import asyncio
 from binascii import b2a_hex
 import concurrent.futures
+from datetime import datetime, timezone
 import random
 import errno
 import hashlib
@@ -15,7 +16,6 @@ import os
 import socket
 import sys
 import threading
-from threading import Thread
 import uuid
 import warnings
 
@@ -37,6 +37,16 @@ def random_port():
 # ISO8601 for strptime with/without milliseconds
 ISO8601_ms = '%Y-%m-%dT%H:%M:%S.%fZ'
 ISO8601_s = '%Y-%m-%dT%H:%M:%SZ'
+
+
+def isoformat(dt):
+    """Render a datetime object as an ISO 8601 UTC timestamp
+
+    Naïve datetime objects are assumed to be UTC
+    """
+    if dt.tzinfo:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt.isoformat() + 'Z'
 
 
 def can_connect(ip, port):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ tornado>=4.1
 jinja2
 pamela
 python-oauth2>=1.0
+python-dateutil
 SQLAlchemy>=1.1
 requests
 prometheus_client>=0.0.21

--- a/share/jupyterhub/static/js/admin.js
+++ b/share/jupyterhub/static/js/admin.js
@@ -58,7 +58,8 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function ($, bs, mo
     $(".time-col").map(function (i, el) {
         // convert ISO datestamps to nice momentjs ones
         el = $(el);
-        el.text(moment(new Date(el.text())).fromNow());
+        let m = moment(new Date(el.text().trim()));
+        el.text(m.isValid() ? m.fromNow() : "Never");
     });
 
     $(".stop-server").click(function () {

--- a/share/jupyterhub/templates/admin.html
+++ b/share/jupyterhub/templates/admin.html
@@ -45,7 +45,13 @@
       {% block user_row scoped %}
       <td class="name-col col-sm-2">{{u.name}}</td>
       <td class="admin-col col-sm-2">{% if u.admin %}admin{% endif %}</td>
-      <td class="time-col col-sm-3">{{u.last_activity.isoformat() + 'Z'}}</td>
+      <td class="time-col col-sm-3">
+        {%- if u.last_activity -%}
+        {{ u.last_activity.isoformat() + 'Z' }}
+        {%- else -%}
+        Never
+        {%- endif -%}
+      </td>
       <td class="server-col col-sm-2 text-center">
         <a role="button" class="stop-server btn btn-xs btn-danger {% if not u.running %}hidden{% endif %}">stop server</span>
         <a role="button" class="start-server btn btn-xs btn-success {% if u.running %}hidden{% endif %}">start server</span>


### PR DESCRIPTION
- adds user.created timestamp
- adds spawner.started timestamp
- adds spawner.last_activity (needed for named servers)
- update user activity whenever we see them performing any authenticated action
- update last_activity on token objects when they are used
- user.last_activity starts with no value, rather than user creation time.
  This allows recognizing users who have never logged in.
- cull-idle script supports max-age culling based on 'created' and 'started' timestamps