### PR TITLE
expose cookie options and pass them down to spawners

### DIFF
--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -218,6 +218,7 @@ class Service(LoggingConfigurable):
     base_url = Unicode()
     db = Any()
     orm = Any()
+    cookie_options = Dict()
 
     oauth_provider = Any()
 
@@ -299,6 +300,7 @@ class Service(LoggingConfigurable):
             environment=env,
             api_token=self.api_token,
             oauth_client_id=self.oauth_client_id,
+            cookie_options=self.cookie_options,
             cwd=self.cwd,
             hub=self.hub,
             user=_MockUser(

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -6,6 +6,7 @@ Contains base Spawner class & default implementation
 # Distributed under the terms of the Modified BSD License.
 
 import errno
+import json
 import os
 import pipes
 import shutil
@@ -99,11 +100,12 @@ class Spawner(LoggingConfigurable):
         """
         return bool(self.pending or self.ready)
 
-
+    # options passed by constructor
     authenticator = Any()
     hub = Any()
     orm_spawner = Any()
     db = Any()
+    cookie_options = Dict()
 
     @observe('orm_spawner')
     def _orm_spawner_changed(self, change):
@@ -125,7 +127,7 @@ class Spawner(LoggingConfigurable):
         if missing:
             raise NotImplementedError("class `{}` needs to redefine the `start`,"
                   "`stop` and `poll` methods. `{}` not redefined.".format(cls.__name__, '`, `'.join(missing)))
-    
+
     proxy_spec = Unicode()
 
     @property
@@ -587,6 +589,8 @@ class Spawner(LoggingConfigurable):
             env['JUPYTERHUB_ADMIN_ACCESS'] = '1'
         # OAuth settings
         env['JUPYTERHUB_CLIENT_ID'] = self.oauth_client_id
+        if self.cookie_options:
+            env['JUPYTERHUB_COOKIE_OPTIONS'] = json.dumps(self.cookie_options)
         env['JUPYTERHUB_HOST'] = self.hub.public_host
         env['JUPYTERHUB_OAUTH_CALLBACK_URL'] = \
             url_path_join(self.user.url, self.name, 'oauth_callback')

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -215,6 +215,7 @@ class User:
             proxy_spec=url_path_join(self.proxy_spec, name, '/'),
             db=self.db,
             oauth_client_id=client_id,
+            cookie_options = self.settings.get('cookie_options', {}),
         )
         # update with kwargs. Mainly for testing.
         spawn_kwargs.update(kwargs)


### PR DESCRIPTION
enables forcing all-session cookies with:

```python
c.JupyterHub.tornado_settings['cookie_options'] = {
    'expires_days': None,
}
```

closes #1672