### PR TITLE
avoid deleting routes for spawners in a pending state

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -312,7 +312,8 @@ class Proxy(LoggingConfigurable):
                             )
                             futures.append(self.add_user(user, name))
                 elif spawner.pending:
-                    # don't consider routes for spawners in any pending event stale
+                    # don't consider routes stale if the spawner is in any pending event
+                    # wait until after the pending state clears before taking any actions
                     # they could be pending deletion from the proxy!
                     good_routes.add(spawner.proxy_spec)
 

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -311,7 +311,9 @@ class Proxy(LoggingConfigurable):
                                 spec, route['target'], spawner.server,
                             )
                             futures.append(self.add_user(user, name))
-                elif spawner._spawn_pending:
+                elif spawner.pending:
+                    # don't consider routes for spawners in any pending event stale
+                    # they could be pending deletion from the proxy!
                     good_routes.add(spawner.proxy_spec)
 
         # check service routes


### PR DESCRIPTION
We previously checked if spawn_pending, but *any* transitional state should exclude them from the check

symptom: "Deleting stale route" messages occurring in the logs in the middle of shutting down user servers

Typical cause (where I found it in the Binder logs): if check_routes fires during idle-server culling, it may delete routes that the cull process is about to delete on its own. This is likely to happen if the default intervals of 5 minutes for check_routes and 10 minutes for cull-idle are used, since both events will be firing at the same time a lot.