### PR TITLE
Added Post groups API in group list handlers

### DIFF
--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -979,28 +979,12 @@ def test_add_multi_group(app):
     r_names = [group['name'] for group in reply]
     assert names == r_names
 
-    # for name in names:
-    #     user = find_user(db, name)
-    #     assert user is not None
-    #     assert user.name == name
-    #     assert not user.admin
-
     # try to create the same groups again
     r = yield api_request(app, 'users', method='post',
                           data=json.dumps({'groups': names}),
                           )
     assert r.status_code == 400
 
-    # names = ['a', 'b', 'ab']
-
-    # # try to create the same users again
-    # r = yield api_request(app, 'users', method='post',
-    #                       data=json.dumps({'usernames': names}),
-    #                       )
-    # assert r.status_code == 201
-    # reply = r.json()
-    # r_names = [user['name'] for user in reply]
-    # assert r_names == ['ab']
 
 @mark.group
 @mark.gen_test

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -968,6 +968,42 @@ def test_groups_list(app):
 
 @mark.group
 @mark.gen_test
+def test_add_multi_group(app):
+    db = app.db
+    names = ['group1', 'group2']
+    r = yield api_request(app, 'groups', method='post',
+                          data=json.dumps({'groups': names}),
+                          )
+    assert r.status_code == 201
+    reply = r.json()
+    r_names = [group['name'] for group in reply]
+    assert names == r_names
+
+    # for name in names:
+    #     user = find_user(db, name)
+    #     assert user is not None
+    #     assert user.name == name
+    #     assert not user.admin
+
+    # try to create the same groups again
+    r = yield api_request(app, 'users', method='post',
+                          data=json.dumps({'groups': names}),
+                          )
+    assert r.status_code == 400
+
+    # names = ['a', 'b', 'ab']
+
+    # # try to create the same users again
+    # r = yield api_request(app, 'users', method='post',
+    #                       data=json.dumps({'usernames': names}),
+    #                       )
+    # assert r.status_code == 201
+    # reply = r.json()
+    # r_names = [user['name'] for user in reply]
+    # assert r_names == ['ab']
+
+@mark.group
+@mark.gen_test
 def test_group_get(app):
     group = orm.Group.find(app.db, name='alphaflight')
     user = add_user(app.db, app=app, name='sasquatch')


### PR DESCRIPTION
Solves issue #1602 
Its possible to add/post multiple groups using the post method of "/groups" API.
