### PR TITLE
Progress on spawn-pending page

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -99,14 +99,9 @@ class APIHandler(BaseHandler):
 
     def server_model(self, spawner):
         """Get the JSON model for a Spawner"""
-        last_activity = spawner.orm_spawner.last_activity
-        # don't call isoformat if last_activity is None
-        if last_activity:
-            last_activity = isoformat(last_activity)
-
         return {
             'name': spawner.name,
-            'last_activity': last_activity,
+            'last_activity': isoformat(spawner.orm_spawner.last_activity),
             'started': isoformat(spawner.orm_spawner.started),
             'pending': spawner.pending,
             'url': url_path_join(spawner.user.url, spawner.name, '/'),
@@ -118,12 +113,6 @@ class APIHandler(BaseHandler):
         if isinstance(user, orm.User):
             user = self.users[user.id]
 
-
-        last_activity = user.last_activity
-        # don't call isoformat if last_activity is None
-        if last_activity:
-            last_activity = isoformat(last_activity)
-
         model = {
             'kind': 'user',
             'name': user.name,
@@ -133,8 +122,8 @@ class APIHandler(BaseHandler):
             'progress_url': user.spawner._progress_url if user.active else None,
             'pending': None,
             'created': isoformat(user.created),
-            'last_activity': last_activity,
             'started': None,
+            'last_activity': isoformat(user.last_activity),
         }
         if '' in user.spawners:
             server_model = self.server_model(user.spawners[''])

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -18,9 +18,12 @@ class APIHandler(BaseHandler):
     def content_security_policy(self):
         return '; '.join([super().content_security_policy, "default-src 'none'"])
 
+    def get_content_type(self):
+        return 'application/json'
+
     def set_default_headers(self):
         super().set_default_headers()
-        self.set_header('Content-Type', 'application/json')
+        self.set_header('Content-Type', self.get_content_type())
 
     def check_referer(self):
         """Check Origin for cross-site API requests.

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -18,13 +18,6 @@ class APIHandler(BaseHandler):
     def content_security_policy(self):
         return '; '.join([super().content_security_policy, "default-src 'none'"])
 
-    def get_content_type(self):
-        return 'application/json'
-
-    def set_default_headers(self):
-        super().set_default_headers()
-        self.set_header('Content-Type', self.get_content_type())
-
     def check_referer(self):
         """Check Origin for cross-site API requests.
 

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -103,7 +103,7 @@ class APIHandler(BaseHandler):
             'name': spawner.name,
             'last_activity': isoformat(spawner.orm_spawner.last_activity),
             'started': isoformat(spawner.orm_spawner.started),
-            'pending': spawner.pending,
+            'pending': spawner.pending or None,
             'url': url_path_join(spawner.user.url, spawner.name, '/'),
             'progress_url': spawner._progress_url,
         }
@@ -119,7 +119,7 @@ class APIHandler(BaseHandler):
             'admin': user.admin,
             'groups': [ g.name for g in user.groups ],
             'server': user.url if user.running else None,
-            'progress_url': user.spawner._progress_url if user.active else None,
+            'progress_url': user.progress_url(''),
             'pending': None,
             'created': isoformat(user.created),
             'started': None,
@@ -128,7 +128,7 @@ class APIHandler(BaseHandler):
         if '' in user.spawners:
             server_model = self.server_model(user.spawners[''])
             # copy some values from the default server to the user model
-            for key in ('started', 'pending', 'progress_url'):
+            for key in ('started', 'pending'):
                 model[key] = server_model[key]
 
         if self.allow_named_servers:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -5,10 +5,11 @@
 
 import json
 
-from tornado import gen, web
+from tornado import  web
+from tornado.iostream import StreamClosedError
 
 from .. import orm
-from ..utils import admin_only, maybe_future
+from ..utils import admin_only, maybe_future, url_path_join
 from .base import APIHandler
 
 
@@ -17,6 +18,7 @@ class SelfAPIHandler(APIHandler):
 
     Based on the authentication info. Acts as a 'whoami' for auth tokens.
     """
+
     async def get(self):
         user = self.get_current_user()
         if user is None:
@@ -101,6 +103,7 @@ def admin_or_self(method):
             raise web.HTTPError(404)
         return method(self, name, *args, **kwargs)
     return m
+
 
 class UserAPIHandler(APIHandler):
 
@@ -269,10 +272,108 @@ class UserAdminAccessAPIHandler(APIHandler):
             raise web.HTTPError(404)
 
 
+class SpawnProgressAPIHandler(APIHandler):
+    """EventStream handler for pending spawns"""
+    def get_content_type(self):
+        return 'text/event-stream'
+
+    async def send_event(self, event):
+        try:
+            self.write('data: {}\n\n'.format(json.dumps(event)))
+            await self.flush()
+        except StreamClosedError:
+            self.log.warning("Stream closed while handling %s", self.request.uri)
+            # raise Finish to halt the handler
+            raise web.Finish()
+
+    @admin_or_self
+    async def get(self, username, server_name=''):
+        self.set_header('Cache-Control', 'no-cache')
+        if server_name is None:
+            server_name = ''
+        user = self.find_user(username)
+        if user is None:
+            # no such user
+            raise web.HTTPError(404)
+        if server_name not in user.spawners:
+            # user has no such server
+            raise web.HTTPError(404)
+        spawner = user.spawners[server_name]
+        # cases:
+        # - spawner already started and ready
+        # - spawner not running at all
+        # - spawner failed
+        # - spawner pending start (what we expect)
+        url = url_path_join(user.url, server_name, '/')
+        ready_event = {
+            'progress': 100,
+            'ready': True,
+            'message': "Server ready at {}".format(url),
+            'html_message': 'Server ready at <a href="{0}">{0}</a>'.format(url),
+            'url': url,
+        }
+        failed_event = {
+            'progress': 100,
+            'failed': True,
+            'message': "Spawn failed",
+        }
+
+        if spawner.ready:
+            # spawner already ready. Trigger progress-completion immediately
+            self.log.info("Server %s is already started", spawner._log_name)
+            await self.send_event(ready_event)
+            return
+
+        if not spawner._spawn_pending:
+            # not pending, no progress to fetch
+            # check if spawner has just failed
+            f = spawner._spawn_future
+            if f and f.done() and f.exception():
+                failed_event['message'] = "Spawn failed: %s" % f.exception()
+                await self.send_event(failed_event)
+                return
+            else:
+                raise web.HTTPError(400, "%s is not starting...", spawner._log_name)
+
+        # retrieve progress events from the Spawner
+        async for event in spawner._generate_progress():
+            # don't allow events to sneakily set the 'ready flag'
+            if 'ready' in event:
+                event.pop('ready', None)
+            await self.send_event(event)
+
+        # events finished, check if we are still pending
+        if spawner._spawn_pending:
+            try:
+                await spawner._spawn_future
+            except Exception:
+                # suppress exceptions in spawn future,
+                # which will be logged elsewhere
+                pass
+
+        # progress finished, check if we are done
+        if spawner.ready:
+            # spawner is ready, signal completion and redirect
+            self.log.info("Server %s is ready", spawner._log_name)
+            await self.send_event(ready_event)
+            return
+        else:
+            # what happened? Maybe spawn failed?
+            f = spawner._spawn_future
+            if f and f.done() and f.exception():
+                failed_event['message'] = "Spawn failed: %s" % f.exception()
+            else:
+                self.log.warning("Server %s didn't start for unknown reason", spawner._log_name)
+            await self.send_event(failed_event)
+            return
+
+
 default_handlers = [
     (r"/api/user", SelfAPIHandler),
     (r"/api/users", UserListAPIHandler),
     (r"/api/users/([^/]+)", UserAPIHandler),
+    (r"/api/users/([^/]+)/server-progress", SpawnProgressAPIHandler),
+    (r"/api/users/([^/]+)/server-progress/([^/]*)", SpawnProgressAPIHandler),
     (r"/api/users/([^/]+)/server", UserServerAPIHandler),
     (r"/api/users/([^/]+)/servers/([^/]*)", UserServerAPIHandler),
     (r"/api/users/([^/]+)/admin-access", UserAdminAccessAPIHandler),

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -349,7 +349,7 @@ class SpawnProgressAPIHandler(APIHandler):
         if spawner._spawn_pending:
             # wait for spawn_future to complete
             # (ignore errors, which will be logged elsewhere)
-            await asyncio.wait(spawn_future)
+            await asyncio.wait([spawn_future])
 
         # progress and spawn finished, check if spawn succeeded
         if spawner.ready:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -372,9 +372,9 @@ default_handlers = [
     (r"/api/user", SelfAPIHandler),
     (r"/api/users", UserListAPIHandler),
     (r"/api/users/([^/]+)", UserAPIHandler),
-    (r"/api/users/([^/]+)/server-progress", SpawnProgressAPIHandler),
-    (r"/api/users/([^/]+)/server-progress/([^/]*)", SpawnProgressAPIHandler),
     (r"/api/users/([^/]+)/server", UserServerAPIHandler),
+    (r"/api/users/([^/]+)/server/progress", SpawnProgressAPIHandler),
     (r"/api/users/([^/]+)/servers/([^/]*)", UserServerAPIHandler),
+    (r"/api/users/([^/]+)/servers/([^/]*)/progress", SpawnProgressAPIHandler),
     (r"/api/users/([^/]+)/admin-access", UserAdminAccessAPIHandler),
 ]

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -135,11 +135,15 @@ class BaseHandler(RequestHandler):
             "report-uri " + self.csp_report_uri,
         ])
 
+    def get_content_type(self):
+        return 'text/html'
+
     def set_default_headers(self):
         """
         Set any headers passed as tornado_settings['headers'].
 
         By default sets Content-Security-Policy of frame-ancestors 'self'.
+        Also responsible for setting content-type header
         """
         # wrap in HTTPHeaders for case-insensitivity
         headers = HTTPHeaders(self.settings.get('headers', {}))
@@ -152,6 +156,7 @@ class BaseHandler(RequestHandler):
             self.set_header('Access-Control-Allow-Headers', 'accept, content-type, authorization')
         if 'Content-Security-Policy' not in headers:
             self.set_header('Content-Security-Policy', self.content_security_policy)
+        self.set_header('Content-Type', self.get_content_type())
 
     #---------------------------------------------------------------
     # Login and cookie-related

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -887,13 +887,6 @@ class UserSpawnHandler(BaseHandler):
                     pass
 
             # we may have waited above, check pending again:
-            url_parts = [self.hub.base_url, 'api/users', user.escaped_name]
-            if spawner.name:
-                url_parts.extend(['servers', spawner.name, 'progress'])
-            else:
-                url_parts.extend(['server/progress'])
-            progress_url = url_path_join(*url_parts)
-
             if spawner.pending:
                 self.log.info("%s is pending %s", spawner._log_name, spawner.pending)
                 # spawn has started, but not finished
@@ -902,7 +895,7 @@ class UserSpawnHandler(BaseHandler):
                 html = self.render_template(
                     "spawn_pending.html",
                     user=user,
-                    progress_url=progress_url,
+                    progress_url=spawner._progress_url,
                 )
                 self.finish(html)
                 return
@@ -934,7 +927,7 @@ class UserSpawnHandler(BaseHandler):
                 html = self.render_template(
                     "spawn_pending.html",
                     user=user,
-                    progress_url=progress_url,
+                    progress_url=spawner._progress_url,
                 )
                 self.finish(html)
                 return

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -887,11 +887,21 @@ class UserSpawnHandler(BaseHandler):
                     pass
 
             # we may have waited above, check pending again:
+            progress_url = url_path_join(
+                self.hub.base_url, 'api/users',
+                user.escaped_name, 'server-progress', spawner.name,
+            )
+
             if spawner.pending:
                 self.log.info("%s is pending %s", spawner._log_name, spawner.pending)
                 # spawn has started, but not finished
                 self.statsd.incr('redirects.user_spawn_pending', 1)
-                html = self.render_template("spawn_pending.html", user=user)
+                url_parts = []
+                html = self.render_template(
+                    "spawn_pending.html",
+                    user=user,
+                    progress_url=progress_url,
+                )
                 self.finish(html)
                 return
 
@@ -919,7 +929,11 @@ class UserSpawnHandler(BaseHandler):
                 self.log.info("%s is pending %s", spawner._log_name, spawner.pending)
                 # spawn has started, but not finished
                 self.statsd.incr('redirects.user_spawn_pending', 1)
-                html = self.render_template("spawn_pending.html", user=user)
+                html = self.render_template(
+                    "spawn_pending.html",
+                    user=user,
+                    progress_url=progress_url,
+                )
                 self.finish(html)
                 return
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -887,10 +887,12 @@ class UserSpawnHandler(BaseHandler):
                     pass
 
             # we may have waited above, check pending again:
-            progress_url = url_path_join(
-                self.hub.base_url, 'api/users',
-                user.escaped_name, 'server-progress', spawner.name,
-            )
+            url_parts = [self.hub.base_url, 'api/users', user.escaped_name]
+            if spawner.name:
+                url_parts.extend(['servers', spawner.name, 'progress'])
+            else:
+                url_parts.extend(['server/progress'])
+            progress_url = url_path_join(*url_parts)
 
             if spawner.pending:
                 self.log.info("%s is pending %s", spawner._log_name, spawner.pending)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -697,11 +697,8 @@ class BaseHandler(RequestHandler):
         try:
             await gen.with_timeout(timedelta(seconds=self.slow_stop_timeout), stop())
         except gen.TimeoutError:
-            if spawner._stop_pending:
-                # hit timeout, but stop is still pending
-                self.log.warning("User %s:%s server is slow to stop", user.name, name)
-            else:
-                raise
+            # hit timeout, but stop is still pending
+            self.log.warning("User %s:%s server is slow to stop", user.name, name)
 
     #---------------------------------------------------------------
     # template rendering

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -705,15 +705,15 @@ class Spawner(LoggingConfigurable):
         if not self._spawn_pending:
             raise RuntimeError("Spawn not pending, can't generate progress")
 
-        spawn_future = self._spawn_future
-
         await yield_({
             "progress": 0,
             "message": "Server requested",
         })
+        from async_generator import aclosing
 
-        async for event in iterate_until(spawn_future, self.progress()):
-            await yield_(event)
+        async with aclosing(self.progress()) as progress:
+            async for event in progress:
+                await yield_(event)
 
     @async_generator
     async def progress(self):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1096,6 +1096,7 @@ class LocalProcessSpawner(Spawner):
             if self.ip:
                 self.server.ip = self.ip
             self.server.port = self.port
+            self.db.commit()
         return (self.ip or '127.0.0.1', self.port)
 
     async def poll(self):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -692,6 +692,10 @@ class Spawner(LoggingConfigurable):
         if self.pre_spawn_hook:
             return self.pre_spawn_hook(self)
 
+    @property
+    def _progress_url(self):
+        return self.user.progress_url(self.name)
+
     @async_generator
     async def _generate_progress(self):
         """Private wrapper of progress generator

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -3,7 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import os
 import logging
 from getpass import getuser
@@ -12,6 +11,7 @@ from subprocess import TimeoutExpired
 from unittest import mock
 from pytest import fixture, raises
 from tornado import ioloop, gen
+from tornado.httpclient import HTTPError
 
 from .. import orm
 from .. import crypto
@@ -71,8 +71,10 @@ def cleanup_after(request, io_loop):
         for uid, user in app.users.items():
             for name, spawner in list(user.spawners.items()):
                 if spawner.active:
-                    print('closing', user)
-                    io_loop.run_sync(lambda: app.proxy.delete_user(user, name))
+                    try:
+                        io_loop.run_sync(lambda: app.proxy.delete_user(user, name))
+                    except HTTPError:
+                        pass
                     io_loop.run_sync(lambda: user.stop(name))
 
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -56,7 +56,7 @@ def io_loop(request):
 
 
 @fixture(autouse=True)
-def cleanup_after(request):
+def cleanup_after(request, io_loop):
     """function-scoped fixture to shutdown user servers
 
     allows cleanup of servers between tests
@@ -68,12 +68,12 @@ def cleanup_after(request):
         if not MockHub.initialized():
             return
         app = MockHub.instance()
-        loop = asyncio.new_event_loop()
         for uid, user in app.users.items():
             for name, spawner in list(user.spawners.items()):
                 if spawner.active:
-                    loop.run_until_complete(app.proxy.delete_user(user, name))
-                    loop.run_until_complete(user.stop(name))
+                    print('closing', user)
+                    io_loop.run_sync(lambda: app.proxy.delete_user(user, name))
+                    io_loop.run_sync(lambda: user.stop(name))
 
 
 @fixture(scope='module')

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -72,6 +72,7 @@ def cleanup_after(request):
         for uid, user in app.users.items():
             for name, spawner in list(user.spawners.items()):
                 if spawner.active:
+                    loop.run_until_complete(app.proxy.delete_user(user, name))
                     loop.run_until_complete(user.stop(name))
 
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -76,6 +76,7 @@ def cleanup_after(request, io_loop):
                     except HTTPError:
                         pass
                     io_loop.run_sync(lambda: user.stop(name))
+        app.db.commit()
 
 
 @fixture(scope='module')

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -201,10 +201,17 @@ def normalize_user(user):
     """
     for key in ('created', 'last_activity', 'started'):
         user[key] = normalize_timestamp(user[key])
+    if user['progress_url']:
+        user['progress_url'] = re.sub(
+            r'.*/hub/api',
+            'PREFIX/hub/api',
+            user['progress_url'],
+        )
     if 'servers' in user:
         for server in user['servers'].values():
             for key in ('started', 'last_activity'):
                 server[key] = normalize_timestamp(server[key])
+            server['progress_url'] = re.sub(r'.*/hub/api', 'PREFIX/hub/api', server['progress_url'])
     return user
 
 def fill_user(model):
@@ -221,6 +228,7 @@ def fill_user(model):
     model.setdefault('created', TIMESTAMP)
     model.setdefault('last_activity', TIMESTAMP)
     model.setdefault('started', None)
+    model.setdefault('progress_url', 'PREFIX/hub/api/users/{name}/server/progress'.format(**model))
     return model
 
 

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -41,6 +41,8 @@ def test_default_server(app, named_servers):
                 'started': TIMESTAMP,
                 'last_activity': TIMESTAMP,
                 'url': user.url,
+                'pending': None,
+                'progress_url': 'PREFIX/hub/api/users/{}/server/progress'.format(username),
             },
         },
     })
@@ -96,6 +98,9 @@ def test_create_named_server(app, named_servers):
                 'started': TIMESTAMP,
                 'last_activity': TIMESTAMP,
                 'url': url_path_join(user.url, name, '/'),
+                'pending': None,
+                'progress_url': 'PREFIX/hub/api/users/{}/servers/{}/progress'.format(
+                    username, servername),
             }
             for name in [servername]
         },
@@ -124,13 +129,7 @@ def test_delete_named_server(app, named_servers):
     assert user_model == fill_user({
         'name': username,
         'auth_state': None,
-        'servers': {
-            name: {
-                'name': name,
-                'url': url_path_join(user.url, name, '/'),
-            }
-            for name in []
-        },
+        'servers': {},
     })
 
 @pytest.mark.gen_test

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -110,9 +110,6 @@ def test_spawn_redirect(app):
     cookies = yield app.login_user(name)
     u = app.users[orm.User.find(app.db, name)]
 
-    # ensure wash's server isn't running:
-    r = yield api_request(app, 'users', name, 'server', method='delete', cookies=cookies)
-    r.raise_for_status()
     status = yield u.spawner.poll()
     assert status is not None
 

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -1,0 +1,57 @@
+"""Tests for utilities"""
+
+import asyncio
+import pytest
+
+from async_generator import async_generator, yield_
+from ..utils import iterate_until
+
+
+@async_generator
+async def yield_n(n, delay=0.01):
+    """Yield n items with a delay between each"""
+    for i in range(n):
+        if delay:
+            await asyncio.sleep(delay)
+        await yield_(i)
+
+
+def schedule_future(io_loop, *, delay, result=None):
+    """Construct a Future that will resolve after a delay"""
+    f = asyncio.Future()
+    if delay:
+        io_loop.call_later(delay, lambda: f.set_result(result))
+    else:
+        f.set_result(result)
+    return f
+
+
+@pytest.mark.gen_test
+@pytest.mark.parametrize("deadline, n, delay, expected", [
+    (0, 3, 1, []),
+    (0, 3, 0, [0, 1, 2]),
+    (5, 3, 0.01, [0, 1, 2]),
+    (0.5, 10, 0.2, [0, 1]),
+])
+async def test_iterate_until(io_loop, deadline, n, delay, expected):
+    f = schedule_future(io_loop, delay=deadline)
+
+    yielded = []
+    async for item in iterate_until(f, yield_n(n, delay=delay)):
+        yielded.append(item)
+    assert yielded == expected
+
+
+@pytest.mark.gen_test
+async def test_iterate_until_ready_after_deadline(io_loop):
+    f = schedule_future(io_loop, delay=0)
+
+    @async_generator
+    async def gen():
+        for i in range(5):
+            await yield_(i)
+
+    yielded = []
+    async for item in iterate_until(f, gen()):
+        yielded.append(item)
+    assert yielded == list(range(5))

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -3,7 +3,7 @@
 import asyncio
 import pytest
 
-from async_generator import async_generator, yield_
+from async_generator import aclosing, async_generator, yield_
 from ..utils import iterate_until
 
 
@@ -37,8 +37,9 @@ async def test_iterate_until(io_loop, deadline, n, delay, expected):
     f = schedule_future(io_loop, delay=deadline)
 
     yielded = []
-    async for item in iterate_until(f, yield_n(n, delay=delay)):
-        yielded.append(item)
+    async with aclosing(iterate_until(f, yield_n(n, delay=delay))) as items:
+        async for item in items:
+            yielded.append(item)
     assert yielded == expected
 
 
@@ -52,6 +53,7 @@ async def test_iterate_until_ready_after_deadline(io_loop):
             await yield_(i)
 
     yielded = []
-    async for item in iterate_until(f, gen()):
-        yielded.append(item)
+    async with aclosing(iterate_until(f, gen())) as items:
+        async for item in items:
+            yielded.append(item)
     assert yielded == list(range(5))

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -555,7 +555,10 @@ class User:
             except Exception:
                 self.log.exception("Error in Authenticator.post_spawn_stop for %s", self)
             spawner._stop_pending = False
-            if not (spawner._spawn_future and spawner._spawn_future.exception()):
+            if not (
+                spawner._spawn_future and
+                (not spawner._spawn_future.done() or spawner._spawn_future.exception())
+            ):
                 # pop Spawner *unless* it's stopping due to an error
                 # because some pages serve latest-spawn error messages
                 self.spawners.pop(server_name)

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -406,6 +406,7 @@ class User:
             if ip_port:
                 # get ip, port info from return value of start()
                 server.ip, server.port = ip_port
+                db.commit()
             else:
                 # prior to 0.7, spawners had to store this info in user.server themselves.
                 # Handle < 0.7 behavior with a warning, assuming info was stored in db by the Spawner.

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -320,6 +320,15 @@ class User:
         else:
             return self.base_url
 
+    def progress_url(self, server_name=''):
+        """API URL for progress endpoint for a server with a given name"""
+        url_parts = [self.settings['hub'].base_url, 'api/users', self.escaped_name]
+        if server_name:
+            url_parts.extend(['servers', server_name, 'progress'])
+        else:
+            url_parts.extend(['server/progress'])
+        return url_path_join(*url_parts)
+
     async def spawn(self, server_name='', options=None):
         """Start the user's spawner
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -554,5 +554,7 @@ class User:
             except Exception:
                 self.log.exception("Error in Authenticator.post_spawn_stop for %s", self)
             spawner._stop_pending = False
-            # pop the Spawner object
-            self.spawners.pop(server_name)
+            if not (spawner._spawn_future and spawner._spawn_future.exception()):
+                # pop Spawner *unless* it's stopping due to an error
+                # because some pages serve latest-spawn error messages
+                self.spawners.pop(server_name)

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -19,6 +19,7 @@ import threading
 import uuid
 import warnings
 
+from async_generator import async_generator, yield_
 from tornado import gen, ioloop, web
 from tornado.platform.asyncio import to_asyncio_future
 from tornado.httpclient import AsyncHTTPClient, HTTPError
@@ -445,3 +446,43 @@ def maybe_future(obj):
         return asyncio.wrap_future(obj)
     else:
         return to_asyncio_future(gen.maybe_future(obj))
+
+
+@async_generator
+async def iterate_until(deadline_future, generator):
+    """An async generator that yields items from a generator
+    until a deadline future resolves
+
+    This could *almost* be implemented as a context manager
+    like asyncio_timeout with a Future for the cutoff.
+
+    However, we want one distinction: continue yielding items
+    after the future is complete, as long as the are already finished.
+
+    Usage::
+
+        async for item in iterate_until(some_future, some_async_generator()):
+            print(item)
+
+    """
+    aiter = generator.__aiter__()
+    while True:
+        item_future = asyncio.ensure_future(aiter.__anext__())
+        await asyncio.wait(
+            [item_future, deadline_future],
+            return_when=asyncio.FIRST_COMPLETED)
+        if item_future.done():
+            try:
+                await yield_(item_future.result())
+            except StopAsyncIteration:
+                break
+        elif deadline_future.done():
+            # deadline is done *and* next item is not ready
+            # cancel item future to avoid warnings about
+            # unawaited tasks
+            if not item_future.cancelled():
+                item_future.cancel()
+            break
+        else:
+            # neither is done, this shouldn't happen
+            continue

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -45,6 +45,10 @@ def isoformat(dt):
 
     Naïve datetime objects are assumed to be UTC
     """
+    # allow null timestamps to remain None without
+    # having to check if isoformat should be called
+    if dt is None:
+        return None
     if dt.tzinfo:
         dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
     return dt.isoformat() + 'Z'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic
+async_generator>=1.8
 traitlets>=4.3.2
 tornado>=4.1
 jinja2

--- a/share/jupyterhub/static/less/page.less
+++ b/share/jupyterhub/static/less/page.less
@@ -12,3 +12,17 @@
 .hidden {
   display: none;
 }
+
+#progress-log {
+  margin-top: 8px;
+}
+
+.progress-log-event {
+  border-top: 1px solid #e7e7e7;
+  padding: 8px;
+}
+
+// hover-highlight on log events?
+// .progress-log-event:hover {
+//   background: rgba(66, 165, 245, 0.2);
+// }

--- a/share/jupyterhub/templates/spawn_pending.html
+++ b/share/jupyterhub/templates/spawn_pending.html
@@ -78,6 +78,8 @@ require(["jquery"], function ($) {
 
     if (evt.failed) {
       evtSource.close();
+      // stop spinner
+      $(".fa-pulse").removeClass("fa-pulse");
       // turn progress bar red
       progressBar.addClass('progress-bar-danger');
       // open event log for debugging

--- a/share/jupyterhub/templates/spawn_pending.html
+++ b/share/jupyterhub/templates/spawn_pending.html
@@ -10,9 +10,20 @@
       <p>You will be redirected automatically when it's ready for you.</p>
       {% endblock %}
       <p><i class="fa fa-spinner fa-pulse fa-fw fa-3x" aria-hidden="true"></i></p>
-      <a role="button" id="refresh" class="btn btn-lg btn-primary" href="#">refresh</a>
-    </div>
+      <div class="progress">
+        <div id="progress-bar" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;">
+          <span class="sr-only"><span id="sr-progress">0%</span> Complete</span>
+        </div>
+      </div>
+      <p id="progress-message"></p>
   </div>
+  <div class="row">
+    <div class="col-md-8 col-md-offset-2">
+      <details id="progress-details">
+        <summary>Event log</summary>
+        <div id="progress-log"></div>
+      </details>
+    </div>
 </div>
 
 {% endblock %}
@@ -24,9 +35,56 @@ require(["jquery"], function ($) {
   $("#refresh").click(function () {
     window.location.reload();
   })
-  setTimeout(function () {
-    window.location.reload();
-  }, 5000);
+
+  // hook up event-stream for progress
+  var evtSource = new EventSource("{{ progress_url }}");
+  var progressMessage = $("#progress-message");
+  var progressBar = $("#progress-bar");
+  var srProgress = $("#sr-progress");
+  var progressLog = $("#progress-log");
+
+  evtSource.onmessage = function(e) {
+    var evt = JSON.parse(e.data);
+    console.log(evt);
+    if (evt.progress !== undefined) {
+      // update progress
+      var progText = evt.progress.toString();
+      progressBar.attr('aria-valuenow', progText);
+      srProgress.text(progText + '%');
+      progressBar.css('width', progText + '%');
+    }
+    // update message
+    var html_message;
+    if (evt.html_message !== undefined) {
+      progressMessage.html(evt.html_message);
+      html_message = evt.html_message;
+    } else if (evt.message !== undefined) {
+      progressMessage.text(evt.message);
+      html_message = progressMessage.html();
+    }
+    if (html_message) {
+      progressLog.append(
+        $("<div>")
+          .addClass('progress-log-event')
+          .html(html_message)
+      );
+    }
+
+    if (evt.ready) {
+      // reload the current page
+      // which should result in a redirect to the running server
+      window.location.reload();
+    }
+
+    if (evt.failed) {
+      evtSource.close();
+      // turn progress bar red
+      progressBar.addClass('progress-bar-danger');
+      // open event log for debugging
+      $('progress-details').prop('open', true);
+    }
+  }
+
 });
 </script>
 {% endblock %}

--- a/share/jupyterhub/templates/spawn_pending.html
+++ b/share/jupyterhub/templates/spawn_pending.html
@@ -71,6 +71,7 @@ require(["jquery"], function ($) {
     }
 
     if (evt.ready) {
+      evtSource.close();
       // reload the current page
       // which should result in a redirect to the running server
       window.location.reload();
@@ -83,7 +84,7 @@ require(["jquery"], function ($) {
       // turn progress bar red
       progressBar.addClass('progress-bar-danger');
       // open event log for debugging
-      $('progress-details').prop('open', true);
+      $('#progress-details').prop('open', true);
     }
   }
 

--- a/share/jupyterhub/templates/spawn_pending.html
+++ b/share/jupyterhub/templates/spawn_pending.html
@@ -9,7 +9,6 @@
       <p>Your server is starting up.</p>
       <p>You will be redirected automatically when it's ready for you.</p>
       {% endblock %}
-      <p><i class="fa fa-spinner fa-pulse fa-fw fa-3x" aria-hidden="true"></i></p>
       <div class="progress">
         <div id="progress-bar" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;">
           <span class="sr-only"><span id="sr-progress">0%</span> Complete</span>
@@ -79,8 +78,6 @@ require(["jquery"], function ($) {
 
     if (evt.failed) {
       evtSource.close();
-      // stop spinner
-      $(".fa-pulse").removeClass("fa-pulse");
       // turn progress bar red
       progressBar.addClass('progress-bar-danger');
       // open event log for debugging


### PR DESCRIPTION
Implement progress bar on spawn-pending page:

![progress-2](https://user-images.githubusercontent.com/151929/38306137-d42298ee-380f-11e8-92d5-3c6c36f282e5.gif)


Spawners may define a `.progress` method. This method must be an async generator. This generator must yield event dicts of the form:

```python
{
  'progress': 80, # integer out of 100
  'message': 'text', # plain-text message
  'html_message': 'text', # optional html-formatted message
}
```

There is a default progress event implementation that has a single "Spawning server..." event at 50% progress.

On success, the user is sent to their server. On failure, the event log is expanded.

TODO:

- [x] implement Spawner.progress
- [x] implement default progress events (single "Spawning..." event)
- [x] implement event-stream API for spawner events
- [x] halt events when spawn finishes or fails, regardless of event iterator status
- [x] tests!

cc @clkao: would you like to take a stab at implementing `Spawner.progress` for KubeSpawner and see how well this fits?
