### PR TITLE
proxy performance tweaks

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1655,7 +1655,6 @@ class JupyterHub(Application):
 
         await self.proxy.check_routes(self.users, self._service_map)
 
-
         if self.service_check_interval and any(s.url for s in self._service_map.values()):
             pc = PeriodicCallback(self.check_services_health, 1e3 * self.service_check_interval)
             pc.start()

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -305,7 +305,7 @@ class Proxy(LoggingConfigurable):
 
         hub = self.app.hub
         if '/' not in routes:
-            self.log.warning("Adding missing default route")
+            self.log.warning("Adding default route")
             futures.append(self.add_hub_route(hub))
         else:
             route = routes['/']


### PR DESCRIPTION
related to #1754

This shouldn't significantly affect performance, but it might improve some edge cases. The main thing this should do is improve diagnostics when check_routes is costly.

- use semaphore to limit concurrent requests to the proxy
- add lock to prevent concurrent calls to check_routes (closes #1770)
- a bit more debug logging in check_routes
  - log (info) that check_routes is starting
  - log (debug) when fetching routes