### PR TITLE
Options form template variables

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -65,6 +65,8 @@ class SpawnHandler(BaseHandler):
     Only enabled when Spawner.options_form is defined.
     """
     async def _render_form(self, message='', for_user=None):
+        # Note that 'user' is the authenticated user making the request and
+        # 'for_user' is the user whose server is being spawned.
         user = for_user or self.get_current_user()
         spawner_options_form = await user.spawner.get_options_form()
         return self.render_template('spawn.html',
@@ -72,6 +74,7 @@ class SpawnHandler(BaseHandler):
             spawner_options_form=spawner_options_form,
             error_message=message,
             url=self.request.uri,
+            spawner=for_user.spawner
         )
 
     @web.authenticated


### PR DESCRIPTION
We are working on a custom spawner options form template for a custom spawner, and the form is a bit involved so putting it into `options_form` and hacking on it is a bit unwieldy.  With `options_form` though you can dynamically customize/personalize the form content, similar to how `batchspawner` does it.  But if the form is in a separate template, it's not quite the same.

This PR adds a `template_vars` configurable dict to `Spawner` and then when the form is rendered those variables are substituted in by Jinja2.  These variables can be computed when the spawner is instantiated --- that is the main idea, some other way of substituting in variables since we can't do .format().  I've tested it locally and it works.