### PR TITLE
raise 409 conflict on duplicate actions

### DIFF
--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -47,16 +47,16 @@ class GroupListAPIHandler(_GroupAPIHandler):
         model = self.get_json_body()
         if not model or not isinstance(model, dict) or not model.get('groups'):
             raise web.HTTPError(400, "Must specify at least one group to create")
-        
+
         groupnames = model.pop("groups",[])
         self._check_group_model(model)
-        
+
         created = []
         for name in groupnames:
             existing = orm.Group.find(self.db, name=name)
             if existing is not None:
-                raise web.HTTPError(400, "Group %s already exists" % name)
-        
+                raise web.HTTPError(409, "Group %s already exists" % name)
+
             usernames = model.get('users', [])
             # check that users exist
             users = self._usernames_to_users(usernames)
@@ -71,6 +71,7 @@ class GroupListAPIHandler(_GroupAPIHandler):
             created.append(group)
         self.write(json.dumps([self.group_model(group) for group in created]))
         self.set_status(201)
+
 
 class GroupAPIHandler(_GroupAPIHandler):
     """View and modify groups by name"""
@@ -91,7 +92,7 @@ class GroupAPIHandler(_GroupAPIHandler):
 
         existing = orm.Group.find(self.db, name=name)
         if existing is not None:
-            raise web.HTTPError(400, "Group %s already exists" % name)
+            raise web.HTTPError(409, "Group %s already exists" % name)
 
         usernames = model.get('users', [])
         # check that users exist

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -66,7 +66,7 @@ class UserListAPIHandler(APIHandler):
             raise web.HTTPError(400, msg)
 
         if not to_create:
-            raise web.HTTPError(400, "All %i users already exist" % len(usernames))
+            raise web.HTTPError(409, "All %i users already exist" % len(usernames))
 
         created = []
         for name in to_create:
@@ -122,7 +122,7 @@ class UserAPIHandler(APIHandler):
         data = self.get_json_body()
         user = self.find_user(name)
         if user is not None:
-            raise web.HTTPError(400, "User %s already exists" % name)
+            raise web.HTTPError(409, "User %s already exists" % name)
 
         user = self.user_from_username(name)
         if data:

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -357,7 +357,7 @@ def test_add_multi_user(app):
     r = yield api_request(app, 'users', method='post',
         data=json.dumps({'usernames': names}),
     )
-    assert r.status_code == 400
+    assert r.status_code == 409
 
     names = ['a', 'b', 'ab']
 
@@ -400,6 +400,19 @@ def test_add_user_bad(app):
     assert r.status_code == 400
     user = find_user(db, name)
     assert user is None
+
+
+@mark.user
+@mark.gen_test
+def test_add_user_duplicate(app):
+    db = app.db
+    name = 'user'
+    user = find_user(db, name)
+    # double-check that it exists
+    assert user is not None
+    r = yield api_request(app, 'users', name, method='post')
+    # special 409 conflict for creating a user that already exists
+    assert r.status_code == 409
 
 
 @mark.user
@@ -1005,7 +1018,7 @@ def test_add_multi_group(app):
     r = yield api_request(app, 'users', method='post',
                           data=json.dumps({'groups': names}),
                           )
-    assert r.status_code == 400
+    assert r.status_code == 409
 
 
 @mark.group
@@ -1054,7 +1067,7 @@ def test_group_create_delete(app):
 
     # create duplicate raises 400
     r = yield api_request(app, 'groups/omegaflight', method='post')
-    assert r.status_code == 400
+    assert r.status_code == 409
 
     r = yield api_request(app, 'groups/omegaflight', method='delete')
     assert r.status_code == 204


### PR DESCRIPTION
Makes it easier for clients (e.g. BinderHub) to retry failed actions and ignore failure due to duplicate transactions.