### PR TITLE
add missing commits for deprecated ip/port

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1042,6 +1042,7 @@ class LocalProcessSpawner(Spawner):
             if self.ip:
                 self.server.ip = self.ip
             self.server.port = self.port
+            self.db.commit()
         return (self.ip or '127.0.0.1', self.port)
 
     async def poll(self):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1032,17 +1032,6 @@ class LocalProcessSpawner(Spawner):
             raise
 
         self.pid = self.proc.pid
-
-        if self.__class__ is not LocalProcessSpawner:
-            # subclasses may not pass through return value of super().start,
-            # relying on deprecated 0.6 way of setting ip, port,
-            # so keep a redundant copy here for now.
-            # A deprecation warning will be shown if the subclass
-            # does not return ip, port.
-            if self.ip:
-                self.server.ip = self.ip
-            self.server.port = self.port
-            self.db.commit()
         return (self.ip or '127.0.0.1', self.port)
 
     async def poll(self):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -397,6 +397,7 @@ class User:
             if ip_port:
                 # get ip, port info from return value of start()
                 server.ip, server.port = ip_port
+                db.commit()
             else:
                 # prior to 0.7, spawners had to store this info in user.server themselves.
                 # Handle < 0.7 behavior with a warning, assuming info was stored in db by the Spawner.


### PR DESCRIPTION
Removes deprecated handling of Spawners that don't return (ip, port), which seems to have been causing sql issues in tests since the switch to asyncio, which has slightly different behavior for how finished coroutines are handled.