### PR TITLE
check if server is defined before accessing server.port

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -667,7 +667,7 @@ class Spawner(LoggingConfigurable):
 
         if self.port:
             args.append('--port=%i' % self.port)
-        elif self.server.port:
+        elif self.server and self.server.port:
             self.log.warning("Setting port from user.server is deprecated as of JupyterHub 0.7.")
             args.append('--port=%i' % self.server.port)
 


### PR DESCRIPTION
avoids error on premature access of Spawner.get_args if port is not set

closes #1776