### PR TITLE
fix and test deletion cascades

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -22,6 +22,11 @@ class TokenAPIHandler(APIHandler):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             orm_token = orm.OAuthAccessToken.find(self.db, token)
+            if orm_token and not orm_token.client_id:
+                self.log.warning("Deleting stale oauth token for %s", orm_token.user)
+                self.db.delete(orm_token)
+                self.db.commit()
+                orm_token = None
         if orm_token is None:
             raise web.HTTPError(404)
 

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -22,11 +22,6 @@ class TokenAPIHandler(APIHandler):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             orm_token = orm.OAuthAccessToken.find(self.db, token)
-            if orm_token and not orm_token.client_id:
-                self.log.warning("Deleting stale oauth token for %s", orm_token.user)
-                self.db.delete(orm_token)
-                self.db.commit()
-                orm_token = None
         if orm_token is None:
             raise web.HTTPError(404)
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -195,11 +195,6 @@ class BaseHandler(RequestHandler):
         orm_token = orm.OAuthAccessToken.find(self.db, token)
         if orm_token is None:
             return None
-        if orm_token and not orm_token.client_id:
-            self.log.warning("Deleting stale oauth token for %s", orm_token.user)
-            self.db.delete(orm_token)
-            self.db.commit()
-            return None
         orm_token.last_activity = \
             orm_token.user.last_activity = datetime.utcnow()
         self.db.commit()

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -151,6 +151,12 @@ class User(Base):
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
+    oauth_tokens = relationship(
+        "OAuthAccessToken",
+        backref="user",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
     cookie_id = Column(Unicode(255), default=new_token, nullable=False, unique=True)
     # User.state is actually Spawner state
     # We will need to figure something else out if/when we have multiple spawners per user

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -457,6 +457,19 @@ class OAuthAccessToken(Hashed, Base):
             prefix=self.prefix,
         )
 
+    @classmethod
+    def find(cls, db, token):
+        orm_token = super().find(db, token)
+        if orm_token and not orm_token.client_id:
+            app_log.warning(
+                "Deleting stale oauth token for %s with no client",
+                orm_token.user and orm_token.user.name,
+            )
+            db.delete(orm_token)
+            db.commit()
+            return
+        return orm_token
+
 
 class OAuthCode(Base):
     __tablename__ = 'oauth_codes'

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -274,8 +274,12 @@ def test_get_self(app):
     # identifying user via oauth token works
     u = add_user(db, app=app, name='orpheus')
     token = uuid.uuid4().hex
+    oauth_client = orm.OAuthClient(identifier='eurydice')
+    db.add(oauth_client)
+    db.commit()
     oauth_token = orm.OAuthAccessToken(
         user=u.orm_user,
+        client_id=oauth_client.identifier,
         token=token,
         grant_type=orm.GrantType.authorization_code,
     )

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -17,6 +17,11 @@ from .mocking import MockSpawner
 from ..emptyclass import EmptyClass
 
 
+def assert_not_found(db, ORMType, id):
+    """Assert that an item with a given id is not found"""
+    assert db.query(ORMType).filter(ORMType.id==id).first() is None
+
+
 def test_server(db):
     server = orm.Server()
     db.add(server)
@@ -116,14 +121,20 @@ def test_service_server(db):
     service = orm.Service(name='has_servers')
     db.add(service)
     db.commit()
-    
+
     assert service.server is None
     server = service.server = orm.Server()
     assert service
     assert server.id is None
     db.commit()
     assert isinstance(server.id, int)
-    
+    server_id = server.id
+
+    # deleting service should delete its server
+    db.delete(service)
+    db.commit()
+    assert_not_found(db, orm.Server, server_id)
+
 
 def test_token_find(db):
     service = db.query(orm.Service).first()
@@ -160,7 +171,7 @@ def test_spawn_fails(db):
     orm_user = orm.User(name='aeofel')
     db.add(orm_user)
     db.commit()
-    
+
     class BadSpawner(MockSpawner):
         @gen.coroutine
         def start(self):
@@ -181,7 +192,7 @@ def test_spawn_fails(db):
 def test_groups(db):
     user = orm.User.find(db, name='aeofel')
     db.add(user)
-    
+
     group = orm.Group(name='lives')
     db.add(group)
     db.commit()
@@ -191,6 +202,9 @@ def test_groups(db):
     db.commit()
     assert group.users == [user]
     assert user.groups == [group]
+    db.delete(user)
+    db.commit()
+    assert group.users == []
 
 
 @pytest.mark.gen_test
@@ -224,7 +238,7 @@ def test_auth_state(db):
     assert user.encrypted_auth_state is not None
     decrypted_state = yield user.get_auth_state()
     assert decrypted_state == state
-    
+
     # can't read auth_state without keys
     ck.keys = []
     auth_state = yield user.get_auth_state()
@@ -256,3 +270,97 @@ def test_auth_state(db):
     decrypted_state = yield user.get_auth_state()
     assert decrypted_state is None
 
+
+def test_spawner_delete_cascade(db):
+    user = orm.User(name='spawner-delete')
+    db.add(user)
+    db.commit()
+
+    spawner = orm.Spawner(user=user)
+    db.commit()
+    spawner.server = server = orm.Server()
+    db.commit()
+    db.delete(spawner)
+    server_id = server.id
+
+    # delete the user
+    db.delete(spawner)
+    db.commit()
+
+    # verify that server gets deleted
+    assert_not_found(db, orm.Server, server_id)
+
+
+def test_user_delete_cascade(db):
+    user = orm.User(name='db-delete')
+    oauth_client = orm.OAuthClient(identifier='db-delete-client')
+    db.add(user)
+    db.add(oauth_client)
+    db.commit()
+
+    # create a bunch of objects that reference the User
+    # these should all be deleted automatically when the user goes away
+    user.new_api_token()
+    api_token = user.api_tokens[0]
+    spawner = orm.Spawner(user=user)
+    db.commit()
+    spawner.server = server = orm.Server()
+    oauth_code = orm.OAuthCode(client_id=oauth_client.identifier, user_id=user.id)
+    db.add(oauth_code)
+    oauth_token = orm.OAuthAccessToken(
+        client_id=oauth_client.identifier,
+        user_id=user.id,
+        grant_type=orm.GrantType.authorization_code,
+    )
+    db.add(oauth_token)
+    db.commit()
+
+    # record all of the ids
+    spawner_id = spawner.id
+    server_id = server.id
+    api_token_id = api_token.id
+    oauth_code_id = oauth_code.id
+    oauth_token_id = oauth_token.id
+
+    # delete the user
+    db.delete(user)
+    db.commit()
+
+    # verify that everything gets deleted
+    assert_not_found(db, orm.APIToken, api_token_id)
+    assert_not_found(db, orm.Spawner, spawner_id)
+    assert_not_found(db, orm.Server, server_id)
+    assert_not_found(db, orm.OAuthCode, oauth_code_id)
+    assert_not_found(db, orm.OAuthAccessToken, oauth_token_id)
+
+
+def test_oauth_client_delete_cascade(db):
+    user = orm.User(name='oauth-delete')
+    oauth_client = orm.OAuthClient(identifier='oauth-delete-client')
+    db.add(user)
+    db.add(oauth_client)
+    db.commit()
+
+    # create a bunch of objects that reference the User
+    # these should all be deleted automatically when the user goes away
+    oauth_code = orm.OAuthCode(client_id=oauth_client.identifier, user_id=user.id)
+    db.add(oauth_code)
+    oauth_token = orm.OAuthAccessToken(
+        client_id=oauth_client.identifier,
+        user_id=user.id,
+        grant_type=orm.GrantType.authorization_code,
+    )
+    db.add(oauth_token)
+    db.commit()
+
+    # record all of the ids
+    oauth_code_id = oauth_code.id
+    oauth_token_id = oauth_token.id
+
+    # delete the user
+    db.delete(oauth_client)
+    db.commit()
+
+    # verify that everything gets deleted
+    assert_not_found(db, orm.OAuthCode, oauth_code_id)
+    assert_not_found(db, orm.OAuthAccessToken, oauth_token_id)


### PR DESCRIPTION
we were leaving some remnants in the database by assuming that some items would be deleted, when they were actually being detached.

- ensure foreign keys are enabled on sqlite (for `ondelete='CASCADE'` support)
- fix deletion cascades where relationships were causing dissociation
  instead of deletion
- handle possible failure to delete oauth tokens