### PR TITLE
/user/someone-else redirection retain query strings

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -985,6 +985,9 @@ class UserSpawnHandler(BaseHandler):
             # logged in as a different user, redirect
             self.statsd.incr('redirects.user_to_user', 1)
             target = url_path_join(current_user.url, user_path or '')
+            if self.request.query:
+                # FIXME: use urlunparse instead?
+                target += '?' + self.request.query
             self.redirect(target)
         else:
             # not logged in, clear any cookies and reload


### PR DESCRIPTION
Closes #1769 - A redirect from `/user/someone-else-user-account` to `/user/my-user-account` now retain query strings on redirection.

I simply copy-pasted the "retain query string"-logic from this redirection that functioned properly already.
https://github.com/jupyterhub/jupyterhub/blob/58069d015be486085351c98c14fd2181a58528c1/jupyterhub/handlers/base.py#L1011-L1017