### PR TITLE
don't expire objects on commit

### DIFF
--- a/jupyterhub/oauth/store.py
+++ b/jupyterhub/oauth/store.py
@@ -70,11 +70,12 @@ class AccessTokenStore(HubDBMixin, oauth2.store.AccessTokenStore):
 
         """
 
-        user = self.db.query(orm.User).filter(orm.User.id == access_token.user_id).first()
+        user = self.db.query(orm.User).filter_by(id=access_token.user_id).first()
         if user is None:
             raise ValueError("No user for access token: %s" % access_token.user_id)
+        client = self.db.query(orm.OAuthClient).filter_by(identifier=access_token.client_id).first()
         orm_access_token = orm.OAuthAccessToken(
-            client_id=access_token.client_id,
+            client=client,
             grant_type=access_token.grant_type,
             expires_at=access_token.expires_at,
             refresh_token=access_token.refresh_token,
@@ -127,10 +128,10 @@ class AuthCodeStore(HubDBMixin, oauth2.store.AuthCodeStore):
                                    :class:`oauth2.datatype.AuthorizationCode`.
         """
         orm_code = orm.OAuthCode(
-            client_id=authorization_code.client_id,
+            client=authorization_code.client,
             code=authorization_code.code,
             expires_at=authorization_code.expires_at,
-            user_id=authorization_code.user_id,
+            user=authorization_code.user,
             redirect_uri=authorization_code.redirect_uri,
             session_id=authorization_code.data.get('session_id', ''),
         )

--- a/jupyterhub/oauth/store.py
+++ b/jupyterhub/oauth/store.py
@@ -102,10 +102,12 @@ class AuthCodeStore(HubDBMixin, oauth2.store.AuthCodeStore):
                  given code.
 
         """
-        orm_code = self.db\
-            .query(orm.OAuthCode)\
-            .filter(orm.OAuthCode.code == code)\
+        orm_code = (
+            self.db
+            .query(orm.OAuthCode)
+            .filter_by(code=code)
             .first()
+        )
         if orm_code is None:
             raise AuthCodeNotFound()
         else:
@@ -119,7 +121,6 @@ class AuthCodeStore(HubDBMixin, oauth2.store.AuthCodeStore):
                 data={'session_id': orm_code.session_id},
             )
 
-
     def save_code(self, authorization_code):
         """
         Stores the data belonging to an authorization code token.
@@ -127,11 +128,29 @@ class AuthCodeStore(HubDBMixin, oauth2.store.AuthCodeStore):
         :param authorization_code: An instance of
                                    :class:`oauth2.datatype.AuthorizationCode`.
         """
+        orm_client = (
+            self.db
+            .query(orm.OAuthClient)
+            .filter_by(identifier=authorization_code.client_id)
+            .first()
+        )
+        if orm_client is None:
+            raise ValueError("No such client: %s" % authorization_code.client_id)
+
+        orm_user = (
+            self.db
+            .query(orm.User)
+            .filter_by(id=authorization_code.user_id)
+            .first()
+        )
+        if orm_user is None:
+            raise ValueError("No such user: %s" % authorization_code.user_id)
+
         orm_code = orm.OAuthCode(
-            client=authorization_code.client,
+            client=orm_client,
             code=authorization_code.code,
             expires_at=authorization_code.expires_at,
-            user=authorization_code.user,
+            user=orm_user,
             redirect_uri=authorization_code.redirect_uri,
             session_id=authorization_code.data.get('session_id', ''),
         )
@@ -147,7 +166,7 @@ class AuthCodeStore(HubDBMixin, oauth2.store.AuthCodeStore):
 
         :param code: The authorization code.
         """
-        orm_code = self.db.query(orm.OAuthCode).filter(orm.OAuthCode.code == code).first()
+        orm_code = self.db.query(orm.OAuthCode).filter_by(code=code).first()
         if orm_code is not None:
             self.db.delete(orm_code)
             self.db.commit()
@@ -167,7 +186,7 @@ class HashComparable:
     """
     def __init__(self, hashed_token):
         self.hashed_token = hashed_token
-    
+
     def __repr__(self):
         return "<{} '{}'>".format(self.__class__.__name__, self.hashed_token)
 
@@ -186,10 +205,12 @@ class ClientStore(HubDBMixin, oauth2.store.ClientStore):
         :raises: :class:`oauth2.error.ClientNotFoundError` if no data could be retrieved for
                  given client_id.
         """
-        orm_client = self.db\
-            .query(orm.OAuthClient)\
-            .filter(orm.OAuthClient.identifier == client_id)\
+        orm_client = (
+            self.db
+            .query(orm.OAuthClient)
+            .filter_by(identifier=client_id)
             .first()
+        )
         if orm_client is None:
             raise ClientNotFoundError()
         return Client(identifier=client_id,
@@ -203,10 +224,12 @@ class ClientStore(HubDBMixin, oauth2.store.ClientStore):
         hash its client_secret before putting it in the database.
         """
         # clear existing clients with same ID
-        for client in self.db\
-                .query(orm.OAuthClient)\
-                .filter(orm.OAuthClient.identifier == client_id):
-            self.db.delete(client)
+        for orm_client in (
+            self.db
+            .query(orm.OAuthClient)\
+            .filter_by(identifier=client_id)
+        ):
+            self.db.delete(orm_client)
         self.db.commit()
 
         orm_client = orm.OAuthClient(

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -599,5 +599,9 @@ def new_session_factory(url="sqlite:///:memory:", reset=False, **kwargs):
     check_db_revision(engine)
     Base.metadata.create_all(engine)
 
-    session_factory = sessionmaker(bind=engine)
+    # We set expire_on_commit=False, since we don't actually need
+    # SQLAlchemy to expire objects after commiting - we don't expect
+    # concurrent runs of the hub talking to the same db. Turning
+    # this off gives us a major performance boost
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
     return session_factory

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -621,7 +621,10 @@ def check_db_revision(engine):
         ))
 
 
-def new_session_factory(url="sqlite:///:memory:", reset=False, **kwargs):
+def new_session_factory(url="sqlite:///:memory:",
+                        reset=False,
+                        expire_on_commit=False,
+                        **kwargs):
     """Create a new session at url"""
     if url.startswith('sqlite'):
         kwargs.setdefault('connect_args', {'check_same_thread': False})
@@ -648,5 +651,7 @@ def new_session_factory(url="sqlite:///:memory:", reset=False, **kwargs):
     # SQLAlchemy to expire objects after commiting - we don't expect
     # concurrent runs of the hub talking to the same db. Turning
     # this off gives us a major performance boost
-    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    session_factory = sessionmaker(bind=engine,
+                                   expire_on_commit=expire_on_commit,
+    )
     return session_factory

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -222,11 +222,20 @@ class MockHub(JupyterHub):
 
     def load_config_file(self, *args, **kwargs):
         pass
+
     def init_tornado_application(self):
         """Instantiate the tornado Application object"""
         super().init_tornado_application()
         # reconnect tornado_settings so that mocks can update the real thing
         self.tornado_settings = self.users.settings = self.tornado_application.settings
+
+    def init_services(self):
+        # explicitly expire services before reinitializing
+        # this only happens in tests because re-initialize
+        # does not occur in a real instance
+        for service in self.db.query(orm.Service):
+            self.db.expire(service)
+        return super().init_services()
 
     @gen.coroutine
     def initialize(self, argv=None):

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -280,7 +280,7 @@ def test_get_self(app):
     db.commit()
     oauth_token = orm.OAuthAccessToken(
         user=u.orm_user,
-        client_id=oauth_client.identifier,
+        client=oauth_client,
         token=token,
         grant_type=orm.GrantType.authorization_code,
     )

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -370,14 +370,10 @@ def test_spawner_delete_server(app):
     assert spawner.server is not None
     assert spawner.orm_spawner.server is not None
 
-    # trigger delete via db
-    db.delete(spawner.orm_spawner.server)
-    db.commit()
-    assert spawner.orm_spawner.server is None
-
-    # setting server = None also triggers delete
+    # setting server = None triggers delete
     spawner.server = None
     db.commit()
+    assert spawner.orm_spawner.server is None
     # verify that the server was actually deleted from the db
     assert db.query(orm.Server).filter(orm.Server.id == server_id).first() is None
     # verify that both ORM and top-level references are None


### PR DESCRIPTION
after much sqlalchemy digging, we may have a sustainable solution for #1291.

The key points:

1. expire-on-commit, sqlalchemy's default behavior, means that on every commit, all of our local objects are expired.
   This means not only that we must re-retrieve information when we next use it,
   but also that expiry can itself be costly, as we can have many objects in memory to be marked as expired on every commit.
1. To enable this optimization, we must use sqlachemy's orm-level `relationships` for setting and propagating foreign-key relationships.
   This is what allows local updates of `User.api_tokens` lists, etc. to always be up-to-date.
   This means never setting foreign key columns directly, always assigning foreign keys via relationship
   (`APIToken(user=user)` not `APIToken(user_id=user.id)`).
1. relationships cover deletion in the `user.groups.remove(group)` direction, but not the `db.delete(group)` direction.
   We seem to have to add an sqlalchemy event listener for the deletion event to handle this.
   The current implementation expires relationships to a deleted entity.

Using sqlalchemy's relationships basically nullifies database-level ondelete behavior. This makes deletion quite a bit more costly, as sqlalchemy will propagate deletions in Python as one big transaction, rather than relying on the database-level implementation, which is much more efficient. E.g. for deleting a user:

1. query to find all spawners, api tokens, oauth tokens, codes, etc. for the user
2. delete everything that would be orphaned
3. keep querying in case that cascades more steps
4. finally delete the user

This could be a single delete statement with passive-deletes enabled.

There is a passive-delete option that can be used on relationships to skip this and rely on the database, but then we lose local propagation of deletions and are back to inconsistent state.