### PR TITLE
Always include server sub-models in user api requests

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
   title: JupyterHub
   description: The REST API for JupyterHub
-  version: 0.8.0dev
+  version: 0.9.0dev
   license:
     name: BSD-3-Clause
 schemes:
@@ -606,12 +606,52 @@ definitions:
         description: The user's notebook server's base URL, if running; null if not.
       pending:
         type: string
-        enum: ["spawn", "stop"]
+        enum: ["spawn", "stop", null]
         description: The currently pending action, if any
       last_activity:
         type: string
         format: date-time
         description: Timestamp of last-seen activity from the user
+      servers:
+        type: object
+        description: The active servers for this user.
+        items:
+          schema:
+            $ref: '#/definitions/Server'
+  Server:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The server's name. The user's default server has an empty name ('')
+      ready:
+        type: boolean
+        description: |
+          Whether the server is ready for traffic.
+          Will always be false when any transition is pending.
+      pending:
+        type: string
+        enum: ["spawn", "stop", null]
+        description: |
+          The currently pending action, if any.
+          A server is not ready if an action is pending.
+      url:
+        type: string
+        description: |
+          The URL where the server can be accessed
+          (typically /user/:name/:server.name/).
+      progress_url:
+        type: string
+        description: |
+          The URL for an event-stream to retrieve events during a spawn.
+      started:
+        type: string
+        format: date-time
+        description: UTC timestamp when the server was last started.
+      last_activity:
+        type: string
+        format: date-time
+        description: UTC timestamp last-seen activity on this server.
   Group:
     type: object
     properties:

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -97,6 +97,7 @@ class APIHandler(BaseHandler):
             'last_activity': isoformat(spawner.orm_spawner.last_activity),
             'started': isoformat(spawner.orm_spawner.started),
             'pending': spawner.pending or None,
+            'ready': spawner.ready,
             'url': url_path_join(spawner.user.url, spawner.name, '/'),
             'progress_url': spawner._progress_url,
         }
@@ -147,23 +148,19 @@ class APIHandler(BaseHandler):
             'admin': user.admin,
             'groups': [ g.name for g in user.groups ],
             'server': user.url if user.running else None,
-            'progress_url': user.progress_url(''),
             'pending': None,
             'created': isoformat(user.created),
-            'started': None,
             'last_activity': isoformat(user.last_activity),
         }
         if '' in user.spawners:
-            server_model = self.server_model(user.spawners[''])
-            # copy some values from the default server to the user model
-            for key in ('started', 'pending'):
-                model[key] = server_model[key]
+            model['pending'] = user.spawners[''].pending
 
-        if self.allow_named_servers:
-            servers = model['servers'] = {}
-            for name, spawner in user.spawners.items():
-                if spawner.ready:
-                    servers[name] = self.server_model(spawner)
+        servers = model['servers'] = {}
+        for name, spawner in user.spawners.items():
+            # include 'active' servers, not just ready
+            # (this includes pending events)
+            if spawner.active:
+                servers[name] = self.server_model(spawner)
         return model
 
     def group_model(self, group):

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -96,7 +96,7 @@ class APIHandler(BaseHandler):
             'name': spawner.name,
             'last_activity': isoformat(spawner.orm_spawner.last_activity),
             'started': isoformat(spawner.orm_spawner.started),
-            'pending': spawner.pending or None,
+            'pending': spawner.pending,
             'ready': spawner.ready,
             'url': url_path_join(spawner.user.url, spawner.name, '/'),
             'progress_url': spawner._progress_url,

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -137,7 +137,7 @@ class APIHandler(BaseHandler):
         model.update(extra)
         return model
 
-    def user_model(self, user):
+    def user_model(self, user, include_servers=False):
         """Get the JSON model for a User object"""
         if isinstance(user, orm.User):
             user = self.users[user.id]
@@ -154,6 +154,10 @@ class APIHandler(BaseHandler):
         }
         if '' in user.spawners:
             model['pending'] = user.spawners[''].pending
+
+        if not include_servers:
+            model['servers'] = None
+            return model
 
         servers = model['servers'] = {}
         for name, spawner in user.spawners.items():

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -35,7 +35,10 @@ class SelfAPIHandler(APIHandler):
 class UserListAPIHandler(APIHandler):
     @admin_only
     def get(self):
-        data = [ self.user_model(u) for u in self.db.query(orm.User) ]
+        data = [
+            self.user_model(u, include_servers=True)
+            for u in self.db.query(orm.User)
+        ]
         self.write(json.dumps(data))
 
     @admin_only
@@ -113,15 +116,15 @@ class UserAPIHandler(APIHandler):
     @admin_or_self
     async def get(self, name):
         user = self.find_user(name)
-        user_ = self.user_model(user)
+        model = self.user_model(user, include_servers=True)
         # auth state will only be shown if the requestor is an admin
         # this means users can't see their own auth state unless they
         # are admins, Hub admins often are also marked as admins so they
         # will see their auth state but normal users won't
         requestor = self.get_current_user()
         if requestor.admin:
-            user_['auth_state'] = await user.get_auth_state()
-        self.write(json.dumps(user_))
+            model['auth_state'] = await user.get_auth_state()
+        self.write(json.dumps(model))
 
     @admin_only
     async def post(self, name):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -81,7 +81,7 @@ class Spawner(LoggingConfigurable):
             return 'spawn'
         elif self._stop_pending:
             return 'stop'
-        return False
+        return None
 
     @property
     def ready(self):

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -200,14 +200,8 @@ def normalize_user(user):
     smooths out user model with things like timestamps
     for easier comparison
     """
-    for key in ('created', 'last_activity', 'started'):
+    for key in ('created', 'last_activity'):
         user[key] = normalize_timestamp(user[key])
-    if user['progress_url']:
-        user['progress_url'] = re.sub(
-            r'.*/hub/api',
-            'PREFIX/hub/api',
-            user['progress_url'],
-        )
     if 'servers' in user:
         for server in user['servers'].values():
             for key in ('started', 'last_activity'):
@@ -228,8 +222,7 @@ def fill_user(model):
     model.setdefault('pending', None)
     model.setdefault('created', TIMESTAMP)
     model.setdefault('last_activity', TIMESTAMP)
-    model.setdefault('started', None)
-    model.setdefault('progress_url', 'PREFIX/hub/api/users/{name}/server/progress'.format(**model))
+    model.setdefault('servers', {})
     return model
 
 

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -34,7 +34,6 @@ def test_default_server(app, named_servers):
         'name': username,
         'auth_state': None,
         'server': user.url,
-        'started': TIMESTAMP,
         'servers': {
             '': {
                 'name': '',
@@ -42,6 +41,7 @@ def test_default_server(app, named_servers):
                 'last_activity': TIMESTAMP,
                 'url': user.url,
                 'pending': None,
+                'ready': True,
                 'progress_url': 'PREFIX/hub/api/users/{}/server/progress'.format(username),
             },
         },
@@ -99,6 +99,7 @@ def test_create_named_server(app, named_servers):
                 'last_activity': TIMESTAMP,
                 'url': url_path_join(user.url, name, '/'),
                 'pending': None,
+                'ready': True,
                 'progress_url': 'PREFIX/hub/api/users/{}/servers/{}/progress'.format(
                     username, servername),
             }


### PR DESCRIPTION
Rather than only when named servers are enabled.

New server fields (started, ready, pending_url) introduced in 0.9 are exclusively in the new user.servers models, rather than duplicated to the top level. Only the pre-existing fields (pending, server.url as user.server, last_activity) are kept at the top level.

- Makes user structure less sensitive to configuration (always have user.servers, not just in certain situations)
- stops adding server-specific state from user model
- Adds explicit 'ready' boolean field in server models, deprecating the current implicit `bool(url)` used to determine if a server is running.