### PR TITLE
Add a pytest ini file for running marked tests and edit testing mock files

### DIFF
--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -1,5 +1,31 @@
-"""mock utilities for testing"""
+"""mock utilities for testing
 
+Functions
+---------
+- mock_authenticate
+- mock_check_account
+- mock_open_session
+
+Spawners
+--------
+- MockSpawner: based on LocalProcessSpawner
+- SlowSpawner:
+- NeverSpawner:
+- BadSpawner:
+- SlowBadSpawner
+- FormSpawner
+
+Other components
+----------------
+- MockPAMAuthenticator
+- MockHub
+- MockSingleUserServer
+- StubSingleUserSpawner
+
+- public_host
+- public_url
+
+"""
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import os
@@ -26,6 +52,7 @@ from .utils import async_requests
 
 from pamela import PAMError
 
+
 def mock_authenticate(username, password, service, encoding):
     # just use equality for testing
     if password == username:
@@ -49,7 +76,7 @@ class MockSpawner(LocalProcessSpawner):
     """Base mock spawner
     
     - disables user-switching that we need root permissions to do
-    - spawns jupyterhub.tests.mocksu instead of a full single-user server
+    - spawns `jupyterhub.tests.mocksu` instead of a full single-user server
     """
     def make_preexec_fn(self, *a, **kw):
         # skip the setuid stuff
@@ -72,6 +99,7 @@ class MockSpawner(LocalProcessSpawner):
         elif self.will_resume:
             self.use_this_api_token = self.api_token
         return super().start()
+
 
 class SlowSpawner(MockSpawner):
     """A spawner that takes a few seconds to start"""
@@ -128,7 +156,6 @@ class SlowBadSpawner(MockSpawner):
         raise RuntimeError("I don't work!")
 
 
-
 class FormSpawner(MockSpawner):
     """A spawner that has an options form defined"""
     options_form = "IMAFORM"
@@ -164,7 +191,7 @@ class MockPAMAuthenticator(PAMAuthenticator):
                 open_session=mock_open_session,
                 close_session=mock_open_session,
                 check_account=mock_check_account,
-                ):
+        ):
             username = yield super(MockPAMAuthenticator, self).authenticate(*args, **kwargs)
         if username is None:
             return

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -1,13 +1,16 @@
 """Mock service for testing Service integration
 
 A JupyterHub service running a basic HTTP server.
-Used by the mockservice fixtures.
 
-Handlers allow:
+Used by the `mockservice` fixtures found in `conftest.py` file.
 
-- echoing proxied URLs back
-- retrieving service's environment variables
-- testing service's API access to the Hub retrieval of sys.argv.
+Handlers and their purpose include:
+
+- EchoHandler: echoing proxied URLs back
+- EnvHandler: retrieving service's environment variables
+- APIHandler: testing service's API access to the Hub retrieval of `sys.argv`.
+- WhoAmIHandler: returns name of user making a request (deprecated cookie login)
+- OWhoAmIHandler: returns name of user making a request (OAuth login)
 """
 
 import json
@@ -51,11 +54,12 @@ class APIHandler(web.RequestHandler):
 class WhoAmIHandler(HubAuthenticated, web.RequestHandler):
     """Reply with the name of the user who made the request.
     
-    Uses deprecated cookie login
+    Uses "deprecated" cookie login
     """
     @web.authenticated
     def get(self):
         self.write(self.get_current_user())
+
 
 class OWhoAmIHandler(HubOAuthenticated, web.RequestHandler):
     """Reply with the name of the user who made the request.

--- a/jupyterhub/tests/mocksu.py
+++ b/jupyterhub/tests/mocksu.py
@@ -2,8 +2,15 @@
 
 basic HTTP Server that echos URLs back,
 and allow retrieval of sys.argv.
-"""
 
+Used by the mock spawners found in `mocking.py` file.
+
+Handlers and their purpose include:
+
+- EchoHandler: echoing URLs back
+- ArgsHandler: allowing retrieval of `sys.argv`.
+
+"""
 import argparse
 import json
 import sys

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -608,6 +608,7 @@ def test_spawn(app):
     assert app.users.count_active_users()['pending'] == 0
 
 
+@mark.slow
 @mark.gen_test
 def test_slow_spawn(app, no_patience, slow_spawn):
     db = app.db
@@ -712,7 +713,7 @@ def next_event(it):
         if line.startswith('data:'):
             return json.loads(line.split(':', 1)[1])
 
-
+@mark.slow
 @mark.gen_test
 def test_progress(request, app, no_patience, slow_spawn):
     db = app.db
@@ -950,7 +951,7 @@ def test_spawn_limit(app, no_patience, slow_spawn, request):
     while any(u.spawner.active for u in users):
         yield gen.sleep(0.1)
 
-
+@mark.slow
 @mark.gen_test
 def test_active_server_limit(app, request):
     db = app.db
@@ -1008,7 +1009,7 @@ def test_active_server_limit(app, request):
     assert counts['ready'] == 0
     assert counts['pending'] == 0
 
-
+@mark.slow
 @mark.gen_test
 def test_start_stop_race(app, no_patience, slow_spawn):
     user = add_user(app.db, app, name='panda')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+minversion = 3.3
+python_files = test_*.py
+markers =
+    gen_test: marks an async tornado test
+    group: mark as a test for groups
+    services: mark as a services test
+    user: mark as a test for a user
+    slow: mark a test as slow


### PR DESCRIPTION
- Add a `pytest.ini` so that it is easier to run local marked tests
- Add a "slow" mark to several tests that account for 1/3 of the testing time. This allows tests to be
   a bit quicker locally. It may also be useful for running the fast tests on Travis and running the slow
   ones only on fast passing
- Add/expand a file docstring for the files related to mocking tests to better capture what functionality is available when mocking

Slowest tests (`pytest -v --duration=10 jupyterhub/tests`):
```
5.02s call     jupyterhub/tests/test_api.py::test_start_stop_race
5.02s call     jupyterhub/tests/test_api.py::test_active_server_limit
4.33s call     jupyterhub/tests/test_api.py::test_slow_spawn
4.29s teardown jupyterhub/tests/test_api.py::test_start_stop_race
4.04s call     jupyterhub/tests/test_spawner.py::test_spawner_poll
3.23s call     jupyterhub/tests/test_app.py::test_token_app
2.69s call     jupyterhub/tests/test_singleuser.py::test_singleuser_auth
2.55s call     jupyterhub/tests/test_app.py::test_generate_config
2.11s teardown jupyterhub/tests/test_api.py::test_progress
2.08s call     jupyterhub/tests/test_api.py::test_progress
```

Tests without the 4 tests marked slow:
```
67.19 seconds
215 passed
4 delected
1 warning  `test_shell_cmd` in test spawner
```

All tests:
```
90.13 seconds
217 passed
2 failed
1 warning 1 error  `test_shell_cmd` is warning
jupyterhub/tests/test_api.py::test_active_server_limit FAILED                                                         - jupyterhub/tests/test_api.py::test_active_server_limit ERROR                                                          - jupyterhub/tests/test_api.py::test_start_stop_race FAILED
```