### PR TITLE
chore: bump moment.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bootstrap": "^3.3.7",
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",
-    "moment": "^2.18.1",
+    "moment": "^2.19.3",
     "requirejs": "^2.3.4"
   }
 }


### PR DESCRIPTION
Moving to 2.19.3 or higher to clear some regex issues