### PR TITLE
Use verb spawn in README to refer to things related to spawner

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Three main actors make up JupyterHub:
 
 Basic principles for operation are:
 
-- Hub spawns a proxy.
+- Hub launches a proxy.
 - Proxy forwards all requests to Hub by default.
 - Hub handles login, and spawns single-user servers on demand.
 - Hub configures proxy to forward url prefixes to the single-user notebook


### PR DESCRIPTION
We should probably use the verb spawn to refer to the spawner since the spawner is the name of a specific part of JHub

For future reference we may want to put this in the `CONTRIBUTING.md` or other style guide