### PR TITLE
allow authenticator to identify current user

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -234,6 +234,11 @@ class Authenticator(LoggingConfigurable):
             return True
         return username not in self.blacklist
 
+    def get_current_user(self, handler):
+        """Return username for current request.
+        """
+        return None
+
     async def get_authenticated_user(self, handler, data):
         """Authenticate the user who is attempting to log in
 
@@ -590,8 +595,8 @@ class PAMAuthenticator(LocalAuthenticator):
         help="""
         Whether to check the user's account status via PAM during authentication.
 
-        The PAM account stack performs non-authentication based account 
-        management. It is typically used to restrict/permit access to a 
+        The PAM account stack performs non-authentication based account
+        management. It is typically used to restrict/permit access to a
         service and this step is needed to access the host's user access control.
 
         Disabling this can be dangerous as authenticated but unauthorized users may

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -258,6 +258,13 @@ class BaseHandler(RequestHandler):
 
     def get_current_user(self):
         """get current username"""
+        user = self.authenticator.get_current_user(self)
+        if user is not None:
+            user = self.find_user(user)
+        if user is not None:
+            user.last_activiy = datetime.utcnow()
+            self.db.commit()
+            return user
         user = self.get_current_user_token()
         if user is not None:
             return user


### PR DESCRIPTION
I have the use case, where I want to use OAuth access tokens to identify the current user for an API request, when using oauthenticator.

Would something like this be useful?