### PR TITLE
Use URLs for config

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -308,7 +308,22 @@ class JupyterHub(Application):
 
         This is the address on which the proxy will listen. The default is to
         listen on all interfaces. This is the only address through which JupyterHub
-        should be accessed by users."""
+        should be accessed by users.
+
+        .. deprecated: 0.9
+        """
+    ).tag(config=True)
+
+    port = Integer(8000,
+        help="""The public facing port of the proxy.
+
+        This is the port on which the proxy will listen.
+        This is the only port through which JupyterHub
+        should be accessed by users.
+
+        .. deprecated: 0.9
+            Use JupyterHub.bind_url
+        """
     ).tag(config=True)
 
     @observe('ip', 'port')
@@ -323,6 +338,9 @@ class JupyterHub(Application):
 
         This is the address on which the proxy will bind.
         Sets protocol, ip, base_url
+
+        .. deprecated: 0.9
+            Use JupyterHub.bind_url
         """
     ).tag(config=True)
 
@@ -330,6 +348,17 @@ class JupyterHub(Application):
     def _bind_url_changed(self, change):
         urlinfo = urlparse(change.new)
         self.base_url = urlinfo.path
+
+    base_url = URLPrefix('/',
+        help="""The base URL of the entire application.
+
+        Add this to the beginning of all JupyterHub URLs.
+        Use base_url to run JupyterHub within an existing website.
+
+        .. deprecated: 0.9
+            Use JupyterHub.bind_url
+        """
+    ).tag(config=True)
 
     subdomain_host = Unicode('',
         help="""Run single-user servers on subdomains of this host.
@@ -362,21 +391,6 @@ class JupyterHub(Application):
             return ''
         return urlparse(self.subdomain_host).hostname
 
-    port = Integer(8000,
-        help="""The public facing port of the proxy.
-
-        This is the port on which the proxy will listen.
-        This is the only port through which JupyterHub
-        should be accessed by users.
-        """
-    ).tag(config=True)
-    base_url = URLPrefix('/',
-        help="""The base URL of the entire application.
-
-        Add this to the begining of all JupyterHub URLs.
-        Use base_url to run JupyterHub within an existing website.
-        """
-    ).tag(config=True)
     logo_file = Unicode('',
         help="Specify path to a logo image to override the Jupyter logo in the banner."
     ).tag(config=True)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -360,6 +360,12 @@ class JupyterHub(Application):
         """
     ).tag(config=True)
 
+    @default('base_url')
+    def _default_base_url(self):
+        # call validate to ensure leading/trailing slashes
+        print(self.bind_url)
+        return JupyterHub.base_url.validate(self, urlparse(self.bind_url).path)
+
     subdomain_host = Unicode('',
         help="""Run single-user servers on subdomains of this host.
 

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -305,7 +305,6 @@ class Proxy(LoggingConfigurable):
 
         hub = self.app.hub
         if '/' not in routes:
-            self.log.warning("Adding default route")
             futures.append(self.add_hub_route(hub))
         else:
             route = routes['/']

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -213,17 +213,21 @@ class MockHub(JupyterHub):
     """Hub with various mock bits"""
 
     db_file = None
-    
     last_activity_interval = 2
-    
-    base_url = '/@/space%20word/'
-    
     log_datefmt = '%M:%S'
-    
+
     @default('subdomain_host')
     def _subdomain_host_default(self):
         return os.environ.get('JUPYTERHUB_TEST_SUBDOMAIN_HOST', '')
-    
+
+    @default('bind_url')
+    def _default_bind_url(self):
+        if self.subdomain_host:
+            port = urlparse(self.subdomain_host).port
+        else:
+            port = random_port()
+        return 'http://127.0.0.1:%i/@/space%%20word/' % port
+
     @default('ip')
     def _ip_default(self):
         return '127.0.0.1'


### PR DESCRIPTION
deprecates ip/port config in favor of full URLs

- `JupyterHub.bind_url` for the public-facing URL of the whole thing (sets ip, port, proto, base_url)
- `JupyterHub.hub_bind_url` supports unix sockets as `unix+http://%2Ftmp%2Fhub.sock` (no other URLs support this yet)
- `JupyterHub.hub_connect_url` for the connect URL of the Hub, used by services, spawners, and proxy
- `Spawner.start` may return a URL in addition to `(ip, port)` tuple

Actually deprecated config (with warnings):

- `JupyterHub.hub_connect_port`

Superseded but not deprecated (no warnings, no plans to ever remove):

- `JupyterHub.ip`
- `JupyterHub.port`
- `JupyterHub.hub_ip`
- `JupyterHub.hub_port`
- `JupyterHub.hub_connect_ip` which is still useful for the common (e.g. docker) case of connect and bind IPs being different, but ports being the same. I don't think replacing these with redundant specifications of full URLs is desirable.

Among other things this allows specifying certain connections to be https, which wasn't possible in the ip/port cases.

closes #1289
closes #1287
closes #1446