### PR TITLE
Add custom handlers and allow setting of defaults

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -839,9 +839,7 @@ class JupyterHub(Application):
         return handlers
 
     extra_page_handlers = List().tag(config=True)
-    default_page = Any(default_value=None).tag(config=True)
-    default_user_page = Any(default_value=None).tag(config=True)
- 
+    default_url = Any(default_value=None).tag(config=True)
 
     def init_handlers(self):
         h = []

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -838,9 +838,20 @@ class JupyterHub(Application):
             handlers[i] = tuple(lis)
         return handlers
 
+    extra_page_handlers = List().tag(config=True)
+    default_page = Any(default_value=None).tag(config=True)
+    default_user_page = Any(default_value=None).tag(config=True)
+ 
+
     def init_handlers(self):
         h = []
+
+        # add any user configurable handlers. Make it first so it can override
+        # builtin handlers
+
+        h.extend(self.extra_page_handlers)
         # load handlers from the authenticator
+
         h.extend(self.authenticator.get_handlers(self))
         # set default handlers
         h.extend(handlers.default_handlers)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -838,8 +838,8 @@ class JupyterHub(Application):
             handlers[i] = tuple(lis)
         return handlers
 
-    extra_page_handlers = List().tag(config=True)
-    default_url = Any(default_value=None).tag(config=True)
+    extra_handlers = List(help="Register extra page handlers for jupyterhub, should be of the form (<regex>,handler)").tag(config=True)
+    default_url = Any(default_value=None, help='specify default URL for "next_url" (e.g. when user directs to "/"').tag(config=True)
 
     def init_handlers(self):
         h = []
@@ -850,7 +850,7 @@ class JupyterHub(Application):
         h.extend(apihandlers.default_handlers)
 
         # add any user configurable handlers.
-        h.extend(self.extra_page_handlers)
+        h.extend(self.extra_handlers)
 
         h.append((r'/logo', LogoHandler, {'path': self.logo_file}))
         self.handlers = self.add_url_prefix(self.hub_prefix, h)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -846,16 +846,15 @@ class JupyterHub(Application):
     def init_handlers(self):
         h = []
 
-        # add any user configurable handlers. Make it first so it can override
-        # builtin handlers
-
-        h.extend(self.extra_page_handlers)
         # load handlers from the authenticator
 
         h.extend(self.authenticator.get_handlers(self))
         # set default handlers
         h.extend(handlers.default_handlers)
         h.extend(apihandlers.default_handlers)
+
+        # add any user configurable handlers.
+        h.extend(self.extra_page_handlers)
 
         h.append((r'/logo', LogoHandler, {'path': self.logo_file}))
         self.handlers = self.add_url_prefix(self.hub_prefix, h)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -843,9 +843,7 @@ class JupyterHub(Application):
 
     def init_handlers(self):
         h = []
-
         # load handlers from the authenticator
-
         h.extend(self.authenticator.get_handlers(self))
         # set default handlers
         h.extend(handlers.default_handlers)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -431,9 +431,15 @@ class BaseHandler(RequestHandler):
             # default URL after login
             # if self.redirect_to_server, default login URL initiates spawn
             if user and self.redirect_to_server:
-                next_url = user.url
+                if self.config.JupyterHub.get('default_user_page'):
+                    next_url = self.config.JupyterHub['default_user_page']
+                else:
+                    next_url = user.url
             else:
-                next_url = url_path_join(self.hub.base_url, 'home')
+                if self.config.JupyterHub.get('default_page'):
+                    next_url = self.config.JupyterHub['default_page']
+                else:
+                    next_url = url_path_join(self.hub.base_url, 'home')
         return next_url
 
     async def login_user(self, data=None):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -427,7 +427,7 @@ class BaseHandler(RequestHandler):
                 self.request.uri, next_url,
             )
         if not next_url and self.config.JupyterHub.get('default_url'):
-            next_url = url_path_join(self.hub.base_url, self.config.JupyterHub['default_url'])
+            next_url = self.config.JupyterHub['default_url']
 
         if not next_url:
             # default URL after login

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -426,20 +426,16 @@ class BaseHandler(RequestHandler):
             self.log.warning("Redirecting %s to %s. For sharing public links, use /user-redirect/",
                 self.request.uri, next_url,
             )
+        if not next_url and self.config.JupyterHub.get('default_url'):
+            next_url = url_path_join(self.hub.base_url, self.config.JupyterHub['default_url'])
 
         if not next_url:
             # default URL after login
             # if self.redirect_to_server, default login URL initiates spawn
             if user and self.redirect_to_server:
-                if self.config.JupyterHub.get('default_user_page'):
-                    next_url = self.config.JupyterHub['default_user_page']
-                else:
-                    next_url = user.url
+                next_url = user.url
             else:
-                if self.config.JupyterHub.get('default_page'):
-                    next_url = self.config.JupyterHub['default_page']
-                else:
-                    next_url = url_path_join(self.hub.base_url, 'home')
+                next_url = url_path_join(self.hub.base_url, 'home')
         return next_url
 
     async def login_user(self, data=None):


### PR DESCRIPTION
Can be used to override existing handlers and add new ones, plus new defaults can be specified both for running user state and not.

Example usage:
```
c.JupyterHub.extra_page_handlers = [
    (r'/?', CustomRootHandler),
    (r'/welcome', WelcomeHandler)]

c.JupyterHub.default_user_page = "/welcome"
```

See https://github.com/jupyterhub/jupyterhub/issues/1853