### PR TITLE
Allow Authenticators to authenticate requests for API tokens

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -214,18 +214,29 @@ class UserTokenListAPIHandler(APIHandler):
             'oauth_tokens': oauth_tokens,
         }))
 
-    @admin_or_self
-    def post(self, name):
+    async def post(self, name):
+        body = self.get_json_body() or {}
+        if not isinstance(body, dict):
+            raise web.HTTPError(400, "Body must be a JSON dict or empty")
+
         requester = self.get_current_user()
+        if requester is None:
+            # defer to Authenticator for identifying the user
+            # can be username+password or an upstream auth token
+            name = await self.authenticator.authenticate(self, body.get('auth'))
+            requester = self.find_user(name)
+        if requester is None:
+            # couldn't identify requester
+            raise web.HTTPError(403)
         user = self.find_user(name)
         if requester is not user and not requester.admin:
             raise web.HTTPError(403, "Only admins can request tokens for other users")
         if not user:
             raise web.HTTPError(404, "No such user: %s" % name)
-        body = self.get_json_body()
         if requester is not user:
             kind = 'user' if isinstance(requester, User) else 'service'
-        note = (body or {}).get('note')
+
+        note = body.get('note')
         if not note:
             note = "Requested via api"
             if requester is not user:

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1289,6 +1289,31 @@ def test_token_for_user(app, as_user, for_user, status):
     )
     assert r.status_code == 404
 
+
+@mark.gen_test
+def test_token_authenticator_noauth(app):
+    """Create a token for a user relying on Authenticator.authenticate and no auth header"""
+    name = 'user'
+    data = {
+        'auth': {
+            'username': name,
+            'password': name,
+        },
+    }
+    r = yield api_request(app, 'users', name, 'tokens',
+        method='post',
+        data=json.dumps(data) if data else None,
+        noauth=True,
+    )
+    assert r.status_code == 200
+    reply = r.json()
+    assert 'token' in reply
+    r = yield api_request(app, 'authorizations', 'token', reply['token'])
+    r.raise_for_status()
+    reply = r.json()
+    assert reply['name'] == name
+
+
 @mark.gen_test
 @mark.parametrize("as_user, for_user, status", [
     ('admin', 'other', 200),


### PR DESCRIPTION
Gives Authenticators a hook for authenticating requests for JupyterHub API tokens,
e.g. with upstream access tokens or username+password.

This automatically works with form authenticators that use username+password fields.