### PR TITLE
Allow extra variables to be passed into templates

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -287,6 +287,10 @@ class JupyterHub(Application):
     def _template_paths_default(self):
         return [os.path.join(self.data_files_path, 'templates')]
 
+    template_vars = Dict(
+        help="Extra variables to be passed into jinja templates",
+    ).tag(config=True)
+
     confirm_no_ssl = Bool(False,
         help="""DEPRECATED: does nothing"""
     ).tag(config=True)
@@ -1514,6 +1518,7 @@ class JupyterHub(Application):
             static_url_prefix=url_path_join(self.hub.base_url, 'static/'),
             static_handler_class=CacheControlStaticFilesHandler,
             template_path=self.template_paths,
+            template_vars=self.template_vars,
             jinja2_env=jinja_env,
             version_hash=version_hash,
             subdomain_host=self.subdomain_host,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -752,7 +752,7 @@ class BaseHandler(RequestHandler):
     @property
     def template_namespace(self):
         user = self.get_current_user()
-        return dict(
+        ns = dict(
             base_url=self.hub.base_url,
             prefix=self.base_url,
             user=user,
@@ -762,6 +762,9 @@ class BaseHandler(RequestHandler):
             static_url=self.static_url,
             version_hash=self.version_hash,
         )
+        if self.settings['template_vars']:
+            ns.update(self.settings['template_vars'])
+        return ns
 
     def write_error(self, status_code, **kwargs):
         """render custom error pages"""


### PR DESCRIPTION
We make JupyterHub deploys fairly often, and we use custom templates for the JH control panel.  These vary slightly, but predictably, for deploy to deploy.  Right now, we upload slightly different versions to each deploy.  It would be easier if we could parameterize the templates.

This patch adds a `template_vars` config value, which takes a dictionary of variable names and values.  These are added to the variables passed in to every template construction.

One possible worry is that this could overwrite an existing variable name.  In some cases this might be useful as a feature, but that would seem to be pretty rare to me.  One way to avoid this would be to pass the dictionary directly into the template, instead of each of its entries.  This would cause the user to have to use `{{template_vars[var]}}` instead of just `{{var}}`.  I think this is pretty ugly, but if we're worried about this problem, it'd be an easy change.