### PR TITLE
implement API token expiry

### DIFF
--- a/jupyterhub/alembic/versions/896818069c98_token_expires.py
+++ b/jupyterhub/alembic/versions/896818069c98_token_expires.py
@@ -1,0 +1,24 @@
+"""Add APIToken.expires_at
+
+Revision ID: 896818069c98
+Revises: d68c98b66cd4
+Create Date: 2018-05-07 11:35:58.050542
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '896818069c98'
+down_revision = 'd68c98b66cd4'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('api_tokens', sa.Column('expires_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('api_tokens', 'expires_at')

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -115,16 +115,20 @@ class APIHandler(BaseHandler):
 
     def token_model(self, token):
         """Get the JSON model for an APIToken"""
+        expires_at = None
         if isinstance(token, orm.APIToken):
             kind = 'api_token'
             extra = {
                 'note': token.note,
             }
+            expires_at = token.expires_at
         elif isinstance(token, orm.OAuthAccessToken):
             kind = 'oauth'
             extra = {
                 'oauth_client': token.client.description or token.client.client_id,
             }
+            if token.expires_at:
+                expires_at = datetime.fromtimestamp(token.expires_at)
         else:
             raise TypeError(
                 "token must be an APIToken or OAuthAccessToken, not %s"


### PR DESCRIPTION
allows API tokens to expire.

Default behavior is unchanged (no expiry), but API tokens requested via the API can be given an `expires_at` argument for the lifetime (in seconds) of a token. This is potentially useful for something that wants to authenticate with the Hub for a brief period, but not take on responsibility for proliferating API tokens.

prompted by #1840