### PR TITLE
fix listing of OAuth tokens on tokens page

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -273,7 +273,7 @@ class TokenPageHandler(BaseHandler):
             token = tokens[0]
             oauth_clients.append({
                 'client': token.client,
-                'description': token.client.description or token.client.client_id,
+                'description': token.client.description or token.client.identifier,
                 'created': created,
                 'last_activity': last_activity,
                 'tokens': tokens,

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -447,6 +447,21 @@ def test_token_auth(app):
     assert r.status_code == 200
 
 
+@pytest.mark.gen_test
+def test_oauth_token_page(app):
+    name = 'token'
+    cookies = yield app.login_user(name)
+    user = app.users[orm.User.find(app.db, name)]
+    client = orm.OAuthClient(identifier='token')
+    app.db.add(client)
+    oauth_token = orm.OAuthAccessToken(client=client, user=user, grant_type=orm.GrantType.authorization_code)
+    app.db.add(oauth_token)
+    app.db.commit()
+    r = yield get_page('token', app, cookies=cookies)
+    r.raise_for_status()
+    assert r.status_code == 200
+
+
 @pytest.mark.parametrize("error_status", [
     503,
     404,


### PR DESCRIPTION
After spawning a new notebook server the token listing page returns with an error 500. The logs show an AttributError with unknown attribute client_id.

orm.OAuthClient does not have an attribute client_id