### PR TITLE
Prevent TypeError if post_stop_hook is undefined

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -703,10 +703,11 @@ class Spawner(LoggingConfigurable):
 
     def run_post_stop_hook(self):
         """Run the post_stop_hook if defined"""
-        try:
-            return self.post_stop_hook(self)
-        except Exception:
-            self.log.exception("post_stop_hook failed with exception: %s", self)
+        if self.post_stop_hook:
+            try:
+                return self.post_stop_hook(self)
+            except Exception:
+                self.log.exception("post_stop_hook failed with exception: %s", self)
 
     @property
     def _progress_url(self):


### PR DESCRIPTION
Fixes the below error:
```
[E 2018-05-11 14:23:36.102 JupyterHub spawner:709] post_stop_hook failed with exception: <winhpc.jupyter.WinHPCSpawner object at 0x000002296B75DB00>
    Traceback (most recent call last):
      File "c:\dev\src\jupyterhub\jupyterhub\spawner.py", line 707, in run_post_stop_hook
        return self.post_stop_hook(self)
    TypeError: 'NoneType' object is not callable
```