### PR TITLE
test default_url handling

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -937,8 +937,23 @@ class JupyterHub(Application):
             handlers[i] = tuple(lis)
         return handlers
 
-    extra_handlers = List(help="Register extra page handlers for jupyterhub, should be of the form (<regex>,handler)").tag(config=True)
-    default_url = Any(default_value=None, help='specify default URL for "next_url" (e.g. when user directs to "/"').tag(config=True)
+    extra_handlers = List(
+        help="""
+        Register extra tornado Handlers for jupyterhub.
+
+        Should be of the form ``("<regex>", Handler)``
+
+        The Hub prefix will be added, so `/my-page` will be served at `/hub/my-page`.
+        """,
+    ).tag(config=True)
+
+    default_url = Unicode(
+        help="""
+        The default URL for users when they arrive (e.g. when user directs to "/")
+
+        By default, redirects users to their own server.
+        """,
+    ).tag(config=True)
 
     def init_handlers(self):
         h = []
@@ -1541,6 +1556,7 @@ class JupyterHub(Application):
             authenticator=self.authenticator,
             spawner_class=self.spawner_class,
             base_url=self.base_url,
+            default_url=self.default_url,
             cookie_secret=self.cookie_secret,
             cookie_max_age_days=self.cookie_max_age_days,
             redirect_to_server=self.redirect_to_server,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -62,6 +62,10 @@ class BaseHandler(RequestHandler):
         return self.settings.get('base_url', '/')
 
     @property
+    def default_url(self):
+        return self.settings.get('default_url', '')
+
+    @property
     def version_hash(self):
         return self.settings.get('version_hash', '')
 
@@ -428,12 +432,15 @@ class BaseHandler(RequestHandler):
             self.log.warning("Redirecting %s to %s. For sharing public links, use /user-redirect/",
                 self.request.uri, next_url,
             )
-        if not next_url and self.config.JupyterHub.get('default_url'):
-            next_url = self.config.JupyterHub['default_url']
+
+        if not next_url:
+            # custom default URL
+            next_url = self.default_url
 
         if not next_url:
             # default URL after login
-            # if self.redirect_to_server, default login URL initiates spawn
+            # if self.redirect_to_server, default login URL initiates spawn,
+            # otherwise send to Hub home page (control panel)
             if user and self.redirect_to_server:
                 next_url = user.url
             else:

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -31,7 +31,9 @@ class RootHandler(BaseHandler):
     """
     def get(self):
         user = self.get_current_user()
-        if user:
+        if self.default_url:
+            url = self.default_url
+        elif user:
             url = self.get_next_url(user)
         else:
             url = self.settings['login_url']

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -54,6 +54,30 @@ def test_root_redirect(app):
 
 
 @pytest.mark.gen_test
+def test_root_default_url_noauth(app):
+    with mock.patch.dict(app.tornado_settings,
+                         {'default_url': '/foo/bar'}):
+        r = yield get_page('/', app, allow_redirects=False)
+    r.raise_for_status()
+    url = r.headers.get('Location', '')
+    path = urlparse(url).path
+    assert path == '/foo/bar'
+
+
+@pytest.mark.gen_test
+def test_root_default_url_auth(app):
+    name = 'wash'
+    cookies = yield app.login_user(name)
+    with mock.patch.dict(app.tornado_settings,
+                         {'default_url': '/foo/bar'}):
+        r = yield get_page('/', app, cookies=cookies, allow_redirects=False)
+    r.raise_for_status()
+    url = r.headers.get('Location', '')
+    path = urlparse(url).path
+    assert path == '/foo/bar'
+
+
+@pytest.mark.gen_test
 def test_home_no_auth(app):
     r = yield get_page('home', app, allow_redirects=False)
     r.raise_for_status()


### PR DESCRIPTION
follow-up to #1854

- default_url is used even if not logged in
- flesh out help strings
- pass default_url via settings like the rest