### PR TITLE
ConfigurableHTTPProxy.stop: kill child processes on Windows case

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -516,13 +516,26 @@ class ConfigurableHTTPProxy(Proxy):
         self._check_running_callback = pc
         pc.start()
 
+    def _kill_proc_tree(self, pid):
+        import psutil
+        parent = psutil.Process(pid)
+        children = parent.children(recursive=True)
+        for child in children:
+            child.kill()
+        psutil.wait_procs(children, timeout=5)
+
     def stop(self):
         self.log.info("Cleaning up proxy[%i]...", self.proxy_process.pid)
         if self._check_running_callback is not None:
             self._check_running_callback.stop()
         if self.proxy_process.poll() is None:
             try:
-                self.proxy_process.terminate()
+                if os.name == 'nt':
+                     # On Windows we spawned a shell on Popen, so we need to
+                    # terminate all child processes as well
+                    self._kill_proc_tree(self.proxy_process.pid)
+                else:
+                    self.proxy_process.terminate()
             except Exception as e:
                 self.log.error("Failed to terminate proxy process: %s", e)
 


### PR DESCRIPTION
On the Windows case, the configurable-http-proxy is spwaned using a
shell. To stop the proxy, we need to terminate both the main process
(shell) and its child (proxy).

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>