### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ not, Jupyter Notebook version 4 or greater must be installed.
 
 The JupyterHub docker image can be started with the following command:
 
-    docker run -p 8000:8000 -d --name jupyterhub jupyterhub/jupyterhub jupyterhub
+    docker run -p 8000:8000 -d --name jupyterhub jupyterhub/jupyterhub jupyterhub --ip=0.0.0.0
 
 This command will create a container named `jupyterhub` that you can
 **stop and resume** with `docker stop/start`.


### PR DESCRIPTION
The default localhost does not work for docker. `0.0.0.0` is necessary to forward docker inside to outside.