### PR TITLE
default bind url should be on all ips

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -358,7 +358,7 @@ class JupyterHub(Application):
             self.bind_url = bind_url
 
     bind_url = Unicode(
-        "http://127.0.0.1:8000",
+        "http://:8000",
         help="""The public facing URL of the whole JupyterHub application.
 
         This is the address on which the proxy will bind.

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -242,6 +242,16 @@ def test_resume_spawners(tmpdir, request):
             {'bind_url': 'http://0.0.0.0:12345/sub'},
             {'base_url': '/sub/'},
         ),
+        (
+            # no config, test defaults
+            {},
+            {
+                'base_url': '/',
+                'bind_url': 'http://:8000',
+                'ip': '',
+                'port': 8000,
+                },
+        ),
     ]
 )
 def test_url_config(hub_config, expected):


### PR DESCRIPTION
preserves jupyterhub default behavior

typo introduced in new bind_url config caused the default to be listening on localhost only.

closes #1903