### PR TITLE
Add customizable announcement text on home,login,logout,spawn

### DIFF
--- a/docs/source/reference/templates.md
+++ b/docs/source/reference/templates.md
@@ -60,12 +60,14 @@ text about the server starting up, place this content in a file named
 {% endblock %}
 ```
 
-## Simple configuration
+## Page Announcements
 
-The most powerful way to control templates is to directly extend them
-as you see above.  However, some simple configuration is possible:
+To add announcements to be displayed on a page, you have two options:
 
-### Announcement text
+- Extend the page templates as described above
+- Use configuration variables
+
+### Announcement Configuration Variables
 
 If you set the configuration variable `JupyterHub.template_vars =
 {'announcement': 'some_text}`, the given `some_text` will be placed on

--- a/docs/source/reference/templates.md
+++ b/docs/source/reference/templates.md
@@ -59,3 +59,33 @@ text about the server starting up, place this content in a file named
 <p>Patience is a virtue.</p>
 {% endblock %}
 ```
+
+## Simple configuration
+
+The most powerful way to control templates is to directly extend them
+as you see above.  However, some simple configuration is possible:
+
+### Announcement text
+
+If you set the configuration variable `JupyterHub.template_vars =
+{'announcement': 'some_text}`, the given `some_text` will be placed on
+the top of all pages.  The more specific variables
+`announcement_login`, `announcement_spawn`, `announcement_home`, and
+`announcement_logout` are more specific and only show on their
+respective pages (overriding the global `announcement` variable).
+Note that changing these varables require a restart, unlike direct
+template extension.
+
+You can get the same effect by extending templates, which allows you
+to update the messages without restarting.  Set
+`c.JupyterHub.template_paths` as mentioned above, and then create a
+template (for example, `login.html`) with:
+
+```html
+{% extends "templates/login.html" %}
+{% set announcement = 'some message' %}
+```
+
+Extending `page.html` puts the message on all pages, but note that
+extending `page.html` take precedence over an extension of a specific
+page (unlike the variable-based approach above).

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -517,3 +517,84 @@ def test_oauth_token_page(app):
 def test_proxy_error(app, error_status):
     r = yield get_page('/error/%i' % error_status, app)
     assert r.status_code == 200
+
+
+
+@pytest.mark.gen_test
+def test_page_contents(app):
+    """Tests the contents of various pages.
+
+    Currently includes tests for the template_vars variables:
+    announcement, announcement_login, announcement_home,
+    announcement_spawn, and announcement_logout.
+
+    Other simple template tests could be put here.
+    """
+    # Basic announcements - same on all pages
+    ann01 = 'ANNOUNCE01'
+    ann02 = 'ANNOUNCE02'
+    with mock.patch.dict(app.users.settings,
+                         {'template_vars': {'announcement': ann01},
+                         'spawner_class': FormSpawner}):
+        r = yield get_page('login', app)
+        r.raise_for_status()
+        assert ann01 in r.text
+        cookies = yield app.login_user('jones')
+        r = yield get_page('spawn', app, cookies=cookies)
+        r.raise_for_status()
+        assert ann01 in r.text
+        r = yield get_page('home', app, cookies=cookies)  # hub/home
+        r.raise_for_status()
+        assert ann01 in r.text
+        r = yield get_page('logout', app, cookies=cookies)
+        r.raise_for_status()
+        assert ann01 in r.text
+
+    # Different annoncements on one page
+    with mock.patch.dict(app.users.settings,
+                         {'template_vars': {'announcement': ann01,
+                                            'announcement_spawn': ann02},
+                         'spawner_class': FormSpawner}):
+        r = yield get_page('login', app)
+        r.raise_for_status()
+        assert ann01 in r.text
+        assert ann02 not in r.text
+
+        cookies = yield app.login_user('jones')
+        r = yield get_page('spawn', app, cookies=cookies)
+        r.raise_for_status()
+        assert ann01 not in r.text
+        assert ann02 in r.text
+
+    # Different annoucements on all pages.  Must give formspawner to
+    # ensure we get a message on the spawn page
+    with mock.patch.dict(app.users.settings,
+                         {'template_vars': {'announcement': ann01,
+                                            'announcement_spawn': 'ANN_spawn',
+                                            'announcement_home': 'ANN_home',
+                                            'announcement_login': 'ANN_login'},
+                         'spawner_class': FormSpawner
+                         }):
+        r = yield get_page('login', app)
+        assert 'ANN_login' in r.text
+        assert ann01 not in r.text
+
+        cookies = yield app.login_user('jones')
+        r = yield get_page('spawn', app, cookies=cookies)
+        assert 'ANN_spawn' in r.text
+        assert ann01 not in r.text
+
+        r = yield get_page('home', app, cookies=cookies)  # hub/home
+        assert 'ANN_home' in r.text
+        assert ann01 not in r.text
+    # ... and must have auto_login=True in order to not be immediately
+    # redirected from the logout page:
+    with mock.patch.dict(app.users.settings,
+                         {'template_vars': {'announcement': ann01,
+                                            'announcement_logout': 'ANN_logout'},
+                         'authenticator': Authenticator(auto_login=True),
+                         'spawner_class': FormSpawner
+                         }):
+        r = yield get_page('logout', app, cookies=cookies)
+        assert 'ANN_logout' in r.text
+        assert ann01 not in r.text

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -1,4 +1,5 @@
 {% extends "page.html" %}
+{% if announcement_home %}{% set announcement = announcement_home %}{% endif %}
 
 {% block main %}
 

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -1,5 +1,7 @@
 {% extends "page.html" %}
-{% if announcement_home %}{% set announcement = announcement_home %}{% endif %}
+{% if announcement_home %}
+  {% set announcement = announcement_home %}
+{% endif %}
 
 {% block main %}
 

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -1,4 +1,5 @@
 {% extends "page.html" %}
+{% if announcement_login %}{% set announcement = announcement_login %}{% endif %}
 
 {% block login_widget %}
 {% endblock %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -1,5 +1,7 @@
 {% extends "page.html" %}
-{% if announcement_login %}{% set announcement = announcement_login %}{% endif %}
+{% if announcement_login %}
+  {% set announcement = announcement_login %}
+{% endif %}
 
 {% block login_widget %}
 {% endblock %}

--- a/share/jupyterhub/templates/logout.html
+++ b/share/jupyterhub/templates/logout.html
@@ -1,8 +1,12 @@
 {% extends "page.html" %}
+{% if announcement_logout %}{% set announcement = announcement_logout %}{% endif %}
+
 {% block main %}
+
 <div id="logout-main" class="container">
   <p>
     Successfully logged out.
   </p>
 </div>
+
 {% endblock %}

--- a/share/jupyterhub/templates/logout.html
+++ b/share/jupyterhub/templates/logout.html
@@ -1,5 +1,7 @@
 {% extends "page.html" %}
-{% if announcement_logout %}{% set announcement = announcement_logout %}{% endif %}
+{% if announcement_logout %}
+  {% set announcement = announcement_logout %}
+{% endif %}
 
 {% block main %}
 

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -140,6 +140,16 @@
   </nav>
 {% endblock %}
 
+
+{% block announcement %}
+{% if announcement %}
+<div class="container text-center announcement">
+  {{ announcement | safe }}
+</div>
+{% endif %}
+{% endblock %}
+
+
 {% block main %}
 {% endblock %}
 

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -1,5 +1,7 @@
 {% extends "page.html" %}
-{% if announcement_spawn %}{% set announcement = announcement_spawn %}{% endif %}
+{% if announcement_spawn %}
+  {% set announcement = announcement_spawn %}
+{% endif %}
 
 {% block main %}
 

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -1,4 +1,5 @@
 {% extends "page.html" %}
+{% if announcement_spawn %}{% set announcement = announcement_spawn %}{% endif %}
 
 {% block main %}
 


### PR DESCRIPTION
- Using the new template_vars setting (#1872), allow the variable
  `announcement` to create a header message on all the pages in the
  title, or the variables `announcement_{home,login,logout,spawn}` to
  set variables on these single pages.
- This is not the most powerful method of putting an announcement into
  the templates, because it requires a server restart to change.  But
  the invasiveness is very low, and allows minimal message
  without having to touch the templates themselves.
- Closes: #1836

Usage:
```
c.JupyterHub.template_vars = {'announcement_spawn': 'this is a message',
                              'announcement': 'blah'}
```

This at least needs testing and documentation before it can be used.  More importantly, needs consideration if it is a good idea.  Also some designer could make it prettier and fit better.  This idea could be in other places in the spirit of "make the default templates more customizable".

My big picture opinion is that this, or something like it, would be useful to include, but if people start going deep enough they would instead directly modify templates to do this.  https://jupyterhub.readthedocs.io/en/latest/reference/templates.html#example is the alternative and I think it is clear enough now.