### PR TITLE
Clarify error message on implicit respawns.

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -40,7 +40,8 @@ reasons = {
     'timeout': "Failed to reach your server."
         "  Please try again later."
         "  Contact admin if the issue persists.",
-    'error': "Failed to start your server.  Please contact admin.",
+    'error': "Failed to start your server on the last attempt.  "
+        "  Please contact admin if the issue persists.",
 }
 
 # constant, not configurable


### PR DESCRIPTION
- This message is presented when the last spawn failed, along with a
  HTTP 500.  The current text is quite confusing, especially when the
  problem may just be solvable by trying to respawn again.


Note: I'm not sure if this message is presented other places, too, and thus this obvious change may not be sufficient.  This message would have saved me an hour of debugging.