### PR TITLE
With options form, we never implicit respawn, so don't show that message

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -928,6 +928,7 @@ class UserSpawnHandler(BaseHandler):
             # First, check for previous failure.
             if (
                 not spawner.active
+                and not spawner.options_form
                 and spawner._spawn_future
                 and spawner._spawn_future.done()
                 and spawner._spawn_future.exception()


### PR DESCRIPTION
- Currently, without options form:
  - When going to user URL, try spawning if no server running.
  - If previous spawn failed, don't retry but show error message with
    option to manually retry.
- But with options form:
  - When going to user URL, direct to spawn form if no server running.
  - If previous spawn failed, show an error message with manual method
    to go to the options form.
- It isn't necessary to show the error message again in this case with
  option form, because user would have manually spawned before and
  seen the error message anyway.


This is a follow up to #1915.  Note that I don't know this is necessarily a good change, but it can help to reduce unexpected error messages (when the user should have already seen the message, because they manually spawned anyway).