### PR TITLE
Handle NULL created column of tokens table

### DIFF
--- a/share/jupyterhub/static/js/token.js
+++ b/share/jupyterhub/static/js/token.js
@@ -12,7 +12,7 @@ require(["jquery", "jhapi", "moment"], function($, JHAPI, moment) {
     // convert ISO datestamps to nice momentjs ones
     el = $(el);
     let m = moment(new Date(el.text().trim()));
-    el.text(m.isValid() ? m.fromNow() : "Never");
+    el.text(m.isValid() ? m.fromNow() : el.text());
   });
 
   $("#request-token-form").submit(function() {

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -73,7 +73,11 @@
             {%- endif -%}
           </td>
           <td class="time-col col-sm-3">
+            {%- if token.created -%}
             {{ token.created.isoformat() + 'Z' }}
+            {%- else -%}
+            N/A
+            {%- endif -%}
           </td>
           <td class="col-sm-1 text-center">
             <button class="revoke-token-btn btn btn-xs btn-danger">revoke</button>
@@ -118,7 +122,11 @@
             {%- endif -%}
           </td>
           <td class="time-col col-sm-3">
+            {%- if client['created'] -%}
             {{ client['created'].isoformat() + 'Z' }}
+            {%- else -%}
+            N/A
+            {%- endif -%}
           </td>
           <td class="col-sm-1 text-center">
             <button class="revoke-token-btn btn btn-xs btn-danger">revoke</a>


### PR DESCRIPTION
`created` column is added in `api_tokens` [recently](https://github.com/jupyterhub/jupyterhub/pull/1590), but old API tokens don't have such column after the DB migration. In that case, the tokens page shows 500 error with the following error log.

```
[E 2018-06-02 14:44:45.128 JupyterHub web:1621] Uncaught exception GET /hub/token (::ffff:172.17.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8000', method='GET', uri='/hub/token', version='HTTP/1.1', remote_ip='::ffff:172.17.0.1')
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.6/site-packages/tornado/web.py", line 1541, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/opt/conda/lib/python3.6/site-packages/tornado/web.py", line 2949, in wrapper
        return method(self, *args, **kwargs)
      File "/opt/conda/lib/python3.6/site-packages/jupyterhub/handlers/pages.py", line 300, in get
        oauth_clients=oauth_clients,
      File "/opt/conda/lib/python3.6/site-packages/jupyterhub/handlers/base.py", line 778, in render_template
        return template.render(**template_ns)
      File "/opt/conda/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
        return original_render(self, *args, **kwargs)
      File "/opt/conda/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
        return self.environment.handle_exception(exc_info, True)
      File "/opt/conda/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
        reraise(exc_type, exc_value, tb)
      File "/opt/conda/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
        raise value.with_traceback(tb)
      File "/opt/conda/share/jupyterhub/templates/token.html", line 1, in top-level template code
        {% extends "page.html" %}
      File "/opt/conda/share/jupyterhub/templates/page.html", line 143, in top-level template code
        {% block main %}
      File "/opt/conda/share/jupyterhub/templates/token.html", line 66, in block "main"
        {% block token_row scoped %}
      File "/opt/conda/share/jupyterhub/templates/token.html", line 76, in block "token_row"
        {{ token.created.isoformat() + 'Z' }}
    jinja2.exceptions.UndefinedError: 'None' has no attribute 'isoformat'
```

For the migration compatibility, I think we should handle `NULL` in `created` column on the page, so could you consider merging this fix?