### PR TITLE
delay call to getuser in token app

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -140,7 +140,10 @@ class NewToken(Application):
         ab01cd23ef45
     """
 
-    name = Unicode(getuser())
+    name = Unicode()
+    @default('name')
+    def _default_name(self):
+        return getuser()
 
     aliases = token_aliases
     classes = []


### PR DESCRIPTION
avoids issues with getuser preventing launch, e.g. in weird containers where the current user doesn’t exist