### PR TITLE
Configure max inactive duration

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -274,6 +274,9 @@ class JupyterHub(Application):
     service_check_interval = Integer(60,
         help="Interval (in seconds) at which to check connectivity of services with web endpoints."
     ).tag(config=True)
+    active_user_window = Integer(30 * 60,
+        help="Duration (in seconds) to determine the number of active users."
+    ).tag(config=True)
 
     data_files_path = Unicode(DATA_FILES_PATH,
         help="The location of jupyterhub data files (e.g. /usr/local/share/jupyterhub)"
@@ -1786,8 +1789,7 @@ class JupyterHub(Application):
                 spawner.last_activity = max(spawner.last_activity, dt)
             else:
                 spawner.last_activity = dt
-            # FIXME: Make this configurable duration. 30 minutes for now!
-            if (now - user.last_activity).total_seconds() < 30 * 60:
+            if (now - user.last_activity).total_seconds() < self.active_user_window:
                 active_users_count += 1
         self.statsd.gauge('users.running', users_count)
         self.statsd.gauge('users.active', active_users_count)


### PR DESCRIPTION
I run JupyterHub with `cull_idle_servers.py` and collect metrics via statsd. However, since the max duration which JupyterHub considers a server is inactive is hard-coded and cannot make a consistent logic for both metrics and culling idle servers.

I'm thinking using it like below.
```
max_inactive_duration = 60 * 60
c.JupyterHub.max_inactive_duration = max_inactive_duration
c.JupyterHub.services = [
    {
        'name': 'cull-idle',
        'admin': True,
        'command': ('python3 cull_idle_servers.py --timeout=%d' % (max_inactive_duration * 2)).split(),
    }
]
```

So I'd like to configure max inactive server duration by a config file. Could you consider merging this change?