### PR TITLE
Avoid showing spawn-pending page when user is stopping

### DIFF
--- a/share/jupyterhub/static/js/home.js
+++ b/share/jupyterhub/static/js/home.js
@@ -1,19 +1,29 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-require(["jquery", "jhapi"], function ($, JHAPI) {
-    "use strict";
+require(["jquery", "jhapi"], function($, JHAPI) {
+  "use strict";
 
-    var base_url = window.jhdata.base_url;
-    var user = window.jhdata.user;
-    var api = new JHAPI(base_url);
+  var base_url = window.jhdata.base_url;
+  var user = window.jhdata.user;
+  var api = new JHAPI(base_url);
 
-    $("#stop").click(function () {
-        api.stop_server(user, {
-            success: function () {
-                $("#stop").hide();
-            }
-        });
+  $("#stop").click(function() {
+    $("#start")
+      .attr("disabled", true)
+      .attr("title", "Your server is stopping")
+      .click(function() {
+        return false;
+      });
+    api.stop_server(user, {
+      success: function() {
+        $("#start")
+          .text("Start My Server")
+          .attr("title", "Start your server")
+          .attr("disabled", false)
+          .off("click");
+        $("#stop").hide();
+      }
     });
-
+  });
 });

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -8,8 +8,8 @@
       {% if user.running %}
       <a id="stop" role="button" class="btn btn-lg btn-danger">Stop My Server</a>
       {% endif %}
-      <a id="start"role="button" class="btn btn-lg btn-primary" href="{{ url }}">
-      {% if not user.running %}
+      <a id="start" role="button" class="btn btn-lg btn-primary" href="{{ url }}">
+      {% if not user.active %}
       Start
       {% endif %}
         My Server

--- a/share/jupyterhub/templates/stop_pending.html
+++ b/share/jupyterhub/templates/stop_pending.html
@@ -1,0 +1,32 @@
+{% extends "page.html" %}
+
+{% block main %}
+
+<div class="container">
+  <div class="row">
+    <div class="text-center">
+      {% block message %}
+        <p>Your server is stopping.</p>
+        <p>You will be able to start it again once it has finished stopping.</p>
+      {% endblock message %}
+      <p><i class="fa fa-spinner fa-pulse fa-fw fa-3x" aria-hidden="true"></i></p>
+      <a role="button" id="refresh" class="btn btn-lg btn-primary" href="#">refresh</a>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script type="text/javascript">
+require(["jquery"], function ($) {
+  $("#refresh").click(function () {
+    window.location.reload();
+  })
+  setTimeout(function () {
+    window.location.reload();
+  }, 5000);
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
- separate stop_pending page when a spawn is requested but cannot be completed because stop is still pending
- disable "My Server" link on home page while "Stop My Server" is outstanding, so it's a little less likely to make these requests in the first place

closes #1945