### PR TITLE
clarify that conda installs npm and proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,37 +50,62 @@ for administration of the Hub and its users.
 
 ## Installation
 
+
 ### Check prerequisites
 
-A Linux/Unix based system with the following:
-
+- A Linux/Unix based system
 - [Python](https://www.python.org/downloads/) 3.4 or greater
-- [nodejs/npm](https://www.npmjs.com/) Install a recent version of
-  [nodejs/npm](https://docs.npmjs.com/getting-started/installing-node)
-  For example, install it on Linux (Debian/Ubuntu) using:
+- [nodejs/npm](https://www.npmjs.com/)
 
-      sudo apt-get install npm nodejs-legacy
+  * If you are using **`conda`**, the nodejs and npm dependencies will be installed for
+    you by conda.
 
-  The `nodejs-legacy` package installs the `node` executable and is currently
-  required for npm to work on Debian/Ubuntu.
+  * If you are using **`pip`**, install a recent version of
+    [nodejs/npm](https://docs.npmjs.com/getting-started/installing-node).
+    For example, install it on Linux (Debian/Ubuntu) using:
+
+    ```
+    sudo apt-get install npm nodejs-legacy
+    ```
+
+    The `nodejs-legacy` package installs the `node` executable and is currently
+    required for npm to work on Debian/Ubuntu.
 
 - TLS certificate and key for HTTPS communication
 - Domain name
 
 ### Install packages
 
+#### Using `conda`
+
+To install JupyterHub along with its dependencies including nodejs/npm:
+
+```bash
+conda install jupyterhub
+```
+
+If you plan to run notebook servers locally, install the Jupyter notebook
+or JupyterLab:
+
+```bash
+conda install jupyter
+conda install jupyterlab
+```
+
+#### Using `pip`
+
 JupyterHub can be installed with `pip`, and the proxy with `npm`:
 
 ```bash
 npm install -g configurable-http-proxy
-pip3 install jupyterhub    
+python3 -m pip install jupyterhub    
 ```
 
 If you plan to run notebook servers locally, you will need to install the
 [Jupyter notebook](https://jupyter.readthedocs.io/en/latest/install.html)
 package:
 
-    pip3 install --upgrade notebook
+    python3 -m pip install --upgrade notebook
 
 ### Run the Hub server
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ for administration of the Hub and its users.
 ### Check prerequisites
 
 - A Linux/Unix based system
-- [Python](https://www.python.org/downloads/) 3.4 or greater
+- [Python](https://www.python.org/downloads/) 3.5 or greater
 - [nodejs/npm](https://www.npmjs.com/)
 
   * If you are using **`conda`**, the nodejs and npm dependencies will be installed for
@@ -88,7 +88,7 @@ If you plan to run notebook servers locally, install the Jupyter notebook
 or JupyterLab:
 
 ```bash
-conda install jupyter
+conda install notebook
 conda install jupyterlab
 ```
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -10,15 +10,22 @@ Before installing JupyterHub, you will need:
   [`conda`](https://conda.io/docs/get-started.html) for
   installing Python packages is helpful.
 - [nodejs/npm](https://www.npmjs.com/). [Install nodejs/npm](https://docs.npmjs.com/getting-started/installing-node),
-  using your operating system's package manager. For example, install on Linux
-  Debian/Ubuntu using:
+  using your operating system's package manager.
 
-  ```bash
-  sudo apt-get install npm nodejs-legacy
-  ```
+  * If you are using **`conda`**, the nodejs and npm dependencies will be installed for
+    you by conda.
 
-  The `nodejs-legacy` package installs the `node` executable and is currently
-  required for `npm` to work on Debian/Ubuntu.
+  * If you are using **`pip`**, install a recent version of
+    [nodejs/npm](https://docs.npmjs.com/getting-started/installing-node).
+    For example, install it on Linux (Debian/Ubuntu) using:
+
+    ```
+    sudo apt-get install npm nodejs-legacy
+    ```
+          
+    The `nodejs-legacy` package installs the `node` executable and is currently
+    required for npm to work on Debian/Ubuntu.
+
 - TLS certificate and key for HTTPS communication
 - Domain name
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -5,7 +5,7 @@
 Before installing JupyterHub, you will need:
 
 - a Linux/Unix based system
-- [Python](https://www.python.org/downloads/) 3.4 or greater. An understanding
+- [Python](https://www.python.org/downloads/) 3.5 or greater. An understanding
   of using [`pip`](https://pip.pypa.io/en/stable/) or
   [`conda`](https://conda.io/docs/get-started.html) for
   installing Python packages is helpful.


### PR DESCRIPTION
Our current doc instructions for install caused some confusion in #1936. This should minimize future confusion.