### PR TITLE
Correct 'conda' installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ for administration of the Hub and its users.
 To install JupyterHub along with its dependencies including nodejs/npm:
 
 ```bash
-conda install jupyterhub
+conda install -c conda-forge jupyterhub
 ```
 
 If you plan to run notebook servers locally, install the Jupyter notebook


### PR DESCRIPTION
JupyterHub packages are in the 'conda-forge' channel of Anaconda packages; if the Anaconda installation doesn't already have 'conda-forge' enabled, `conda install jupyterhub` fails.

Rather than adding instructions to enable 'conda-forge' in Anaconda, this patch modifies the installation command to specify that channel.


