### PR TITLE
fix AddSlashHandler for hub_prefix without trailing /

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -976,8 +976,6 @@ class JupyterHub(Application):
         self.handlers = self.add_url_prefix(self.hub_prefix, h)
         # some extra handlers, outside hub_prefix
         self.handlers.extend([
-            # add trailing / to `/hub`
-            (self.hub_prefix.rstrip('/'), handlers.AddSlashHandler),
             # add trailing / to ``/user|services/:name`
             (r"%s(user|services)/([^/]+)" % self.base_url, handlers.AddSlashHandler),
             (r"(?!%s).*" % self.hub_prefix, handlers.PrefixRedirectHandler),

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1119,6 +1119,7 @@ class AddSlashHandler(BaseHandler):
         self.redirect(urlunparse(dest))
 
 default_handlers = [
+    (r'', AddSlashHandler),  # add trailing / to `/hub`
     (r'/user/([^/]+)(/.*)?', UserSpawnHandler),
     (r'/user-redirect/(.*)?', UserRedirectHandler),
     (r'/security/csp-report', CSPReportHandler),

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -336,7 +336,7 @@ class ProxyErrorHandler(BaseHandler):
 
 
 default_handlers = [
-    (r'/?', RootHandler),
+    (r'/', RootHandler),
     (r'/home', HomeHandler),
     (r'/admin', AdminHandler),
     (r'/spawn', SpawnHandler),


### PR DESCRIPTION
Hi, I realized that `AddSlashHandler` for hub_prefix without trailing / ('/hub') is actually never called because url regex of `RootHandler` covers it and `RootHandler` takes place before `AddSlashHandler` in handlers list:

```python
...
('/hub/?', RootHandler)
...
('/hub', AddSlashHandler)
...
```

This causes that `RootHandler` can get '/hub' and it redirects to '/hub/login' even user is already logged in (this problem happened in Chrome but not in Firefox). But it must actually redirect to next url (if no `default_url` is set).

So this PR changes the order of `AddSlashHandler` and puts it before `RootHandler` and also updates the url regex for `RootHandler`:

```python
...
('/hub', AddSlashHandler)
...
('/hub/', RootHandler)
...
```
This way ensures that `RootHandler` always gets `/hub/` (with trailing /) and it correctly redirects.

I hope this PR makes sense. I was confused while debugging redirects.

Thanks a lot!