### PR TITLE
avoid triggering a spawn from API requests to a not-running server

### DIFF
--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -570,3 +570,12 @@ def test_announcements(app, announcements):
             app.authenticator.auto_login = auto_login
         r.raise_for_status()
         assert_announcement("logout", r.text)
+
+
+@pytest.mark.gen_test
+def test_server_not_running_api_request(app):
+    cookies = yield app.login_user("bees")
+    r = yield get_page("user/bees/api/status", app, hub=False, cookies=cookies)
+    assert r.status_code == 404
+    assert r.headers["content-type"] == "application/json"
+    assert r.json() == {"message": "bees is not running"}


### PR DESCRIPTION
this avoids left-open notebook tabs from respawning a culled server indefinitely

Attempts to refresh the human page will still trigger a respawn.