### PR TITLE
managed services always talk to hub on localhost

### DIFF
--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -63,6 +63,9 @@ class Server(HasTraits):
     @validate('connect_url')
     def _connect_url_add_prefix(self, proposal):
         """Ensure connect_url includes base_url"""
+        if not proposal.value:
+            # Don't add the prefix if the setting is being cleared
+            return proposal.value
         urlinfo = urlparse(proposal.value)
         if not urlinfo.path.startswith(self.base_url):
             urlinfo = urlinfo._replace(path=self.base_url)

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -39,6 +39,7 @@ A hub-managed service with no URL::
 
 """
 
+import copy
 import pipes
 import shutil
 from subprocess import Popen
@@ -303,6 +304,15 @@ class Service(LoggingConfigurable):
         if self.url:
             env['JUPYTERHUB_SERVICE_URL'] = self.url
             env['JUPYTERHUB_SERVICE_PREFIX'] = self.server.base_url
+
+        hub = self.hub
+        if self.hub.ip in ('0.0.0.0', ''):
+            # if the Hub is listening on all interfaces,
+            # tell services to connect via localhost
+            # since they are always local subprocesses
+            hub = copy.deepcopy(self.hub)
+            hub.connect_url = ''
+            hub.connect_ip = '127.0.0.1'
 
         self.spawner = _ServiceSpawner(
             cmd=self.command,


### PR DESCRIPTION
When the Hub listens on all ips by default, connections use the hub's hostname.

In some cases (e.g. certain kubernetes deployments) the hub’s container’s hostname is not connectable from within itself, preventing managed services from connecting to the hub.

This ensures that managed service processes talk to the hub over localhost in this case, rather than via the hostname.

cc @betatim I believe #2004 is caused by the the z2jh [workaround for this](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/4dda7eb9aadafb8bf5a9eab4c0fd132d8c3b662e/images/hub/jupyterhub_config.py#L256) where it sets the Hub URL and can do it incorrectly, where the internal Hub URL setting should always do the right thing for base URLs.

With this patch and removing z2jh's workaround, I think #2004 should not happen.