### PR TITLE
c.LocalProcessSpawner.shell_cmd configuration option does not work

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1002,7 +1002,7 @@ class LocalProcessSpawner(Spawner):
             which could change what the jupyterhub-singleuser launch command does.
             Only use this for trusted users.
         """
-    )
+    ).tag(config=True)
 
     proc = Instance(Popen,
         allow_none=True,


### PR DESCRIPTION
If you want to be able to change the shell_cmd option of the LocalProcessSpawner, this tag is needed in the class.

example config

```
c.LocalProcessSpawner.shell_cmd = ['bash', '-l', '-c']
```

Otherwise it will generate the following error during configuration parsing: 

```
[... JupyterHub configurable:168] Config option `shell_cmd` not recognized by `LocalProcessSpawner`.
```

