### PR TITLE
disable host checking in upcoming notebook app

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -213,7 +213,10 @@ class SingleUserNotebookApp(NotebookApp):
     subcommands = {}
     version = __version__
     classes = NotebookApp.classes + [HubOAuth]
-    
+
+    # disable single-user app's localhost checking
+    allow_remote_access = True
+
     # don't store cookie secrets
     cookie_secret_file = ''
     # always generate a new cookie secret on launch
@@ -225,7 +228,7 @@ class SingleUserNotebookApp(NotebookApp):
 
     user = CUnicode().tag(config=True)
     group = CUnicode().tag(config=True)
-    
+
     @default('user')
     def _default_user(self):
         return os.environ.get('JUPYTERHUB_USER') or ''


### PR DESCRIPTION
https://github.com/jupyter/notebook/pull/3714 will check if the incoming host is local when the bind host is also local. This will block access to jupyterhub for the default spawner unless it is disabled.