### PR TITLE
_ServiceSpawner: add 'SYSTEMROOT' to environment if Windows

### DIFF
--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -41,6 +41,7 @@ A hub-managed service with no URL::
 
 import pipes
 import shutil
+import os
 from subprocess import Popen
 
 from traitlets import (
@@ -104,6 +105,8 @@ class _ServiceSpawner(LocalProcessSpawner):
     def start(self):
         """Start the process"""
         env = self.get_env()
+        if os.name == 'nt':
+            env['SYSTEMROOT'] = os.environ['SYSTEMROOT']
         cmd = self.cmd
 
         self.log.info("Spawning %s", ' '.join(pipes.quote(s) for s in cmd))


### PR DESCRIPTION
Python 3 cannot be started without SYSTEMROOT environment variable.
Otherwise, CryptAcquireContext() is unable to find a dll.

https://bugs.python.org/issue20614

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>


