### PR TITLE
pass requesting handler to spawner

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -602,7 +602,7 @@ class BaseHandler(RequestHandler):
 
         self.log.debug("Initiating spawn for %s", user_server_name)
 
-        spawn_future = user.spawn(server_name, options)
+        spawn_future = user.spawn(server_name, options, handler=self)
 
         self.log.debug("%i%s concurrent spawns",
             spawn_pending_count,

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -111,7 +111,11 @@ class SpawnHandler(BaseHandler):
             if user.spawner._spawn_future and user.spawner._spawn_future.done():
                 user.spawner._spawn_future = None
             # not running, no form. Trigger spawn by redirecting to /user/:name
-            self.redirect(user.url)
+            url = user.url
+            if self.request.query:
+                # add query params
+                url += '?' + self.request.query
+            self.redirect(url)
 
     @web.authenticated
     async def post(self, for_user=None):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -161,6 +161,7 @@ class Spawner(LoggingConfigurable):
     admin_access = Bool(False)
     api_token = Unicode()
     oauth_client_id = Unicode()
+    handler = Any()
 
     will_resume = Bool(False,
         help="""Whether the Spawner will resume on next start

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -74,18 +74,20 @@ def mock_open_session(username, service, encoding):
 
 class MockSpawner(LocalProcessSpawner):
     """Base mock spawner
-    
+
     - disables user-switching that we need root permissions to do
     - spawns `jupyterhub.tests.mocksu` instead of a full single-user server
     """
     def make_preexec_fn(self, *a, **kw):
         # skip the setuid stuff
         return
-    
+
     def _set_user_changed(self, name, old, new):
         pass
-    
+
     def user_env(self, env):
+        if self.handler:
+            env['HANDLER_ARGS'] = self.handler.request.query
         return env
 
     @default('cmd')

--- a/jupyterhub/tests/mocksu.py
+++ b/jupyterhub/tests/mocksu.py
@@ -27,13 +27,13 @@ class ArgsHandler(web.RequestHandler):
         self.write(json.dumps(sys.argv))
 
 def main(args):
-    
+
     app = web.Application([
         (r'.*/args', ArgsHandler),
         (r'.*/env', EnvHandler),
         (r'.*', EchoHandler),
     ])
-    
+
     server = httpserver.HTTPServer(app)
     server.listen(args.port)
     try:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -331,7 +331,7 @@ class User:
             url_parts.extend(['server/progress'])
         return url_path_join(*url_parts)
 
-    async def spawn(self, server_name='', options=None):
+    async def spawn(self, server_name='', options=None, handler=None):
         """Start the user's spawner
 
         depending from the value of JupyterHub.allow_named_servers
@@ -361,6 +361,9 @@ class User:
         spawner.server = server = Server(orm_server=orm_server)
         assert spawner.orm_spawner.server is orm_server
 
+        # pass requesting handler to the spawner
+        # e.g. for processing GET params
+        spawner.handler = handler
         # Passing user_options to the spawner
         spawner.user_options = options or {}
         # we are starting a new server, make sure it doesn't restore state
@@ -484,6 +487,9 @@ class User:
             # raise original exception
             spawner._start_pending = False
             raise e
+        finally:
+            # clear reference to handler after start finishes
+            spawner.handler = None
         spawner.start_polling()
 
         # store state


### PR DESCRIPTION
allows Spawners to implement logic such as processing GET params to select inputs

USE WITH CARE because this gives authors of links the ability to pass parameters to spawn without user knowledge or input.

This should only be used for things like selecting from a list of all known-good choices, e.g. a profile list, NEVER to set free-field values such as resource requests, image, etc.

cf https://github.com/jupyterhub/kubespawner/issues/189

cc @yuvipanda