### PR TITLE
add Spawner.consecutive_failure_limit

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -195,6 +195,19 @@ class Spawner(LoggingConfigurable):
         """
     ).tag(config=True)
 
+    consecutive_failure_limit = Integer(
+        0,
+        help="""
+        Maximum number of consecutive failures to allow before
+        shutting down JupyterHub.
+
+        This helps JupyterHub recover from a certain class of problem preventing launch
+        in contexts where the Hub is automatically restarted (e.g. systemd, docker, kubernetes).
+
+        A limit of 0 means no limit and consecutive failures will not be tracked.
+        """,
+    ).tag(config=True)
+
     start_timeout = Integer(60,
         help="""
         Timeout (in seconds) before giving up on starting of single-user server.


### PR DESCRIPTION
The Hub will exit if consecutive failure count reaches this threshold

Any successful spawn will reset the count to 0

useful for auto-restarting / self-healing deployments such as kubernetes/systemd/docker where restarting the Hub can fix intermittent issues

default is disabled, since it would bring down the Hub if it’s not an auto-restarting deployment

closes #2028