### PR TITLE
Update dependencies used by ReadTheDocs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,3 +1,5 @@
+# ReadTheDocs uses the `environment.yaml` so make sure to update that as well
+# if you change the dependencies of JupyterHub in the various `requirements.txt`
 name: jhub_docs
 channels:
   - conda-forge
@@ -17,3 +19,4 @@ dependencies:
   - recommonmark==0.4.0
   - async_generator
   - prometheus_client
+  - attrs>=17.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+# ReadTheDocs uses the `environment.yaml` so make sure to update that as well
+# if you change this file
 -r ../requirements.txt
 sphinx>=1.7
 recommonmark==0.4.0


### PR DESCRIPTION
Update the dependencies used by RTD per @willingc's comment. I also added a comment to the doc's dependency files to write down this knowledge that RTD uses the `environment.yml`. Till just now I was confused about why we had both :)