### PR TITLE
move attrs pinning to dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,6 @@ pytest>=3.3
 notebook
 requests-mock
 virtualenv
+# temporary pin of attrs for jsonschema 0.3.0a1
+# seems to be a pip bug
+attrs>=17.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ python-dateutil
 SQLAlchemy>=1.1
 requests
 prometheus_client>=0.0.21
-attrs>=17.4.0


### PR DESCRIPTION
it shouldn’t be in the package’s own requirements, which are propagated to users