### PR TITLE
fix jupyterhub/singleuser tagging

### DIFF
--- a/singleuser/hooks/build
+++ b/singleuser/hooks/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-stable=0.8
+stable=0.9
 
 for V in master $stable; do
     docker build --build-arg JUPYTERHUB_VERSION=$V -t $DOCKER_REPO:$V .

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -ex
 
-stable=0.8
+stable=0.9
 for V in master $stable; do
   docker push $DOCKER_REPO:$V
 done


### PR DESCRIPTION
jupyterhub/singluser:master was getting clobbered by the 'stable' tag

and '0.9' is now stable