### PR TITLE
add .dev suffix to development x.y image tags

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -11,12 +11,16 @@ function get_hub_version() {
   hub_xyz=$(cat hub_version)
   split=( ${hub_xyz//./ } )
   hub_xy="${split[0]}.${split[1]}"
+  # add .dev on hub_xy so it's 1.0.dev
+  if [[ ! -z "${split[3]}" ]]; then
+    hub_xy="${hub_xy}.${split[3]}"
+  fi
 }
 
 
 get_hub_version
 
-# when building master, push 0.9.0 as well
+# when building master, push 0.9.0.dev as well
 docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$hub_xyz
 docker push $DOCKER_REPO:$hub_xyz
 docker tag $ONBUILD:$DOCKER_TAG $ONBUILD:$hub_xyz

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -13,6 +13,10 @@ function get_hub_version() {
   hub_xyz=$(cat hub_version)
   split=( ${hub_xyz//./ } )
   hub_xy="${split[0]}.${split[1]}"
+  # add .dev on hub_xy so it's 1.0.dev
+  if [[ ! -z "${split[3]}" ]]; then
+    hub_xy="${hub_xy}.${split[3]}"
+  fi
 }
 # tag e.g. 0.8.1 with 0.8
 get_hub_version $stable


### PR DESCRIPTION
instead of publishing "1.0" for a development version, publish "1.0.dev"