### PR TITLE
disable quit button

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -298,6 +298,7 @@ class SingleUserNotebookApp(NotebookApp):
     # disble some single-user configurables
     token = ''
     open_browser = False
+    quit_button = False
     trust_xheaders = True
     login_handler_class = JupyterHubLoginHandler
     logout_handler_class = JupyterHubLogoutHandler


### PR DESCRIPTION
quit button (new in recent notebook 5.x) shuts down the server, which we want to happen via the JupyterHub control panel