### PR TITLE
Allow authenticators to provide groups

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -307,8 +307,9 @@ class Authenticator(LoggingConfigurable):
             user (str or dict or None): The username of the authenticated user,
                 or None if Authentication failed.
                 The Authenticator may return a dict instead, which MUST have a
-                key 'name' holding the username, and may have two optional keys
-                set - 'auth_state', a dictionary of of auth state that will be
+                key 'name' holding the username, and may have three optional keys
+                set - 'groups', a list of the groups to which the user belongs,
+                'auth_state', a dictionary of of auth state that will be
                 persisted; and 'admin', the admin setting value for the user.
         """
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -486,11 +486,10 @@ class BaseHandler(RequestHandler):
             if groupnames is not None:
                 orm_groups = []
                 for group in groupnames:
-                    g = orm.Groups.find(db=self.db, group)
+                    g = orm.Groups.find(db=self.db, name=group)
                     if g is None:
                         g = orm.Group(name=group)
                         self.db.add(g)
-                        self.db.commit()
                     orm_groups.append(g)
                 # Set the groups of the user to the authenticator provided ones.
                 user.groups = orm_groups


### PR DESCRIPTION
This PR begins to add the needed logic to allow authenticators to provide groups to the hub. This includes:

* Added a new optional key, `groups`, to the user model that is a list of groups (in addition to `name` and `auth_state`).
* If provided, the authenticator will make sure those groups are added to the hub's db and that the user is part of those groups.

Additional follow on work:

- [ ] Decide if any of the authenticators we maintain should populate the `groups` key from the upstream identity providers.
- [ ] Work through the details of when the hub should re-query the authenticator for updates group membership. The main usage case for this is if a user logs in, and it later removed from a group. We want to make sure we can invalidate that group membership while they are still logged in. This same update question will also apply to `auth_state`.

The design of this was informed by some initial work we did this week integrating Keycloak with JupyterHub. Keycloak makes it really easy to popular the users groups and customize the `auth_state`.

@yuvipanda @minrk @Zsailer @townsenddw

@Zsailer can you take this over and add tests?


