### PR TITLE
Fix some typos using `codespell`.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -118,7 +118,7 @@ and tornado < 5.0.
 - Added "Start All" button to admin page for launching all user servers at once.
 - Services have an `info` field which is a dictionary.
   This is accessible via the REST API.
-- `JupyterHub.extra_handlers` allows defining additonal tornado RequestHandlers attached to the Hub.
+- `JupyterHub.extra_handlers` allows defining additional tornado RequestHandlers attached to the Hub.
 - API tokens may now expire.
   Expiry is available in the REST model as `expires_at`,
   and settable when creating API tokens by specifying `expires_in`.

--- a/docs/source/reference/config-sudo.md
+++ b/docs/source/reference/config-sudo.md
@@ -70,7 +70,7 @@ Cmnd_Alias JUPYTER_CMD = /usr/local/bin/sudospawner
 rhea ALL=(JUPYTER_USERS) NOPASSWD:JUPYTER_CMD
 ```
 
-It might be useful to modifiy `secure_path` to add commands in path.
+It might be useful to modify `secure_path` to add commands in path.
 
 As an alternative to adding every user to the `/etc/sudoers` file, you can
 use a group in the last line above, instead of `JUPYTER_USERS`:

--- a/docs/source/reference/config-user-env.md
+++ b/docs/source/reference/config-user-env.md
@@ -125,7 +125,7 @@ sure are available, I can install their specs system-wide (in /usr/local) with:
 There are two broad categories of user environments that depend on what
 Spawner you choose:
 
-- Multi-user hosts (shared sytem)
+- Multi-user hosts (shared system)
 - Container-based
 
 How you configure user environments for each category can differ a bit

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -196,7 +196,7 @@ allocate. Attempting to use more memory than this limit will cause errors. The
 single-user notebook server can discover its own memory limit by looking at
 the environment variable `MEM_LIMIT`, which is specified in absolute bytes.
 
-`c.Spawner.mem_guarantee`: Sometimes, a **guarantee** of a *minumum amount of
+`c.Spawner.mem_guarantee`: Sometimes, a **guarantee** of a *minimum amount of
 memory* is desirable. In this case, you can set `c.Spawner.mem_guarantee` to
 to provide a guarantee that at minimum this much memory will always be
 available for the single-user notebook server to use. The environment variable

--- a/docs/source/reference/templates.md
+++ b/docs/source/reference/templates.md
@@ -75,7 +75,7 @@ the top of all pages.  The more specific variables
 `announcement_login`, `announcement_spawn`, `announcement_home`, and
 `announcement_logout` are more specific and only show on their
 respective pages (overriding the global `announcement` variable).
-Note that changing these varables require a restart, unlike direct
+Note that changing these variables require a restart, unlike direct
 template extension.
 
 You can get the same effect by extending templates, which allows you

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -166,7 +166,7 @@ startup
 statsd
 stdin
 stdout
-stoppped
+stopped
 subclasses
 subcommand
 subdomain

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -746,7 +746,7 @@ def new_session_factory(url="sqlite:///:memory:",
     Base.metadata.create_all(engine)
 
     # We set expire_on_commit=False, since we don't actually need
-    # SQLAlchemy to expire objects after commiting - we don't expect
+    # SQLAlchemy to expire objects after committing - we don't expect
     # concurrent runs of the hub talking to the same db. Turning
     # this off gives us a major performance boost
     session_factory = sessionmaker(bind=engine,


### PR DESCRIPTION
And checking each manually. It's funny because one of the words in the
sphinx custom dictionary was wrong :-)


