### PR TITLE
add Windows case when stopping the CHP

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -489,7 +489,7 @@ class ConfigurableHTTPProxy(Proxy):
         self.log.warning("Proxy still running at pid=%s", pid)
         for i, sig in enumerate([signal.SIGTERM] * 2 + [signal.SIGKILL]):
             try:
-                os.kill(pid, signal.SIGTERM)
+                os.kill(pid, sig)
             except ProcessLookupError:
                 break
             time.sleep(1)


### PR DESCRIPTION
Currently, if there is a zombie CHP, Windows will fail with:

Failed to start proxy
    Traceback (most recent call last):
      File "c:\\Python\3.6\lib\site-packages\jupyterhub\app.py", line 1859, in start
        await self.proxy.start()
      File "c:\\Python\3.6\lib\site-packages\jupyterhub\proxy.py", line 530, in start
        self._check_previous_process()
      File "c:\\Python\3.6\lib\site-packages\jupyterhub\proxy.py", line 490, in _check_previous_process
        for i, sig in enumerate([signal.SIGTERM] * 2 + [signal.SIGKILL]):
    AttributeError: module 'signal' has no attribute 'SIGKILL'