### PR TITLE
token expiry fixes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 mock
+beautifulsoup4
 codecov
 cryptography
 pytest-cov

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -2,8 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from datetime import datetime
 import json
-import datetime
 
 from http.client import responses
 
@@ -14,7 +14,17 @@ from .. import orm
 from ..handlers import BaseHandler
 from ..utils import isoformat, url_path_join
 
+
 class APIHandler(BaseHandler):
+    """Base class for API endpoints
+
+    Differences from page handlers:
+
+    - JSON responses and errors
+    - strict referer checking for Cookie-authenticated requests
+    - strict content-security-policy
+    - methods for REST API models
+    """
 
     @property
     def content_security_policy(self):
@@ -137,7 +147,7 @@ class APIHandler(BaseHandler):
                 'oauth_client': token.client.description or token.client.client_id,
             }
             if token.expires_at:
-                expires_at = datetime.datetime.fromtimestamp(token.expires_at)
+                expires_at = datetime.fromtimestamp(token.expires_at)
         else:
             raise TypeError(
                 "token must be an APIToken or OAuthAccessToken, not %s"
@@ -157,6 +167,7 @@ class APIHandler(BaseHandler):
             'kind': kind,
             'created': isoformat(token.created),
             'last_activity': isoformat(token.last_activity),
+            'expires_at': isoformat(expires_at),
         }
         model.update(extra)
         return model

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -247,9 +247,11 @@ class TokenPageHandler(BaseHandler):
             api_tokens.append(token)
 
         # group oauth client tokens by client id
+        # AccessTokens have expires_at as an integer timestamp
+        now_timestamp = now.timestamp()
         oauth_tokens = defaultdict(list)
         for token in user.oauth_tokens:
-            if token.expires_at and token.expires_at < now:
+            if token.expires_at and token.expires_at < now_timestamp:
                 self.log.warning("Deleting expired token")
                 self.db.delete(token)
                 self.db.commit()

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1,7 +1,9 @@
 """Tests for HTML pages"""
 
+import sys
 from urllib.parse import urlencode, urlparse
 
+from bs4 import BeautifulSoup
 from tornado import gen
 from tornado.httputil import url_concat
 
@@ -605,20 +607,42 @@ def test_token_page(app):
     r = yield get_page("token", app, cookies=cookies)
     r.raise_for_status()
     assert urlparse(r.url).path.endswith('/hub/token')
-    assert "Request new API token" in r.text
-    assert "API Tokens" in r.text
-    assert "Server at %s" % app.users[name].url in r.text
-    # no oauth tokens yet, shouldn't have that section
-    assert "Authorized Applications" not in r.text
+    def extract_body(r):
+        soup = BeautifulSoup(r.text, "html5lib")
+        import re
+        # trim empty lines
+        return re.sub(r"(\n\s*)+", "\n", soup.body.find(class_="container").text)
+    body = extract_body(r)
+    assert "Request new API token" in body, body
+    # no tokens yet, no lists
+    assert "API Tokens" not in body, body
+    assert "Authorized Applications" not in body, body
 
-    # spawn the user to trigger oauth, etc.
-    r = yield get_page("spawn", app, cookies=cookies)
-    r.raise_fo_status()
+    # request an API token
+    user = app.users[name]
+    token = user.new_api_token(expires_in=60, note="my-test-token")
+    app.db.commit()
 
     r = yield get_page("token", app, cookies=cookies)
     r.raise_for_status()
-    assert "API Tokens" in r.text
-    assert "Authorized Applications" not in r.text
+    body = extract_body(r)
+    assert "API Tokens" in body, body
+    assert "my-test-token" in body, body
+    # no oauth tokens yet, shouldn't have that section
+    assert "Authorized Applications" not in body, body
+
+    # spawn the user to trigger oauth, etc.
+    # request an oauth token
+    user.spawner.cmd = [sys.executable, '-m', 'jupyterhub.singleuser']
+    r = yield get_page("spawn", app, cookies=cookies)
+    r.raise_for_status()
+
+    r = yield get_page("token", app, cookies=cookies)
+    r.raise_for_status()
+    body = extract_body(r)
+    assert "API Tokens" in body, body
+    assert "Server at %s" % user.base_url in body, body
+    assert "Authorized Applications" in body, body
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
typos in token expiry:

- omitted from token model (it's in the spec in docs, but wasn't in the model)
- wrong type when sorting oauth tokens on token page could cause token page to not render

Since the token page can be completely broken due to this bug, it's probably worth doing a 0.9.3 with this fix.