### PR TITLE
make `.get_current_user` async

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -52,7 +52,7 @@ class TokenAPIHandler(APIHandler):
             " Use /hub/api/users/:user/tokens instead."
         ) % self.request.uri
         self.log.warning(warn_msg)
-        requester = user = self.get_current_user()
+        requester = user = self.current_user
         if user is None:
             # allow requesting a token with username and password
             # for authenticators where that's possible
@@ -161,7 +161,7 @@ class OAuthHandler:
         if session_id is None:
             session_id = self.set_session_cookie()
 
-        user = self.get_current_user()
+        user = self.current_user
 
         # Extra credentials we need in the validator
         credentials.update({
@@ -216,10 +216,10 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
                 uri, http_method, body, headers)
             credentials = self.add_credentials(credentials)
             client = self.oauth_provider.fetch_by_client_id(credentials['client_id'])
-            if client.redirect_uri.startswith(self.get_current_user().url):
+            if client.redirect_uri.startswith(self.current_user.url):
                 self.log.debug(
                     "Skipping oauth confirmation for %s accessing %s",
-                    self.get_current_user(), client.description,
+                    self.current_user, client.description,
                 )
                 # access to my own server doesn't require oauth confirmation
                 # this is the pre-1.0 behavior for all oauth

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -36,7 +36,7 @@ class ServiceListAPIHandler(APIHandler):
 def admin_or_self(method):
     """Decorator for restricting access to either the target service or admin"""
     def decorated_method(self, name):
-        current = self.get_current_user()
+        current = self.current_user
         if current is None:
             raise web.HTTPError(403)
         if not current.admin:

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -300,21 +300,27 @@ class Authenticator(LoggingConfigurable):
         Args:
             user (User): the user to refresh
         Returns:
-            auth_data (dict or None):
-                The same return value as `.authenticate`.
-                Any values here will refresh the value
-                for the user.
-                This can include updating `.admin` fields
-                or updating `.auth_state`.
-                Return None if the user's auth data has expired,
+            auth_data (bool or dict):
+                Return **True** if auth data for the user is up-to-date
+                and no updates are required.
+
+                Return **False** if the user's auth data has expired,
                 and they should be required to login again.
+
+                Return a **dict** of auth data if some values should be updated.
+                This dict should have the same structure as that returned
+                by :meth:`.authenticate()` when it returns a dict.
+                Any fields present will refresh the value for the user.
+                Any fields not present will be left unchanged.
+                This can include updating `.admin` or `.auth_state` fields.
         """
-        return {'name': user.name}
+        return True
 
     async def authenticate(self, handler, data):
         """Authenticate a user with login form data
 
-        This must be a tornado gen.coroutine.
+        This must be a coroutine.
+
         It must return the username on successful authentication,
         and return None on failed authentication.
 
@@ -328,12 +334,14 @@ class Authenticator(LoggingConfigurable):
             data (dict): The formdata of the login form.
                          The default form has 'username' and 'password' fields.
         Returns:
-            user (str or dict or None): The username of the authenticated user,
+            user (str or dict or None):
+                The username of the authenticated user,
                 or None if Authentication failed.
+
                 The Authenticator may return a dict instead, which MUST have a
-                key 'name' holding the username, and may have two optional keys
-                set - 'auth_state', a dictionary of of auth state that will be
-                persisted; and 'admin', the admin setting value for the user.
+                key `name` holding the username, and MAY have two optional keys
+                set: `auth_state`, a dictionary of of auth state that will be
+                persisted; and `admin`, the admin setting value for the user.
         """
 
     def pre_spawn_start(self, user, spawner):

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -287,6 +287,30 @@ class Authenticator(LoggingConfigurable):
             self.log.warning("User %r not in whitelist.", username)
             return
 
+    async def refresh_user(self, user):
+        """Refresh auth data for a given user
+
+        Allows refreshing or invalidating auth data.
+
+        Only override if your authenticator needs
+        to refresh its data about users once in a while.
+
+        .. versionadded: 1.0
+
+        Args:
+            user (User): the user to refresh
+        Returns:
+            auth_data (dict or None):
+                The same return value as `.authenticate`.
+                Any values here will refresh the value
+                for the user.
+                This can include updating `.admin` fields
+                or updating `.auth_state`.
+                Return None if the user's auth data has expired,
+                and they should be required to login again.
+        """
+        return {'name': user.name}
+
     async def authenticate(self, handler, data):
         """Authenticate a user with login form data
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -51,6 +51,20 @@ SESSION_COOKIE_NAME = 'jupyterhub-session-id'
 class BaseHandler(RequestHandler):
     """Base Handler class with access to common methods and properties."""
 
+    async def prepare(self):
+        """Identify the user during the prepare stage of each request
+
+        During requests, the current user may be retrieved via
+        self.current_user
+        """
+        try:
+            await self.get_current_user()
+        except Exception:
+            self.log.exception("Failed to get current user")
+            self._jupyterhub_user = None
+
+        return await maybe_future(super().prepare())
+
     @property
     def log(self):
         """I can't seem to avoid typing self.log"""
@@ -209,6 +223,44 @@ class BaseHandler(RequestHandler):
         self.db.commit()
         return self._user_from_orm(orm_token.user)
 
+    async def refresh_user_auth(self, user, force=False):
+        """Refresh user authentication info
+
+        Calls `authenticator.refresh_user(user)`
+
+        Called at most once per user per request.
+
+        Args:
+            user (User): the user whose auth info is to be refreshed
+            force (bool): force a refresh instead of checking last refresh time
+        Returns:
+            user (User): the user having been refreshed, or None if
+        """
+        if not force: # TODO: and it's sufficiently recent
+            return user
+
+        # refresh a user at most once per request
+        if not hasattr(self, '_refreshed_users'):
+            self._refreshed_users = set()
+        if user.name in self._refreshed_users:
+            # already refreshed during this request
+            return user
+        self._refreshed_users.add(user.name)
+
+        self.log.debug("Refreshing auth for %s", user.name)
+        auth_info = await self.authenticator.refresh_user(user)
+        if auth_info is None:
+            self.log.warning("User %s has stale auth info. Login required to refresh.", user.name)
+            return
+
+        if isinstance(auth_info, str):
+            auth_info = {'name': auth_info}
+        if 'auth_state' not in auth_info:
+            # refresh didn't specify auth_state,
+            # so preserve previous value to avoid clearing
+            auth_info['auth_state'] = await user.get_auth_state()
+        return await self.auth_to_user(auth_info, user)
+
     def get_current_user_token(self):
         """get_current_user from Authorization header token"""
         token = self.get_auth_token()
@@ -217,15 +269,18 @@ class BaseHandler(RequestHandler):
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
             return None
-        else:
-            # record token activity
-            now = datetime.utcnow()
-            orm_token.last_activity = now
-            if orm_token.user:
-                orm_token.user.last_activity = now
 
-            self.db.commit()
-            return orm_token.service or self._user_from_orm(orm_token.user)
+        # record token activity
+        now = datetime.utcnow()
+        orm_token.last_activity = now
+        if orm_token.user:
+            orm_token.user.last_activity = now
+        self.db.commit()
+
+        if orm_token.service:
+            return orm_token.service
+
+        return self._user_from_orm(orm_token.user)
 
     def _user_for_cookie(self, cookie_name, cookie_value=None):
         """Get the User for a given cookie, if there is one"""
@@ -265,18 +320,30 @@ class BaseHandler(RequestHandler):
         """get_current_user from a cookie token"""
         return self._user_for_cookie(self.hub.cookie_name)
 
-    def get_current_user(self):
+    async def get_current_user(self):
         """get current username"""
         if not hasattr(self, '_jupyterhub_user'):
             try:
                 user = self.get_current_user_token()
                 if user is None:
                     user = self.get_current_user_cookie()
+                if user:
+                    user = await self.refresh_user_auth(user)
                 self._jupyterhub_user = user
             except Exception:
                 # don't let errors here raise more than once
                 self._jupyterhub_user = None
-                raise
+                self.log.exception("Error getting current user")
+        return self._jupyterhub_user
+
+    @property
+    def current_user(self):
+        """Override .current_user accessor from tornado
+
+        Allows .get_current_user to be async.
+        """
+        if not hasattr(self, '_jupyterhub_user'):
+            raise RuntimeError("Must call async get_current_user first!")
         return self._jupyterhub_user
 
     def find_user(self, name):
@@ -323,7 +390,6 @@ class BaseHandler(RequestHandler):
                 if count:
                     self.log.debug("Deleted %s access tokens for %s", count, user.name)
                     self.db.commit()
-
 
         # clear hub cookie
         self.clear_cookie(self.hub.cookie_name, path=self.hub.base_url, **kwargs)
@@ -467,6 +533,43 @@ class BaseHandler(RequestHandler):
                 next_url = url_path_join(self.hub.base_url, 'home')
         return next_url
 
+    async def auth_to_user(self, authenticated, user=None):
+        """Persist data from .authenticate() or .refresh_user() to the User database
+
+        Args:
+            authenticated(dict): return data from .authenticate or .refresh_user
+            user(User, optional): the User object to refresh, if refreshing
+        Return:
+            user(User): the constructed User object
+        """
+        if isinstance(authenticated, str):
+            authenticated = {'name': authenticated}
+        username = authenticated['name']
+        auth_state = authenticated.get('auth_state')
+        admin = authenticated.get('admin')
+        refreshing = user is not None
+
+        if user and username != user.name:
+            raise ValueError("Username doesn't match! %s != %s" % (username, user.name))
+
+        if user is None:
+            new_user = username not in self.users
+            user = self.user_from_username(username)
+            if new_user:
+                await maybe_future(self.authenticator.add_user(user))
+        # Only set `admin` if the authenticator returned an explicit value.
+        if admin is not None and admin != user.admin:
+            user.admin = admin
+            self.db.commit()
+        # always set auth_state and commit,
+        # because there could be key-rotation or clearing of previous values
+        # going on.
+        if not self.authenticator.enable_auth_state:
+            # auth_state is not enabled. Force None.
+            auth_state = None
+        await user.save_auth_state(auth_state)
+        return user
+
     async def login_user(self, data=None):
         """Login a user"""
         auth_timer = self.statsd.timer('login.authenticate').start()
@@ -474,29 +577,11 @@ class BaseHandler(RequestHandler):
         auth_timer.stop(send=False)
 
         if authenticated:
-            username = authenticated['name']
-            auth_state = authenticated.get('auth_state')
-            admin = authenticated.get('admin')
-            new_user = username not in self.users
-            user = self.user_from_username(username)
-            if new_user:
-                await maybe_future(self.authenticator.add_user(user))
-            # Only set `admin` if the authenticator returned an explicit value.
-            if admin is not None and admin != user.admin:
-                user.admin = admin
-                self.db.commit()
-            # always set auth_state and commit,
-            # because there could be key-rotation or clearing of previous values
-            # going on.
-            if not self.authenticator.enable_auth_state:
-                # auth_state is not enabled. Force None.
-                auth_state = None
-            await user.save_auth_state(auth_state)
-            self.db.commit()
+            user = await self.auth_to_user(authenticated)
             self.set_login_cookie(user)
             self.statsd.incr('login.success')
             self.statsd.timing('login.authenticate.success', auth_timer.ms)
-            self.log.info("User logged in: %s", username)
+            self.log.info("User logged in: %s", user.name)
             return user
         else:
             self.statsd.incr('login.failure')
@@ -815,7 +900,7 @@ class BaseHandler(RequestHandler):
 
     @property
     def template_namespace(self):
-        user = self.get_current_user()
+        user = self.current_user
         ns = dict(
             base_url=self.hub.base_url,
             prefix=self.base_url,
@@ -890,7 +975,8 @@ class BaseHandler(RequestHandler):
 
 class Template404(BaseHandler):
     """Render our 404 template"""
-    def prepare(self):
+    async def prepare(self):
+        await super().prepare()
         raise web.HTTPError(404)
 
 
@@ -935,7 +1021,7 @@ class UserSpawnHandler(BaseHandler):
     async def get(self, name, user_path):
         if not user_path:
             user_path = '/'
-        current_user = self.get_current_user()
+        current_user = self.current_user
         if (
             current_user
             and current_user.name != name
@@ -1143,7 +1229,7 @@ class UserRedirectHandler(BaseHandler):
     """
     @web.authenticated
     def get(self, path):
-        user = self.get_current_user()
+        user = self.current_user
         url = url_path_join(user.url, path)
         if self.request.query:
             # FIXME: use urlunparse instead?

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -14,7 +14,7 @@ from .base import BaseHandler
 class LogoutHandler(BaseHandler):
     """Log a user out by clearing their login cookie."""
     def get(self):
-        user = self.get_current_user()
+        user = self.current_user
         if user:
             self.log.info("User logged out: %s", user.name)
             self.clear_login_cookie()
@@ -44,11 +44,11 @@ class LoginHandler(BaseHandler):
 
     async def get(self):
         self.statsd.incr('login.request')
-        user = self.get_current_user()
+        user = self.current_user
         if user:
             # set new login cookie
             # because single-user cookie may have been cleared or incorrect
-            self.set_login_cookie(self.get_current_user())
+            self.set_login_cookie(user)
             self.redirect(self.get_next_url(user), permanent=False)
         else:
             if self.authenticator.auto_login:
@@ -83,7 +83,7 @@ class LoginHandler(BaseHandler):
 
         if user:
             # register current user for subsequent requests to user (e.g. logging the request)
-            self.get_current_user = lambda: user
+            self._jupyterhub_user = user
             self.redirect(self.get_next_url(user))
         else:
             html = self._render(

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -30,7 +30,7 @@ class RootHandler(BaseHandler):
     Otherwise, renders login page.
     """
     def get(self):
-        user = self.get_current_user()
+        user = self.current_user
         if self.default_url:
             url = self.default_url
         elif user:
@@ -45,7 +45,7 @@ class HomeHandler(BaseHandler):
 
     @web.authenticated
     async def get(self):
-        user = self.get_current_user()
+        user = self.current_user
         if user.running:
             # trigger poll_and_notify event in case of a server that died
             await user.spawner.poll_and_notify()
@@ -87,7 +87,7 @@ class SpawnHandler(BaseHandler):
 
         or triggers spawn via redirect if there is no form.
         """
-        user = current_user = self.get_current_user()
+        user = current_user = self.current_user
         if for_user is not None and for_user != user.name:
             if not user.admin:
                 raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
@@ -120,7 +120,7 @@ class SpawnHandler(BaseHandler):
     @web.authenticated
     async def post(self, for_user=None):
         """POST spawns with user-specified options"""
-        user = current_user = self.get_current_user()
+        user = current_user = self.current_user
         if for_user is not None and for_user != user.name:
             if not user.admin:
                 raise web.HTTPError(403, "Only admins can spawn on behalf of other users")
@@ -214,7 +214,7 @@ class AdminHandler(BaseHandler):
         running = [ u for u in users if u.running ]
 
         html = self.render_template('admin.html',
-            user=self.get_current_user(),
+            user=self.current_user,
             admin_access=self.settings.get('admin_access', False),
             users=users,
             running=running,
@@ -230,7 +230,7 @@ class TokenPageHandler(BaseHandler):
     def get(self):
         never = datetime(1900, 1, 1)
 
-        user = self.get_current_user()
+        user = self.current_user
         def sort_key(token):
             return (
                 token.last_activity or never,

--- a/jupyterhub/log.py
+++ b/jupyterhub/log.py
@@ -123,8 +123,8 @@ def log_request(handler):
     request_time = 1000.0 * handler.request.request_time()
 
     try:
-        user = handler.get_current_user()
-    except HTTPError:
+        user = handler.current_user
+    except (HTTPError, RuntimeError):
         username = ''
     else:
         if user is None:

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -236,14 +236,14 @@ def authenticated_403(self):
     Like tornado.web.authenticated, this decorator raises a 403 error
     instead of redirecting to login.
     """
-    if self.get_current_user() is None:
+    if self.current_user is None:
         raise web.HTTPError(403)
 
 
 @auth_decorator
 def admin_only(self):
     """Decorator for restricting access to admin users"""
-    user = self.get_current_user()
+    user = self.current_user
     if user is None or not user.admin:
         raise web.HTTPError(403)
 


### PR DESCRIPTION
User is identified during the `prepare` stage for all requests, to ensure that `.current_user` is defined.

Use the `.current_user` accessor instead of `.get_current_user` throughout to access the result.

Adds placeholder for `.refresh_user_auth` which calls `Authenticator.refresh_user`, a new method for refreshing user authentication. This is the async part of get_current_user.

related to #2117