### PR TITLE
stop using deprecated `gen.maybe_future`

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -449,7 +449,11 @@ def maybe_future(obj):
     elif isinstance(obj, concurrent.futures.Future):
         return asyncio.wrap_future(obj)
     else:
-        return to_asyncio_future(gen.maybe_future(obj))
+        # could also check for tornado.concurrent.Future
+        # but with tornado >= 5 tornado.Future is asyncio.Future
+        f = asyncio.Future()
+        f.set_result(obj)
+        return f
 
 
 @asynccontextmanager


### PR DESCRIPTION
we already covered supported cases since we are using tornado 5, so handle the scalar case ourselves, as recommended in the deprecation