### PR TITLE
fix oauth client cleanup

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -9,6 +9,12 @@ command line for details.
 
 ## 0.9
 
+### [0.9.4] 2018-09-20
+
+JupyterHub 0.9.4 fixes a single issue that required
+all running user servers to be restarted when performing an upgrade
+from 0.8 to 0.9.
+
 ### [0.9.3] 2018-09-12
 
 JupyterHub 0.9.3 contains small bugfixes and improvements
@@ -417,7 +423,8 @@ Fix removal of `/login` page in 0.4.0, breaking some OAuth providers.
 First preview release
 
 
-[Unreleased]: https://github.com/jupyterhub/jupyterhub/compare/0.9.3...HEAD
+[Unreleased]: https://github.com/jupyterhub/jupyterhub/compare/0.9.4...HEAD
+[0.9.4]: https://github.com/jupyterhub/jupyterhub/compare/0.9.3...0.9.4
 [0.9.3]: https://github.com/jupyterhub/jupyterhub/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/jupyterhub/jupyterhub/compare/0.9.1...0.9.2
 [0.9.1]: https://github.com/jupyterhub/jupyterhub/compare/0.9.0...0.9.1

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1506,6 +1506,10 @@ class JupyterHub(Application):
         for user in self.users.values():
             for spawner in user.spawners.values():
                 oauth_client_ids.add(spawner.oauth_client_id)
+                # avoid deleting clients created by 0.8
+                # 0.9 uses `jupyterhub-user-...` for the client id, while
+                # 0.8 uses just `user-...`
+                oauth_client_ids.add(spawner.oauth_client_id.split('-', 1)[1])
 
         for i, oauth_client in enumerate(self.db.query(orm.OAuthClient)):
             if oauth_client.identifier not in oauth_client_ids:


### PR DESCRIPTION
- delete oauth clients for servers when they shutdown
- avoid deleting oauth clients for servers still running across an 0.8 -> 0.9 upgrade, when the oauth client ids changed from `user-NAME` to `jupyterhub-user-NAME`

closes #2125

We should probably make an 0.9.4 with this fix, since it greatly impacts upgrade from 0.8 to 0.9 with running servers (as in, it's impossible without this).