### PR TITLE
Build docs with pip not conda 

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - traitlets>=4.1
 - sphinx>=1.7
 - pip:
-  - python-oauth2
+  - oauthlib>=2.0
   - recommonmark==0.4.0
   - async_generator
   - prometheus_client

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,5 @@
 name: jupyterhub
 type: sphinx
-conda:
-    file: docs/environment.yml
+requirements_file: docs/requirements.txt
 python:
   version: 3


### PR DESCRIPTION
This PR switches to using pip for docbuilds. The release of Sphinx 1.8 and its bump to docutils 0.12 has an error when building latex.

RTD is not building correctly using conda and Sphinx 1.8 but is using pip. Test build is here: https://readthedocs.org/projects/test-jupyterhub/builds/7812163/