### PR TITLE
Add notes on simplespawner & dummyauthenticator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,26 @@ to make that happen.
 
 Happy developing!
 
+### Using DummyAuthenticator & SimpleSpawner
+
+The default JupyterHub authenticator & spawner require your
+system to have user accounts for each user you want to log in to
+JupyterHub as. This requires you have root / `sudo` access to your
+machine. It also gets cumbersome & insecure quickly as you
+do development.
+
+[DummyAuthenticator](https://github.com/jupyterhub/dummyauthenticator) allows
+you to log in with any username & password.
+[SimpleSpawner](https://github.com/jupyterhub/simplespawner) lets you start
+servers without having to create unix users for each JupyterHub user.
+Together, these make it much easier to test JupyterHub.
+
+If you are working on parts of JupyterHub that are common to all
+authenticators & spawners, we recommend using both DummyAuthenticator &
+SimpleSpawner. If you are working on just authenticator related parts, use
+only SimpleSpawner. Similarly, if you are working on just spawner
+related parts, use only DummyAuthenticator.
+
 ## Troubleshooting a development install
 
 ### `lessc` not found

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,18 +110,22 @@ Happy developing!
 
 ### Using DummyAuthenticator & SimpleSpawner
 
+To simplify testing of JupyterHub,
+it's helpful to use DummyAuthenticator instead of the default JupyterHub authenticator
+and SimpleSpawner instead of the default spawner.
+
 The default JupyterHub [authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#the-default-pam-authenticator)
 & [spawner](https://jupyterhub.readthedocs.io/en/stable/api/spawner.html#localprocessspawner)
 require your system to have user accounts for each user you want to log in to
 JupyterHub as.
 
 [DummyAuthenticator](https://github.com/jupyterhub/dummyauthenticator) allows
-you to log in with any username & password.
-[SimpleSpawner](https://github.com/jupyterhub/simplespawner) lets you start
-servers without having to create unix users for each JupyterHub user.
+you to log in with any username & password, while
+[SimpleSpawner](https://github.com/jupyterhub/simplespawner) allows you to start
+servers without having to create a unix user for each JupyterHub user.
 Together, these make it much easier to test JupyterHub.
 
-If you are working on parts of JupyterHub that are common to all
+Tip: If you are working on parts of JupyterHub that are common to all
 authenticators & spawners, we recommend using both DummyAuthenticator &
 SimpleSpawner. If you are working on just authenticator related parts, use
 only SimpleSpawner. Similarly, if you are working on just spawner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,11 +110,10 @@ Happy developing!
 
 ### Using DummyAuthenticator & SimpleSpawner
 
-The default JupyterHub authenticator & spawner require your
-system to have user accounts for each user you want to log in to
-JupyterHub as. This requires you have root / `sudo` access to your
-machine. It also gets cumbersome & insecure quickly as you
-do development.
+The default JupyterHub [authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#the-default-pam-authenticator)
+& [spawner](https://jupyterhub.readthedocs.io/en/stable/api/spawner.html#localprocessspawner)
+require your system to have user accounts for each user you want to log in to
+JupyterHub as.
 
 [DummyAuthenticator](https://github.com/jupyterhub/dummyauthenticator) allows
 you to log in with any username & password.


### PR DESCRIPTION
The default spawner & auth implementation on JupyterHub requires
users have root on their systems and create new unix users for
each JupyterHub user. This gets complex & hard quickly.

Recommend using simplespawner & dummyauthenticator to 
get started instead. This is what I do, and I think it works well.

Ref #2160 