### PR TITLE
Add user name to control panel in JupyterHub 

### DIFF
--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -123,6 +123,7 @@
               {% block login_widget %}
                 <span id="login_widget">
                   {% if user %}
+		    <p class="navbar-text">{{user.name}}</p>
                     <a id="logout" role="button" class="navbar-btn btn-sm btn btn-default" href="{{logout_url}}"> <i aria-hidden="true" class="fa fa-sign-out"></i> Logout</a>
                   {% else %}
                     <a id="login" role="button" class="btn-sm btn navbar-btn btn-default" href="{{login_url}}">Login</a>


### PR DESCRIPTION
Fixes #2157 . Now username is displayed next to the logout button in control panel.


![screenshot_2018-09-21 jupyterhub](https://user-images.githubusercontent.com/18103181/45882087-b0ad7000-bdca-11e8-8bde-db3514c00001.png)
