### PR TITLE
add sample configuration that loads dummyauthenticator and simplespawner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,12 @@ To simplify testing of JupyterHub,
 it's helpful to use DummyAuthenticator instead of the default JupyterHub authenticator
 and SimpleSpawner instead of the default spawner.
 
+There is a sample configuration file that does this in `testing.jupyterhub_config.py`.
+To launch jupyterhub with this configuration:
+
+    pip install jupyterhub-simplespawner jupyterhub-dummyauthenticator
+    jupyterhub -f testing/jupyterhub_config.py
+
 The default JupyterHub [authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#the-default-pam-authenticator)
 & [spawner](https://jupyterhub.readthedocs.io/en/stable/api/spawner.html#localprocessspawner)
 require your system to have user accounts for each user you want to log in to

--- a/testing/jupyterhub_config.py
+++ b/testing/jupyterhub_config.py
@@ -1,0 +1,21 @@
+"""sample jupyterhub config file for testing
+
+configures jupyterhub with dummyauthenticator and simplespawner
+to enable testing without administrative privileges.
+"""
+
+c = get_config() # noqa
+
+try:
+    from dummyauthenticator import DummyAuthenticator
+except ImportError:
+    print("dummyauthenticator not available. Try: `pip install jupyterhub-dummyauthenticator`")
+else:
+    c.JupyterHub.authenticator_class = DummyAuthenticator
+
+try:
+    from simplespawner import SimpleLocalProcessSpawner
+except ImportError:
+    print("simplespawner not available. Try: `pip install jupyterhub-simplespawner`")
+else:
+    c.JupyterHub.spawner_class = SimpleLocalProcessSpawner


### PR DESCRIPTION
and inline installation of the packages (closes #2163)

Running:

    jupyterhub -f testing/jupyterhub_config.py

loads dummyauth/simplespawn

If they aren't present, the installation command is displayed.