### PR TITLE
back to conda on rtd

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,3 +4,8 @@ conda:
      file: docs/environment.yml
 python:
   version: 3
+formats:
+  - htmlzip
+  - epub
+  # pdf disabled due to bug in sphinx 1.8 + recommonmark
+  # - pdf

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,6 @@
 name: jupyterhub
 type: sphinx
-requirements_file: docs/requirements.txt
+conda:
+     file: docs/environment.yml
 python:
   version: 3


### PR DESCRIPTION
We can't build the docs without conda on rtd because we need it to get npm for rendering the rest-api docs.

Instead, workaround the sphinx 1.8 regression by skipping the broken PDF builds.

Unfortunately, we can't currently pin the sphinx version when using conda due to https://github.com/rtfd/readthedocs.org/issues/3829

cc @willingc 