### PR TITLE
Fix intermittent failures in progress_bad_slow

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -734,7 +734,8 @@ class Spawner(LoggingConfigurable):
         This method is always an async generator and will always yield at least one event.
         """
         if not self._spawn_pending:
-            raise RuntimeError("Spawn not pending, can't generate progress")
+            self.log.warning("Spawn not pending, can't generate progress for %s", self._log_name)
+            return
 
         await yield_({
             "progress": 0,

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -26,6 +26,7 @@ Other components
 - public_url
 
 """
+
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import os
@@ -152,9 +153,8 @@ class BadSpawner(MockSpawner):
 class SlowBadSpawner(MockSpawner):
     """Spawner that fails after a short delay"""
 
-    @gen.coroutine
-    def start(self):
-        yield gen.sleep(0.1)
+    async def start(self):
+        await asyncio.sleep(0.5)
         raise RuntimeError("I don't work!")
 
 


### PR DESCRIPTION
There was a race condition between two separate checks for `if spawner._spawn_pending`. Using two timeouts (slow_spawn_timeout and the sleep in SlowBadSpawner) with the same value made a race extra likely. The timeouts are now different to avoid the race, and when the race occurs, warn and yield no events in `_generate_progress` rather than raise a RuntimeError.