### PR TITLE
add server_poll_duration_seconds prometheus metric

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -32,6 +32,7 @@ from ..utils import maybe_future, url_path_join
 from ..metrics import (
     SERVER_SPAWN_DURATION_SECONDS, ServerSpawnStatus,
     PROXY_ADD_DURATION_SECONDS, ProxyAddStatus,
+    SERVER_POLL_DURATION_SECONDS,
     RUNNING_SERVERS
 )
 
@@ -821,7 +822,10 @@ class BaseHandler(RequestHandler):
 
             # start has finished, but the server hasn't come up
             # check if the server died while we were waiting
+            poll_start_time = time.perf_counter()
             status = await spawner.poll()
+            SERVER_POLL_DURATION_SECONDS.observe(time.perf_counter() - poll_start_time)
+
             if status is not None:
                 toc = IOLoop.current().time()
                 self.statsd.timing('spawner.failure', (toc - tic) * 1000)
@@ -848,7 +852,11 @@ class BaseHandler(RequestHandler):
     async def user_stopped(self, user, server_name):
         """Callback that fires when the spawner has stopped"""
         spawner = user.spawners[server_name]
+
+        poll_start_time = time.perf_counter()
         status = await spawner.poll()
+        SERVER_POLL_DURATION_SECONDS.observe(time.perf_counter() - poll_start_time)
+
         if status is None:
             status = 'unknown'
         self.log.warning("User %s server stopped, with exit code: %s",
@@ -1152,7 +1160,9 @@ class UserSpawnHandler(BaseHandler):
 
             # spawn has supposedly finished, check on the status
             if spawner.ready:
+                poll_start_time = time.perf_counter()
                 status = await spawner.poll()
+                SERVER_POLL_DURATION_SECONDS.observe(time.perf_counter() - poll_start_time)
             else:
                 status = 0
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -32,7 +32,7 @@ from ..utils import maybe_future, url_path_join
 from ..metrics import (
     SERVER_SPAWN_DURATION_SECONDS, ServerSpawnStatus,
     PROXY_ADD_DURATION_SECONDS, ProxyAddStatus,
-    SERVER_POLL_DURATION_SECONDS,
+    SERVER_POLL_DURATION_SECONDS, ServerPollStatus,
     RUNNING_SERVERS
 )
 
@@ -825,7 +825,7 @@ class BaseHandler(RequestHandler):
             poll_start_time = time.perf_counter()
             status = await spawner.poll()
             SERVER_POLL_DURATION_SECONDS.labels(
-                status=ServerPollStatus.status_to_string(status)
+                status=ServerPollStatus.from_status(status)
             ).observe(time.perf_counter() - poll_start_time)
 
             if status is not None:
@@ -859,7 +859,7 @@ class BaseHandler(RequestHandler):
         poll_start_time = time.perf_counter()
         status = await spawner.poll()
         SERVER_POLL_DURATION_SECONDS.labels(
-            status=ServerPollStatus.status_to_string(status)
+            status=ServerPollStatus.from_status(status)
         ).observe(time.perf_counter() - poll_start_time)
 
 
@@ -1170,7 +1170,7 @@ class UserSpawnHandler(BaseHandler):
                 poll_start_time = time.perf_counter()
                 status = await spawner.poll()
                 SERVER_POLL_DURATION_SECONDS.labels(
-                    status=ServerPollStatus.status_to_string(status)
+                    status=ServerPollStatus.from_status(status)
                 ).observe(time.perf_counter() - poll_start_time)
             else:
                 status = 0

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -93,10 +93,12 @@ class ServerPollStatus(Enum):
     running = 'running'
     stopped = 'stopped'
 
-    def status_to_string(status):
+    @classmethod
+    def from_status(cls, status):
+        """Return enum string for a given poll status"""
         if status is None:
-            return running
-        return stopped
+            return cls.running
+        return cls.stopped
 
     def __str__(self):
         return self.value

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -35,6 +35,11 @@ SERVER_SPAWN_DURATION_SECONDS = Histogram(
     buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")]
 )
 
+SERVER_POLL_DURATION_SECONDS = Histogram(
+    'server_poll_duration_seconds',
+    'time taken to poll if server is running',
+)
+
 RUNNING_SERVERS = Gauge(
     'running_servers',
     'the number of user servers currently running',

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -35,14 +35,9 @@ SERVER_SPAWN_DURATION_SECONDS = Histogram(
     buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")]
 )
 
-SERVER_POLL_DURATION_SECONDS = Histogram(
-    'server_poll_duration_seconds',
-    'time taken to poll if server is running',
-)
-
 RUNNING_SERVERS = Gauge(
     'running_servers',
-    'the number of user servers currently running',
+    'the number of user servers currently running'
 )
 
 RUNNING_SERVERS.set(0)
@@ -83,6 +78,32 @@ class ProxyAddStatus(Enum):
 
 for s in ProxyAddStatus:
     PROXY_ADD_DURATION_SECONDS.labels(status=s)
+
+
+SERVER_POLL_DURATION_SECONDS = Histogram(
+    'server_poll_duration_seconds',
+    'time taken to poll if server is running',
+    ['status']
+)
+
+class ServerPollStatus(Enum):
+    """
+    Possible values for 'status' label of SERVER_POLL_DURATION_SECONDS
+    """
+    running = 'running'
+    stopped = 'stopped'
+
+    def status_to_string(status):
+        if status is None:
+            return running
+        return stopped
+
+    def __str__(self):
+        return self.value
+
+for s in ServerPollStatus:
+    SERVER_POLL_DURATION_SECONDS.labels(status=s)
+
 
 def prometheus_log_method(handler):
     """


### PR DESCRIPTION
Hi! I added a server_poll_duration_seconds metric (regarding https://github.com/jupyterhub/outreachy/issues/16) but I am not sure if I should have labeled the histogram based on the status of the polling operation.

closes #2185