### PR TITLE
Replace python with sys.executable in most service examples

### DIFF
--- a/docs/source/getting-started/services-basics.md
+++ b/docs/source/getting-started/services-basics.md
@@ -88,7 +88,7 @@ c.JupyterHub.services = [
     {
         'name': 'cull-idle',
         'admin': True,
-        'command': 'python3 cull_idle_servers.py --timeout=3600'.split(),
+        'command': [sys.executable, 'cull_idle_servers.py', '--timeout=3600'],
     }
 ]
 ```

--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -93,7 +93,7 @@ c.JupyterHub.services = [
     {
         'name': 'cull-idle',
         'admin': True,
-        'command': ['python', '/path/to/cull-idle.py', '--timeout']
+        'command': [sys.executable, '/path/to/cull-idle.py', '--timeout']
     }
 ]
 ```

--- a/examples/cull-idle/README.md
+++ b/examples/cull-idle/README.md
@@ -15,7 +15,7 @@ c.JupyterHub.services = [
     {
         'name': 'cull-idle',
         'admin': True,
-        'command': 'python3 cull_idle_servers.py --timeout=3600'.split(),
+        'command': [sys.executable, 'cull_idle_servers.py', '--timeout=3600'],
     }
 ]
 ```

--- a/examples/cull-idle/cull_idle_servers.py
+++ b/examples/cull-idle/cull_idle_servers.py
@@ -16,7 +16,7 @@ You can run this as a service managed by JupyterHub with this in your config::
         {
             'name': 'cull-idle',
             'admin': True,
-            'command': 'python3 cull_idle_servers.py --timeout=3600'.split(),
+            'command': [sys.executable, 'cull_idle_servers.py', '--timeout=3600'],
         }
     ]
 

--- a/examples/cull-idle/jupyterhub_config.py
+++ b/examples/cull-idle/jupyterhub_config.py
@@ -3,6 +3,6 @@ c.JupyterHub.services = [
     {
         'name': 'cull-idle',
         'admin': True,
-        'command': 'python3 cull_idle_servers.py --timeout=3600'.split(),
+        'command': [sys.executable, 'cull_idle_servers.py', '--timeout=3600'],
     }
 ]

--- a/examples/service-announcement/README.md
+++ b/examples/service-announcement/README.md
@@ -11,7 +11,7 @@ configuration file something like:
             {
                 'name': 'announcement',
                 'url': 'http://127.0.0.1:8888',
-                'command': ["python", "-m", "announcement"],
+                'command': [sys.executable, "-m", "announcement"],
             }
     ]
 

--- a/examples/service-announcement/jupyterhub_config.py
+++ b/examples/service-announcement/jupyterhub_config.py
@@ -5,7 +5,7 @@ c.JupyterHub.services = [
         {
             'name': 'announcement',
             'url': 'http://127.0.0.1:8888',
-            'command': ["python", "-m", "announcement"],
+            'command': [sys.executable, "-m", "announcement"],
         }
 ]
 


### PR DESCRIPTION
There are two ways of executing `jupyterhub` in a virtualenv:

1. Activate the virtualenv first

        source /virtualenv/bin/activate && jupyterhub

    or

2. Run it the executable directly

        /virtualenv/bin/jupyterhub

In both cases jupyterhub will work identically.

However, when using method 2, `$PATH` will not be modified, and calling `python` inside your program might accidentally leave the virtualenv, as can easily be tested using

    from subprocess import call
    call(["which", "python"])

and running it like

    /virtualenv/bin/python test.py                          # yields /usr/bin/python
    source /virtualenv/bin/activate && python test.py       # yields /virtualenv/bin/python

One way to circumvent it is to call `sys.executable` instead of `'python'`.

This PR replaces all relevant instances of `'python'` with `sys.executable` in the `c.JupyterHub.services` examples.