### PR TITLE
Use $() for command substitution instead of backticks/quotes.

### DIFF
--- a/docs/source/getting-started/security-basics.rst
+++ b/docs/source/getting-started/security-basics.rst
@@ -124,7 +124,7 @@ hex-encoded string. You can set it this way:
 
 .. code-block:: bash
 
-    export JPY_COOKIE_SECRET=`openssl rand -hex 32`
+    export JPY_COOKIE_SECRET=$(openssl rand -hex 32)
 
 For security reasons, this environment variable should only be visible to the
 Hub. If you set it dynamically as above, all users will be logged out each time
@@ -173,7 +173,7 @@ using the ``CONFIGPROXY_AUTH_TOKEN`` environment variable:
 
 .. code-block:: bash
 
-    export CONFIGPROXY_AUTH_TOKEN='openssl rand -hex 32'
+    export CONFIGPROXY_AUTH_TOKEN=$(openssl rand -hex 32)
 
 This environment variable needs to be visible to the Hub and Proxy.
 

--- a/examples/cull-idle/README.md
+++ b/examples/cull-idle/README.md
@@ -36,6 +36,6 @@ Generate an API token and store it in the `JUPYTERHUB_API_TOKEN` environment
 variable. Run `cull_idle_servers.py` manually. 
 
 ```bash
-    export JUPYTERHUB_API_TOKEN=`jupyterhub token`
+    export JUPYTERHUB_API_TOKEN=$(jupyterhub token)
     python3 cull_idle_servers.py [--timeout=900] [--url=http://127.0.0.1:8081/hub/api]
 ```

--- a/examples/cull-idle/cull_idle_servers.py
+++ b/examples/cull-idle/cull_idle_servers.py
@@ -22,7 +22,7 @@ You can run this as a service managed by JupyterHub with this in your config::
 
 Or run it manually by generating an API token and storing it in `JUPYTERHUB_API_TOKEN`:
 
-    export JUPYTERHUB_API_TOKEN=`jupyterhub token`
+    export JUPYTERHUB_API_TOKEN=$(jupyterhub token)
     python3 cull_idle_servers.py [--timeout=900] [--url=http://127.0.0.1:8081/hub/api]
 
 This script uses the same ``--timeout`` and ``--max-age`` values for

--- a/examples/external-oauth/README.md
+++ b/examples/external-oauth/README.md
@@ -18,7 +18,7 @@ implementations in other web servers or languages.
 
 1. generate an API token:
 
-        export JUPYTERHUB_API_TOKEN=`openssl rand -hex 32`
+        export JUPYTERHUB_API_TOKEN=$(openssl rand -hex 32)
 
 2. launch a version of the the whoami service.
    For `whoami-oauth`:

--- a/examples/service-whoami-flask/launch.sh
+++ b/examples/service-whoami-flask/launch.sh
@@ -1,4 +1,4 @@
-export CONFIGPROXY_AUTH_TOKEN=`openssl rand -hex 32`
+export CONFIGPROXY_AUTH_TOKEN=$(openssl rand -hex 32)
 
 # start JupyterHub
 jupyterhub --ip=127.0.0.1


### PR DESCRIPTION
One of the example was using quotes instead of backticks.
Backticks are the "older" way of doing things, which has a number of
disadvantes:

    http://mywiki.wooledge.org/BashFAQ/082

Here I'm more worried about readability as depending on font and "smart"
editor helping on the web, many people may confuse ` with ', it could
end up modifying formatting on makrdown powered website... etc...


