### PR TITLE
Adding CHECK_ROUTES_DURATION_SECONDS metric #2183

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -33,7 +33,7 @@ from ..metrics import (
     SERVER_SPAWN_DURATION_SECONDS, ServerSpawnStatus,
     PROXY_ADD_DURATION_SECONDS, ProxyAddStatus,
     SERVER_POLL_DURATION_SECONDS, ServerPollStatus,
-    RUNNING_SERVERS, TOTAL_USERS
+    RUNNING_SERVERS
 )
 
 # pattern for the authentication token header
@@ -740,7 +740,6 @@ class BaseHandler(RequestHandler):
             spawner._proxy_pending = True
             try:
                 await self.proxy.add_user(user, server_name)
-                TOTAL_USERS.inc()
 
                 PROXY_ADD_DURATION_SECONDS.labels(
                     status='success'
@@ -872,7 +871,6 @@ class BaseHandler(RequestHandler):
         )
         await self.proxy.delete_user(user, server_name)
         await user.stop(server_name)
-        TOTAL_USERS.dec()
 
     async def stop_single_user(self, user, server_name=''):
         if server_name not in user.spawners:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -33,7 +33,7 @@ from ..metrics import (
     SERVER_SPAWN_DURATION_SECONDS, ServerSpawnStatus,
     PROXY_ADD_DURATION_SECONDS, ProxyAddStatus,
     SERVER_POLL_DURATION_SECONDS, ServerPollStatus,
-    RUNNING_SERVERS
+    RUNNING_SERVERS, TOTAL_USERS
 )
 
 # pattern for the authentication token header
@@ -740,6 +740,7 @@ class BaseHandler(RequestHandler):
             spawner._proxy_pending = True
             try:
                 await self.proxy.add_user(user, server_name)
+                TOTAL_USERS.inc()
 
                 PROXY_ADD_DURATION_SECONDS.labels(
                     status='success'
@@ -871,6 +872,7 @@ class BaseHandler(RequestHandler):
         )
         await self.proxy.delete_user(user, server_name)
         await user.stop(server_name)
+        TOTAL_USERS.dec()
 
     async def stop_single_user(self, user, server_name=''):
         if server_name not in user.spawners:

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -42,6 +42,13 @@ RUNNING_SERVERS = Gauge(
 
 RUNNING_SERVERS.set(0)
 
+TOTAL_USERS = Gauge(
+	'total_users',
+	'toal number of users'
+	)
+
+TOTAL_USERS.set(0)	
+
 class ServerSpawnStatus(Enum):
     """
     Possible values for 'status' label of SERVER_SPAWN_DURATION_SECONDS

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -49,6 +49,11 @@ TOTAL_USERS = Gauge(
 
 TOTAL_USERS.set(0)	
 
+CHECK_ROUTES_DURATION_SECONDS = Histogram(
+    'check_routes_duration_seconds',
+    'Time taken to validate all routes in proxy'
+)
+
 class ServerSpawnStatus(Enum):
     """
     Possible values for 'status' label of SERVER_SPAWN_DURATION_SECONDS

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -42,6 +42,7 @@ from traitlets.config import LoggingConfigurable
 from .objects import Server
 from . import utils
 from .utils import url_path_join
+from .metrics import CHECK_ROUTES_DURATION_SECONDS
 
 
 def _one_at_a_time(method):
@@ -292,6 +293,7 @@ class Proxy(LoggingConfigurable):
     @_one_at_a_time
     async def check_routes(self, user_dict, service_dict, routes=None):
         """Check that all users are properly routed on the proxy."""
+        start = time.pref_counter() #timer starts here when user is created
         if not routes:
             self.log.debug("Fetching routes to check")
             routes = await self.get_all_routes()
@@ -364,6 +366,8 @@ class Proxy(LoggingConfigurable):
                 futures.append(self.delete_route(routespec))
 
         await gen.multi(futures)
+        stop = time.pref_counter() #timer stops here when user is deleted
+        CHECK_ROUTES_DURATION_SECONDS.observe(stop - start) #histogram metric
 
     def add_hub_route(self, hub):
         """Add the default route for the Hub"""

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -17,6 +17,7 @@ from ._version import _check_version, __version__
 from .objects import Server
 from .spawner import LocalProcessSpawner
 from .crypto import encrypt, decrypt, CryptKeeper, EncryptionUnavailable, InvalidToken
+from .metrics import TOTAL_USERS
 
 class UserDict(dict):
     """Like defaultdict, but for users
@@ -39,6 +40,7 @@ class UserDict(dict):
         """Add a user to the UserDict"""
         if orm_user.id not in self:
             self[orm_user.id] = self.from_orm(orm_user)
+            TOTAL_USERS.inc()
         return self[orm_user.id]
 
     def __contains__(self, key):
@@ -93,6 +95,7 @@ class UserDict(dict):
         self.db.delete(user)
         self.db.commit()
         # delete from dict after commit
+        TOTAL_USERS.dec()
         del self[user_id]
 
     def count_active_users(self):


### PR DESCRIPTION
A new **histogram** metric is defined in jupyterhub/metrics.py which is used to calculate "Time taken to validate all routes in proxy". 
A timer is set in jupyterhub/proxy.py which starts at the time of the function call "check_routes" and stops after the execution of the function.

**time.perf_counter() → float** is used for calculating the time. 
Return the value (in fractional seconds) of a performance counter, i.e. a clock with the highest available resolution to measure a short duration. It does include time elapsed during sleep and is system-wide. The reference point of the returned value is undefined, so that only the difference between the results of consecutive calls is valid.
@minrk @yuvipanda I have made the PR. Kindly check.