### PR TITLE
add html5lib to test requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ mock
 beautifulsoup4
 codecov
 cryptography
+html5lib  # needed for beautifulsoup
 pytest-cov
 pytest-tornado
 pytest>=3.3


### PR DESCRIPTION
this is needed for bs4. I'm not sure why it was there before, but not anymore