### PR TITLE
Add handler to spawner so you can access query params in form

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -107,6 +107,8 @@ class SpawnHandler(BaseHandler):
             self.redirect(url)
             return
         if user.spawner.options_form:
+            # Add handler to spawner here so you can access query params in form rendering.
+            user.spawner.handler = self
             form = await self._render_form(for_user=user)
             self.finish(form)
         else:


### PR DESCRIPTION
Created a Jupyterhub w/ Kubespawner and Oauthenticator where you can specify an image 'profile' via URL query args. Then a choice list is dynamically populated (with defaults and the specified image) and the user can select which one they want and start that server.

https://[base-url]/hub/spawn?image=[docker repository]:[tag]&cpu_limit=2&mem_limit=16G

To get this to work, I had to make sure that the Kubespawner had access to the Handler, so I set it in  SpawnHandler.get. All other changes I was able to put in the config. 

