### PR TITLE
Try to create exception str before logging

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -103,7 +103,11 @@ class APIHandler(BaseHandler):
                 status_message = reason
 
         if exception and isinstance(exception, SQLAlchemyError):
-            self.log.warning("Rolling back session due to database error %s", exception)
+            try:
+                exception_str = str(exception)
+                self.log.warning("Rolling back session due to database error %s", exception_str)
+            except Exception:
+                self.log.warning("Rolling back session due to database error %s", type(exception))
             self.db.rollback()
 
         self.set_header('Content-Type', 'application/json')


### PR DESCRIPTION
While working on #888 / #1564 and hunting down a problem with `test_token_athenticator_noauth`, `orm.User.find` was raising `sqlalchemy.exc.InterfaceError`.

The stack trace reports it as `sqlalchemy.exc.InterfaceError: <unprintable InterfaceError object>`, and `APIHandler.write_error` is trying to print it for the log message. When the logger calls `str` on the exception, it raises, which the logger reports and then re-raises, causing the db rollback (and the rest of the function) to be skipped.

For the record, here's what the logger reports:
```
[W 49:05.253 MockHub base:109] Bad message (AttributeError("'int' object has no attribute 'items'",)): {'name': 'MockHub', 'msg': 'Rolling back session due to database error %s', 'args': (InterfaceError('(sqlite3.InterfaceError) Error bin
ding parameter 0 - probably unsupported type.',),), 'levelname': 'WARNING', 'levelno': 30, 'pathname': '/home/will/jh/jupyterhub/apihandlers/base.py', 'filename': 'base.py', 'module': 'base', 'exc_info': None, 'exc_text': None, 'stack_inf
o': None, 'lineno': 109, 'funcName': 'write_error', 'created': 1539715745.2534204, 'msecs': 253.42035293579102, 'relativeCreated': 52522.23038673401, 'thread': 140497472509760, 'threadName': 'MainThread', 'processName': 'MainProcess', 'pr
ocess': 19852}
```

This fix simply calls str ahead of time and wraps it in a try. If it fails, only the exception type is logged.

The [documentation for SQLAlchemy](https://docs.sqlalchemy.org/en/latest/errors.html#interfaceerror) does not suggest a way to access the details of this exception.