### PR TITLE
unpin coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+parallel = True
 branch = False
 omit =
     jupyterhub/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ share/jupyterhub/static/css/style.min.css.map
 *.egg-info
 MANIFEST
 .coverage
+.coverage.*
 htmlcov
 .idea/
 .pytest_cache

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 mock
 beautifulsoup4
 codecov
-coverage<5  # pin coverage to < 5 due to coveragepy#716
+coverage
 cryptography
 html5lib  # needed for beautifulsoup
 pytest-cov


### PR DESCRIPTION
need run.parallel = True in coveragerc to fix database errors with coverage 5

exclude the resulting .coverage.host.pid files in gitignore