### PR TITLE
Added health check endpoint

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -352,6 +352,12 @@ class ProxyErrorHandler(BaseHandler):
         self.write(html)
 
 
+class HealthCheckHandler(BaseHandler):
+    """Answer to health check"""
+    def get(self, *args):
+        self.finish()
+
+
 default_handlers = [
     (r'/', RootHandler),
     (r'/home', HomeHandler),
@@ -360,4 +366,5 @@ default_handlers = [
     (r'/spawn/([^/]+)', SpawnHandler),
     (r'/token', TokenPageHandler),
     (r'/error/(\d+)', ProxyErrorHandler),
+    (r'/health$', HealthCheckHandler),
 ]

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -667,3 +667,9 @@ def test_server_not_running_api_request(app):
     assert r.status_code == 404
     assert r.headers["content-type"] == "application/json"
     assert r.json() == {"message": "bees is not running"}
+
+
+@pytest.mark.gen_test
+def test_health_check_request(app):
+    r = yield get_page('health', app)
+    assert r.status_code == 200


### PR DESCRIPTION
Health check is very fundamental to make a service to be robust and scalable.

I added health check endpoint to simply return 200 OK to requests.

Note: I'm using zero-to-jupyterhub-k8s so going to fix helm template to add health check.