### PR TITLE
add configuration for shutting down all user spawners on logout

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1020,6 +1020,11 @@ class JupyterHub(Application):
 
     statsd = Any(allow_none=False, help="The statsd client, if any. A mock will be used if we aren't using statsd")
 
+    shutdown_on_logout = Bool(
+        False,
+        help="""Shuts down all user servers on logout"""
+    ).tag(config=True)
+
     @default('statsd')
     def _statsd(self):
         if self.statsd_host:
@@ -1849,6 +1854,7 @@ class JupyterHub(Application):
             internal_ssl_cert=self.internal_ssl_cert,
             internal_ssl_ca=self.internal_ssl_ca,
             trusted_alt_names=self.trusted_alt_names,
+            shutdown_on_logout=self.shutdown_on_logout
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -1,19 +1,24 @@
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
-import requests
 
 from certipy import Certipy
+import requests
+
 
 class _AsyncRequests:
     """Wrapper around requests to return a Future from request methods
 
     A single thread is allocated to avoid blocking the IOLoop thread.
     """
+
     def __init__(self):
         self.executor = ThreadPoolExecutor(1)
 
     def __getattr__(self, name):
         requests_method = getattr(requests, name)
-        return lambda *args, **kwargs: self.executor.submit(requests_method, *args, **kwargs)
+        return lambda *args, **kwargs: asyncio.wrap_future(
+            self.executor.submit(requests_method, *args, **kwargs)
+        )
 
 
 # async_requests.get = requests.get returning a Future, etc.
@@ -22,6 +27,7 @@ async_requests = _AsyncRequests()
 
 class AsyncSession(requests.Session):
     """requests.Session object that runs in the background thread"""
+
     def request(self, *args, **kwargs):
         return async_requests.executor.submit(super().request, *args, **kwargs)
 
@@ -30,9 +36,9 @@ def ssl_setup(cert_dir, authority_name):
     # Set up the external certs with the same authority as the internal
     # one so that certificate trust works regardless of chosen endpoint.
     certipy = Certipy(store_dir=cert_dir)
-    alt_names = ['DNS:localhost', 'IP:127.0.0.1']
+    alt_names = ["DNS:localhost", "IP:127.0.0.1"]
     internal_authority = certipy.create_ca(authority_name, overwrite=True)
-    external_certs = certipy.create_signed_pair('external', authority_name,
-                                                overwrite=True,
-                                                alt_names=alt_names)
+    external_certs = certipy.create_signed_pair(
+        "external", authority_name, overwrite=True, alt_names=alt_names
+    )
     return external_certs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
-minversion = 3.3
+# pytest 3.10 has broken minversion checks,
+# so we have to disable this until pytest 3.11
+# minversion = 3.3
+
 python_files = test_*.py
 markers =
     gen_test: marks an async tornado test


### PR DESCRIPTION
Added `shutdown_on_logout` new setting. JupyterHub is now calling `spawner.stop()` method of the spawner when a user logs out. 