### PR TITLE
Add a logo block, and update the docs regarding base.html.

### DIFF
--- a/docs/source/reference/templates.md
+++ b/docs/source/reference/templates.md
@@ -25,19 +25,19 @@ supplement the material in the block.  The
 make extensive use of blocks, which allows you to customize parts of the
 interface easily.
 
-In general, a child template can extend a base template, `base.html`, by beginning with:
+In general, a child template can extend a base template, `page.html`, by beginning with:
 
 ```html
-{% extends "base.html" %}
+{% extends "page.html" %}
 ```
 
 This works, unless you are trying to extend the default template for the same
 file name.  Starting in version 0.9, you may refer to the base file with a
-`templates/` prefix.  Thus, if you are writing a custom `base.html`, start the
+`templates/` prefix.  Thus, if you are writing a custom `page.html`, start the
 file with this block:
 
 ```html
-{% extends "templates/base.html" %}
+{% extends "templates/page.html" %}
 ```
 
 By defining `block`s with same name as in the base template, child templates

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -96,7 +96,11 @@
   <nav class="navbar navbar-default">
     <div class="container-fluid">
       <div class="navbar-header">
-        <span id="jupyterhub-logo" class="pull-left"><a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a></span>
+        {% block logo %}
+        <span id="jupyterhub-logo" class="pull-left">
+            <a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a>
+        </span>
+        {% endblock %}
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#thenavbar" aria-expanded="false">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>


### PR DESCRIPTION
I'm trying to skin an internal JupyterHub deployment much like I did for individual notebook instances way-back-when. To do this, it is super useful if there is a logo block that I can override in ``page.html``. When digging in the docs I also noticed that there is a reference to the old ``base.html`` template name, so I fixed that too.