### PR TITLE
handle partial launches on startup

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1688,6 +1688,40 @@ class JupyterHub(Application):
                     status = -1
 
             if status is None:
+                # poll claims it's running.
+                # Check if it's really there
+                url_in_db = spawner.server.url
+                url = await spawner.get_url()
+                if url != url_in_db:
+                    self.log.warning(
+                        "%s had invalid url %s. Updating to %s",
+                        spawner._log_name, url_in_db, url,
+                    )
+                    urlinfo = urlparse(url)
+                    spawner.server.protocol = urlinfo.scheme
+                    spawner.server.ip = urlinfo.hostname
+                    if urlinfo.port:
+                        spawner.server.port = urlinfo.port
+                    elif urlinfo.scheme == 'http':
+                        spawner.server.port = 80
+                    elif urlinfo.scheme == 'https':
+                        spawner.server.port = 443
+                    self.db.commit()
+
+                self.log.debug(
+                    "Verifying that %s is running at %s",
+                    spawner._log_name, url,
+                )
+                try:
+                    await user._wait_up(spawner)
+                except TimeoutError:
+                    self.log.error(
+                        "%s does not appear to be running at %s, shutting it down.",
+                        spawner._log_name, url,
+                    )
+                    status = -1
+
+            if status is None:
                 self.log.info("%s still running", user.name)
                 spawner.add_poll_callback(user_stopped, user, name)
                 spawner.start_polling()

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -661,6 +661,22 @@ class Spawner(LoggingConfigurable):
 
         return env
 
+    async def get_url(self):
+        """Get the URL to connect to the server
+
+        Sometimes JupyterHub may ask the Spawner for its url.
+        This can occur e.g. when JupyterHub has restarted while a server was not finished starting,
+        giving Spawners a chance to recover the URL where their server is running.
+
+        The default is to trust that JupyterHub has the right information.
+        Only override this method in Spawners that know how to
+        check the correct URL for the servers they start.
+
+        This will only be asked of Spawners that claim to be running
+        (`poll()` returns `None`).
+        """
+        return self.server.url
+
     def template_namespace(self):
         """Return the template namespace for format-string formatting.
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -531,7 +531,7 @@ class User:
                 self.settings['statsd'].incr('spawner.failure.error')
                 e.reason = 'error'
             try:
-                await self.stop(spawner.server_name)
+                await self.stop(spawner.name)
             except Exception:
                 self.log.error("Failed to cleanup {user}'s server that failed to start".format(
                     user=self.name,
@@ -587,7 +587,7 @@ class User:
                 ))
                 self.settings['statsd'].incr('spawner.failure.http_error')
             try:
-                await self.stop(spawner.server_name)
+                await self.stop(spawner.name)
             except Exception:
                 self.log.error("Failed to cleanup {user}'s server that failed to start".format(
                     user=self.name,

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -531,7 +531,7 @@ class User:
                 self.settings['statsd'].incr('spawner.failure.error')
                 e.reason = 'error'
             try:
-                await self.stop()
+                await self.stop(spawner.server_name)
             except Exception:
                 self.log.error("Failed to cleanup {user}'s server that failed to start".format(
                     user=self.name,
@@ -550,6 +550,15 @@ class User:
         spawner.orm_spawner.state = spawner.get_state()
         db.commit()
         spawner._waiting_for_response = True
+        await self._wait_up(spawner)
+
+    async def _wait_up(self, spawner):
+        """Wait for a server to finish starting.
+
+        Shuts the server down if it doesn't respond within
+        spawner.http_timeout.
+        """
+        server = spawner.server
         key = self.settings.get('internal_ssl_key')
         cert = self.settings.get('internal_ssl_cert')
         ca = self.settings.get('internal_ssl_ca')
@@ -578,7 +587,7 @@ class User:
                 ))
                 self.settings['statsd'].incr('spawner.failure.http_error')
             try:
-                await self.stop()
+                await self.stop(spawner.server_name)
             except Exception:
                 self.log.error("Failed to cleanup {user}'s server that failed to start".format(
                     user=self.name,
@@ -594,7 +603,7 @@ class User:
         finally:
             spawner._waiting_for_response = False
             spawner._start_pending = False
-        return self
+        return spawner
 
     async def stop(self, server_name=''):
         """Stop the user's spawner


### PR DESCRIPTION
Servers may be running, but not have finished storing connection information in the database.

This adds:

1. an opportunity for spawners that can (e.g. docker, kube), to ensure the URL is correct, and
2. a verification that the server is actually available at the URL, shutting it down if not

This should increase the likelihood that Spawners who can recover from a partial spawn do, but more importantly ensures that Spawners that didn't result in a server running at the expected URL (for whatever reason) are not considered to be running at startup.


cc @yuvipanda who reported this on discourse.