### PR TITLE
HubAuth: allow caching None responses

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -277,11 +277,10 @@ class HubAuth(SingletonConfigurable):
             if cache_key is None:
                 raise ValueError("cache_key is required when using cache")
             # check for a cached reply, so we don't check with the Hub if we don't have to
-            cached = self.cache.get(cache_key)
-            if cached is not None:
-                return cached
-            else:
-                app_log.debug("Cache miss: %s" % cache_key)
+            try:
+                return self.cache[cache_key]
+            except KeyError:
+                app_log.debug("HubAuth cache miss: %s", cache_key)
 
         data = self._api_request('GET', url, allow_404=True)
         if data is None:


### PR DESCRIPTION
when a token doesn't identify a user, the response is None. These results are cached, but the cache checked for `is None`, causing failed-auth responses to effectively not be cached.

This fixes the flood of Hub requests caused by repeated stale-auth requests in #2299