### PR TITLE
getgrnam/getpwnam/getgrouplist refactor

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -601,9 +601,8 @@ class LocalAuthenticator(Authenticator):
     @staticmethod
     def system_user_exists(user):
         """Check if the user exists on the system"""
-        import pwd
         try:
-            pwd.getpwnam(user.name)
+            getpwnam(user.name)
         except KeyError:
             return False
         else:

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -547,7 +547,7 @@ class LocalAuthenticator(Authenticator):
             return False
         for grnam in self.group_whitelist:
             try:
-                group = self.getgrnam(grnam)
+                group = self._getgrnam(grnam)
             except KeyError:
                 self.log.error('No such group: [%s]' % grnam)
                 continue
@@ -575,7 +575,7 @@ class LocalAuthenticator(Authenticator):
         await maybe_future(super().add_user(user))
 
     @staticmethod
-    def getgrnam(name):
+    def _getgrnam(name):
         """Wrapper function to protect against `grp` not being available
         on Windows
         """
@@ -583,7 +583,7 @@ class LocalAuthenticator(Authenticator):
         return grp.getgrnam(name)
 
     @staticmethod
-    def getpwnam(name):
+    def _getpwnam(name):
         """Wrapper function to protect against `pwd` not being available
         on Windows
         """
@@ -591,8 +591,8 @@ class LocalAuthenticator(Authenticator):
         return pwd.getpwnam(name)
 
     @staticmethod
-    def getgrouplist(name, group):
-        """Wrapper function to protect against `os.getgrouplist` not being available
+    def _getgrouplist(name, group):
+        """Wrapper function to protect against `os._getgrouplist` not being available
         on Windows
         """
         import os
@@ -601,7 +601,7 @@ class LocalAuthenticator(Authenticator):
     def system_user_exists(self, user):
         """Check if the user exists on the system"""
         try:
-            self.getpwnam(user.name)
+            self._getpwnam(user.name)
         except KeyError:
             return False
         else:
@@ -702,8 +702,8 @@ class PAMAuthenticator(LocalAuthenticator):
                 # fail to authenticate and raise instead of soft-failing and not changing admin status
                 # (returning None instead of just the username) as this indicates some sort of system failure
 
-                admin_group_gids = {self.getgrnam(x).gr_gid for x in self.admin_groups}
-                user_group_gids  = {x.gr_gid for x in self.getgrouplist(username, self.getpwnam(username).pw_gid)}
+                admin_group_gids = {self._getgrnam(x).gr_gid for x in self.admin_groups}
+                user_group_gids  = {x.gr_gid for x in self._getgrouplist(username, self._getpwnam(username).pw_gid)}
                 admin_status = len(admin_group_gids & user_group_gids) != 0
 
             except Exception as e:

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -86,7 +86,7 @@ def test_pam_auth_admin_groups():
                                          admin_users={'override_admin'})
 
     # Check admin_group applies as expected
-    with mock.patch.multiple(auth,
+    with mock.patch.multiple(authenticator,
                              getgrnam=getgrnam,
                              getpwnam=getpwnam,
                              getgrouplist=getgrouplist):
@@ -95,10 +95,10 @@ def test_pam_auth_admin_groups():
             'password': 'group_admin'
         })
     assert authorized['name'] == 'group_admin'
-    assert authorized['admin'] == True
+    assert authorized['admin'] is True
 
     # Check multiple groups work, just in case.
-    with mock.patch.multiple(auth,
+    with mock.patch.multiple(authenticator,
                              getgrnam=getgrnam,
                              getpwnam=getpwnam,
                              getgrouplist=getgrouplist):
@@ -107,10 +107,10 @@ def test_pam_auth_admin_groups():
             'password': 'also_group_admin'
         })
     assert authorized['name'] == 'also_group_admin'
-    assert authorized['admin'] == True
+    assert authorized['admin'] is True
 
     # Check admin_users still applies correctly
-    with mock.patch.multiple(auth,
+    with mock.patch.multiple(authenticator,
                              getgrnam=getgrnam,
                              getpwnam=getpwnam,
                              getgrouplist=getgrouplist):
@@ -119,10 +119,10 @@ def test_pam_auth_admin_groups():
             'password': 'override_admin'
         })
     assert authorized['name'] == 'override_admin'
-    assert authorized['admin'] == True
+    assert authorized['admin'] is True
 
     # Check it doesn't admin everyone
-    with mock.patch.multiple(auth,
+    with mock.patch.multiple(authenticator,
                              getgrnam=getgrnam,
                              getpwnam=getpwnam,
                              getgrouplist=getgrouplist):
@@ -131,7 +131,7 @@ def test_pam_auth_admin_groups():
             'password': 'non_admin'
         })
     assert authorized['name'] == 'non_admin'
-    assert authorized['admin'] == False
+    assert authorized['admin'] is False
 
 
 @pytest.mark.gen_test
@@ -163,14 +163,14 @@ def test_pam_auth_group_whitelist():
 
     authenticator = MockPAMAuthenticator(group_whitelist={'group'})
 
-    with mock.patch.object(auth, 'getgrnam', getgrnam):
+    with mock.patch.object(authenticator, 'getgrnam', getgrnam):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'kaylee',
             'password': 'kaylee',
         })
     assert authorized['name'] == 'kaylee'
 
-    with mock.patch.object(auth, 'getgrnam', getgrnam):
+    with mock.patch.object(authenticator, 'getgrnam', getgrnam):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'mal',
             'password': 'mal',

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -87,9 +87,9 @@ def test_pam_auth_admin_groups():
 
     # Check admin_group applies as expected
     with mock.patch.multiple(authenticator,
-                             getgrnam=getgrnam,
-                             getpwnam=getpwnam,
-                             getgrouplist=getgrouplist):
+                             _getgrnam=getgrnam,
+                             _getpwnam=getpwnam,
+                             _getgrouplist=getgrouplist):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'group_admin',
             'password': 'group_admin'
@@ -99,9 +99,9 @@ def test_pam_auth_admin_groups():
 
     # Check multiple groups work, just in case.
     with mock.patch.multiple(authenticator,
-                             getgrnam=getgrnam,
-                             getpwnam=getpwnam,
-                             getgrouplist=getgrouplist):
+                             _getgrnam=getgrnam,
+                             _getpwnam=getpwnam,
+                             _getgrouplist=getgrouplist):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'also_group_admin',
             'password': 'also_group_admin'
@@ -111,9 +111,9 @@ def test_pam_auth_admin_groups():
 
     # Check admin_users still applies correctly
     with mock.patch.multiple(authenticator,
-                             getgrnam=getgrnam,
-                             getpwnam=getpwnam,
-                             getgrouplist=getgrouplist):
+                             _getgrnam=getgrnam,
+                             _getpwnam=getpwnam,
+                             _getgrouplist=getgrouplist):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'override_admin',
             'password': 'override_admin'
@@ -123,9 +123,9 @@ def test_pam_auth_admin_groups():
 
     # Check it doesn't admin everyone
     with mock.patch.multiple(authenticator,
-                             getgrnam=getgrnam,
-                             getpwnam=getpwnam,
-                             getgrouplist=getgrouplist):
+                             _getgrnam=getgrnam,
+                             _getpwnam=getpwnam,
+                             _getgrouplist=getgrouplist):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'non_admin',
             'password': 'non_admin'
@@ -163,14 +163,14 @@ def test_pam_auth_group_whitelist():
 
     authenticator = MockPAMAuthenticator(group_whitelist={'group'})
 
-    with mock.patch.object(authenticator, 'getgrnam', getgrnam):
+    with mock.patch.object(authenticator, '_getgrnam', getgrnam):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'kaylee',
             'password': 'kaylee',
         })
     assert authorized['name'] == 'kaylee'
 
-    with mock.patch.object(authenticator, 'getgrnam', getgrnam):
+    with mock.patch.object(authenticator, '_getgrnam', getgrnam):
         authorized = yield authenticator.get_authenticated_user(None, {
             'username': 'mal',
             'password': 'mal',


### PR DESCRIPTION
I noticed a function in auth was using its own getpwnam without a wrapper when everything else was, I switched it over. I also moved the getgrnam/getpwnam/getgrouplist wrappers under LocalAuthenticator since they're only used by LocalAuthenticator and PAMAuthenticator.

I've noticed that the spawner code doesn't use a wrapper for pwd or os functions that the python docs say are strictly available on unix platforms. Can we just get rid of the wrapper functions in auth entirely?