### PR TITLE
post_auth_hook processor

### DIFF
--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -459,6 +459,7 @@ def test_validate_names():
 def test_post_auth_hook():
     def test_auth_hook(authenticator, handler, authentication):
         authentication['testkey'] = 'testvalue'
+        return authentication
 
     a = MockPAMAuthenticator(post_auth_hook=test_auth_hook)
 

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -453,3 +453,18 @@ def test_validate_names():
     a = auth.PAMAuthenticator(username_pattern='w.*')
     assert not a.validate_username('xander')
     assert a.validate_username('willow')
+
+
+@pytest.mark.gen_test
+def test_post_auth_hook():
+    def test_auth_hook(authenticator, handler, authentication):
+        authentication['testkey'] = 'testvalue'
+
+    a = MockPAMAuthenticator(post_auth_hook=test_auth_hook)
+
+    authorized = yield a.get_authenticated_user(None, {
+        'username': 'test_user',
+        'password': 'test_user'
+    })
+
+    assert authorized['testkey'] == 'testvalue'


### PR DESCRIPTION
Does what it sounds like, allows an arbitrary function to be called right before the return in `get_authenticated_user`.

(and an accidental reformat of the include section)

#2261 / #2288 (which I just noticed, I should look at issues more)

I'm not sure if the full authentication dictionary should be passed in, or if the signature should be changed to something like `post_auth_hook(authenticator, handler, name, admin, auth_state)` to prevent changes to the name and admin status.

I feel like if I was the end user, I would be annoyed by the restriction, though we have proper places for overriding and setting the name and admin state.