### PR TITLE
refresh_user: add handler parameter

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -307,7 +307,7 @@ class Authenticator(LoggingConfigurable):
             self.log.warning("User %r not in whitelist.", username)
             return
 
-    async def refresh_user(self, user):
+    async def refresh_user(self, user, handler=None):
         """Refresh auth data for a given user
 
         Allows refreshing or invalidating auth data.
@@ -319,6 +319,7 @@ class Authenticator(LoggingConfigurable):
 
         Args:
             user (User): the user to refresh
+            handler (tornado.web.RequestHandler or None): the current request handler
         Returns:
             auth_data (bool or dict):
                 Return **True** if auth data for the user is up-to-date

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -262,7 +262,7 @@ class BaseHandler(RequestHandler):
         self._refreshed_users.add(user.name)
 
         self.log.debug("Refreshing auth for %s", user.name)
-        auth_info = await self.authenticator.refresh_user(user)
+        auth_info = await self.authenticator.refresh_user(user, self)
 
         if not auth_info:
             self.log.warning(


### PR DESCRIPTION
The current request handler might be needed to determine if the auth
data needs to be refreshed.

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>


