### PR TITLE
setuptools entrypoints instead of scripts

### DIFF
--- a/scripts/jupyterhub
+++ b/scripts/jupyterhub
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-
-from jupyterhub.app import main
-main()

--- a/scripts/jupyterhub-singleuser
+++ b/scripts/jupyterhub-singleuser
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-from jupyterhub.singleuser import main
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ with open('README.md', encoding="utf8") as f:
 
 setup_args = dict(
     name                = 'jupyterhub',
-    scripts             = glob(pjoin('scripts', '*')),
     packages            = packages,
                         # dummy, so that install_data doesn't get skipped
                         # this will be overridden when bower is run anyway
@@ -121,6 +120,10 @@ setup_args = dict(
             'localprocess = jupyterhub.spawner:LocalProcessSpawner',
             'simple = jupyterhub.spawner:SimpleLocalProcessSpawner',
         ],
+        'console_scripts': [
+            'jupyterhub = jupyterhub.app:main',
+            'jupyterhub-singleuser = jupyterhub.singleuser:main',
+        ]
     },
     classifiers         = [
         'Intended Audience :: Developers',


### PR DESCRIPTION
Use setuptools console_scripts functionality to create top level jupyter
& jupyterhub-single user entry point scripts on *nix, and executables on
Windows.

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>


