### PR TITLE
Improving Test Coverage of Jupyterhub. 

### DIFF
--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -184,6 +184,18 @@ def test_check_routes(app,  username, disable_check_routes):
     # check that before and after state are the same
     assert before == after
 
+def test_restore_routes(app, username):
+    proxy = app.proxy
+    test_user = add_user(app.db, app, name=username)
+    r = yield api_request(app, 'users/%s/server' % username, method='post')
+    r.raise_for_status()
+
+    #check that all routes are added to hub
+    yield app.users.restore_routes(app.users, app._service_map)
+    routes = yield app.proxy.get_all_routes
+    p = sorted(routes)
+    assert test_user.proxy_spec in p 
+
 
 @pytest.mark.gen_test
 @pytest.mark.parametrize("routespec", [


### PR DESCRIPTION
 **Test function for restore_routes.**
In the coverage report of jupyterhub/proxy.py due to the restore_routes function the percentage is low. https://codecov.io/gh/jupyterhub/jupyterhub/src/302573e860a696b9c67f7d862cfe1af9be199919/jupyterhub/proxy.py#L378...383
A new test function `test_restore_routes ` is added in test_proxy.py .[https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/tests/test_proxy.py](url)
@minrk Kindly , check this and let me know further on this. 