### PR TITLE
[WIP] Moved PAM session creations to a preexec_fn

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -356,6 +356,9 @@ class Authenticator(LoggingConfigurable):
                 persisted; and `admin`, the admin setting value for the user.
         """
 
+    def pre_exec_fn(self, user, spawner):
+        """Hook called before exec is called in the spawned child process """
+
     def pre_spawn_start(self, user, spawner):
         """Hook called before spawning a user's server
 
@@ -746,8 +749,7 @@ class PAMAuthenticator(LocalAuthenticator):
         return username
 
 
-    @run_on_executor
-    def pre_spawn_start(self, user, spawner):
+    def pre_exec_fn(self, user, spawner):
         """Open PAM session for user if so configured"""
         if not self.open_sessions:
             return
@@ -755,8 +757,9 @@ class PAMAuthenticator(LocalAuthenticator):
             pamela.open_session(user.name, service=self.service, encoding=self.encoding)
         except pamela.PAMError as e:
             self.log.warning("Failed to open PAM session for %s: %s", user.name, e)
-            self.log.warning("Disabling PAM sessions from now on.")
-            self.open_sessions = False
+            # this will be ineffective in the child process
+            # self.log.warning("Disabling PAM sessions from now on.")
+            # self.open_sessions = False
 
     @run_on_executor
     def post_spawn_stop(self, user, spawner):

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -357,7 +357,10 @@ class Authenticator(LoggingConfigurable):
         """
 
     def pre_exec_fn(self, user, spawner):
-        """Hook called before exec is called in the spawned child process """
+        """Hook called before Popen is called by LocalProcessSpawner """
+
+    def post_exec_fn(self, user, spawner):
+        """Hook called after child process closes by LocalProcessSpawner """
 
     def pre_spawn_start(self, user, spawner):
         """Hook called before spawning a user's server
@@ -757,12 +760,8 @@ class PAMAuthenticator(LocalAuthenticator):
             pamela.open_session(user.name, service=self.service, encoding=self.encoding)
         except pamela.PAMError as e:
             self.log.warning("Failed to open PAM session for %s: %s", user.name, e)
-            # this will be ineffective in the child process
-            # self.log.warning("Disabling PAM sessions from now on.")
-            # self.open_sessions = False
 
-    #@run_on_executor
-    def post_spawn_stop(self, user, spawner):
+    def post_exec_fn(self, user, spawner):
         """Close PAM session for user if we were configured to opened one"""
         if not self.open_sessions:
             return

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -761,7 +761,7 @@ class PAMAuthenticator(LocalAuthenticator):
             # self.log.warning("Disabling PAM sessions from now on.")
             # self.open_sessions = False
 
-    @run_on_executor
+    #@run_on_executor
     def post_spawn_stop(self, user, spawner):
         """Close PAM session for user if we were configured to opened one"""
         if not self.open_sessions:

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1167,7 +1167,8 @@ class LocalProcessSpawner(Spawner):
         """
         fn = set_user_setuid(name)
         def preexec_fn():
-            self.authenticator.pre_exec_fn(self.user, self)
+            if self.authenticator:
+                self.authenticator.pre_exec_fn(self.user, self)
             fn()
 
         return preexec_fn

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1165,7 +1165,12 @@ class LocalProcessSpawner(Spawner):
 
         This function can be safely passed to `preexec_fn` of `Popen`
         """
-        return set_user_setuid(name)
+        fn = set_user_setuid(name)
+        def preexec_fn():
+            self.authenticator.pre_exec_fn(self.user, self)
+            fn()
+
+        return preexec_fn
 
     def load_state(self, state):
         """Restore state about spawned single-user server after a hub restart.

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1353,7 +1353,6 @@ class LocalProcessSpawner(Spawner):
         we return the exit code of the process if we have access to it, or 0 otherwise.
         """
         # if we started the process, poll with Popen
-        print('POOL CALLED', self.proc_state, self.pid, file=sys.stderr)
         if isinstance(self.proc_state, multiprocessing.queues.Queue):
             try:
                 status = self.proc_state.get(False)

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from certipy import Certipy
 import requests
+import os
 
 
 class _AsyncRequests:
@@ -42,3 +43,14 @@ def ssl_setup(cert_dir, authority_name):
         "external", authority_name, overwrite=True, alt_names=alt_names
     )
     return external_certs
+
+# uses os kill signal 0 to check if process is alive
+def check_if_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+


### PR DESCRIPTION
PAM sessions are intended to be created within the spawned child
process, not in the parent process. This can create issues with
certain PAM session modules (i.e. pam-systemd.so)


