### PR TITLE
UserTokenListAPIHandler support Authenticator.authenticate returning a dict

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -242,7 +242,7 @@ class UserTokenListAPIHandler(APIHandler):
             # defer to Authenticator for identifying the user
             # can be username+password or an upstream auth token
             try:
-                name = await self.authenticator.authenticate(self, body.get('auth'))
+                name = await self.authenticate(body.get('auth'))
                 if isinstance(name, dict):
                     # not a simple string so it has to be a dict
                     name = name.get('name')

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -243,6 +243,9 @@ class UserTokenListAPIHandler(APIHandler):
             # can be username+password or an upstream auth token
             try:
                 name = await self.authenticator.authenticate(self, body.get('auth'))
+                if isinstance(name, dict):
+                    # not a simple string so it has to be a dict
+                    name = name.get('name')
             except web.HTTPError as e:
                 # turn any authentication error into 403
                 raise web.HTTPError(403)


### PR DESCRIPTION
The documentation for `Authenticator.authenticate` allows returning a dictionary with a mandatory key `name`.

The `authenticate` method call in `UserTokenListAPIHandler.post` should support this as well.

(Included test fails without the patch).

