### PR TITLE
WIP: Support options_form for named servers

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -153,7 +153,7 @@ class SpawnHandler(BaseHandler):
             form_options["%s_file"%key] = byte_list
         try:
             options = await maybe_future(spawner.options_from_form(form_options))
-            await self.spawn_single_user(user, options=options)
+            await self.spawn_single_user(user, server_name=server_name, options=options)
         except Exception as e:
             self.log.error("Failed to spawn single-user server with form", exc_info=True)
             form = await self._render_form(message=str(e), for_user=user, server_name=server_name)
@@ -161,7 +161,7 @@ class SpawnHandler(BaseHandler):
             return
         if current_user is user:
             self.set_login_cookie(user)
-        url = user.url
+        url = user.server_url(server_name)
 
         next_url = self.get_argument('next', '')
         if next_url and not next_url.startswith('/'):

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -367,7 +367,7 @@ default_handlers = [
     (r'/admin', AdminHandler),
     (r'/spawn', SpawnHandler),
     (r'/spawn/([^/]+)', SpawnHandler),
-    (r'/spawn/([^/]+)/(^[/]+)', SpawnHandler),
+    (r'/spawn/([^/]+)/([^/]+)', SpawnHandler),
     (r'/token', TokenPageHandler),
     (r'/error/(\d+)', ProxyErrorHandler),
     (r'/health$', HealthCheckHandler),

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -73,11 +73,11 @@ class SpawnHandler(BaseHandler):
 
     Only enabled when Spawner.options_form is defined.
     """
-    async def _render_form(self, message='', for_user=None):
+    async def _render_form(self, message='', for_user=None, server_name=''):
         # Note that 'user' is the authenticated user making the request and
         # 'for_user' is the user whose server is being spawned.
         user = for_user or self.get_current_user()
-        spawner_options_form = await user.spawner.get_options_form()
+        spawner_options_form = await user.spawners[server_name].get_options_form()
         return self.render_template('spawn.html',
             for_user=for_user,
             spawner_options_form=spawner_options_form,
@@ -111,7 +111,7 @@ class SpawnHandler(BaseHandler):
         if spawner.options_form:
             # Add handler to spawner here so you can access query params in form rendering.
             spawner.handler = self
-            form = await self._render_form(for_user=user)
+            form = await self._render_form(for_user=user, server_name=server_name)
             self.finish(form)
         else:
             # Explicit spawn request: clear _spawn_future
@@ -156,7 +156,7 @@ class SpawnHandler(BaseHandler):
             await self.spawn_single_user(user, options=options)
         except Exception as e:
             self.log.error("Failed to spawn single-user server with form", exc_info=True)
-            form = await self._render_form(message=str(e), for_user=user)
+            form = await self._render_form(message=str(e), for_user=user, server_name=server_name)
             self.finish(form)
             return
         if current_user is user:


### PR DESCRIPTION
This is an attempt to support options_form for the new named server ui.

Although in the long term the options facility should probably move to client side, this is a quick fix to allow multiple configurable servers by a single user, reusing the current server-side infrastructure of options_form.

TODO:
- [x] Launch named server with your existing options_form at /hub/spawner/:user/:name
- [ ] Make the spawn page redirect to the progress page for the new server after launch
- [ ] Make named-ui in /hub/home link to the spawner page, rather than doing direct REST requests, if options_form is enabled.
    - this is the behaivour of the existing "My Server" button
- [ ] provide some info about server_name in the spawn template
- [ ] safeguard the use of spawners[server_name] with namedServersAllowed to avoid accidental spawns
- [ ] make sure the named spawners are recycled properly between launches, so hooks amending the pod spec with mutation (such as extending volumes) won't break

Related to: #2089 and #2154