### PR TITLE
Don’t mix no_patience and bad_spawn

### DIFF
--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -718,7 +718,7 @@ def test_never_spawn(app, no_patience, never_spawn):
 
 
 @mark.gen_test
-def test_bad_spawn(app, no_patience, bad_spawn):
+def test_bad_spawn(app, bad_spawn):
     db = app.db
     name = 'prim'
     user = add_user(db, app=app, name=name)
@@ -835,7 +835,7 @@ def test_progress_ready(request, app):
 
 
 @mark.gen_test
-def test_progress_bad(request, app, no_patience, bad_spawn):
+def test_progress_bad(request, app, bad_spawn):
     """Test progress API when spawner has already failed"""
     db = app.db
     name = 'simon'


### PR DESCRIPTION
this introduces a race between the early RuntimeError being tested and the no_patience causing handlers to return early if async start isn’t complete.

With tornado coroutines, an early RuntimeError could be guaranteed to resolve promptly, but asyncio isn’t as consistent, possibly causing some of the recent flaky tests.