### PR TITLE
Fix PAMAuthenticator is_admin

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -703,7 +703,7 @@ class PAMAuthenticator(LocalAuthenticator):
                 # (returning None instead of just the username) as this indicates some sort of system failure
 
                 admin_group_gids = {self._getgrnam(x).gr_gid for x in self.admin_groups}
-                user_group_gids  = {x.gr_gid for x in self._getgrouplist(username, self._getpwnam(username).pw_gid)}
+                user_group_gids  = set(self._getgrouplist(username, self._getpwnam(username).pw_gid))
                 admin_status = len(admin_group_gids & user_group_gids) != 0
 
             except Exception as e:

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -67,10 +67,10 @@ def test_pam_auth_admin_groups():
     system_users = [group_admin, also_group_admin, override_admin, non_admin]
 
     user_group_map = {
-        'group_admin': [jh_users, jh_admins],
-        'also_group_admin': [jh_users, wheel],
-        'override_admin': [jh_users],
-        'non_admin': [jh_users]
+        'group_admin': [jh_users.gr_gid, jh_admins.gr_gid],
+        'also_group_admin': [jh_users.gr_gid, wheel.gr_gid],
+        'override_admin': [jh_users.gr_gid],
+        'non_admin': [jh_users.gr_gid]
     }
 
     def getgrnam(name):


### PR DESCRIPTION
I deployed #2244's patch today and found out that is, in fact, bad. `os.getgrouplist` returns a list of gids directly, not a list of group objects as I and the tester assumed.

I must have gotten the os/grp/pwd functions mixed up during the final refactor and did not give this the final version the thorough testing I should have, as we had already pivoted to LDAP. I'm sorry :C