### PR TITLE
Change id selector to class selector for named servers

### DIFF
--- a/share/jupyterhub/static/js/home.js
+++ b/share/jupyterhub/static/js/home.js
@@ -113,7 +113,7 @@ require(["jquery", "moment", "jhapi"], function($, moment, JHAPI) {
 
   $(".new-server-btn").click(function() {
     var row = getRow($(this));
-    var serverName = $(".new-server-name").val();
+    var serverName = row.find(".new-server-name").val();
     api.start_named_server(user, serverName, {
       success: function(reply) {
         // reload after creating the server

--- a/share/jupyterhub/static/js/home.js
+++ b/share/jupyterhub/static/js/home.js
@@ -111,8 +111,9 @@ require(["jquery", "moment", "jhapi"], function($, moment, JHAPI) {
     });
   });
 
-  $("#new-server-btn").click(function() {
-    var serverName = $("#new-server-name").val();
+  $(".new-server-btn").click(function() {
+    var row = getRow($(this));
+    var serverName = $(".new-server-name").val();
     api.start_named_server(user, serverName, {
       success: function(reply) {
         // reload after creating the server

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -42,8 +42,8 @@
     <tbody>
       <tr class="home-server-row add-server-row">
         <td colspan="4">
-          <input id="new-server-name" placeholder="Name your server">
-          <a role="button" id="new-server-btn" class="add-server btn btn-xs btn-primary">
+          <input class="new-server-name" placeholder="Name your server">
+          <a role="button" class="new-server-btn" class="add-server btn btn-xs btn-primary">
             Add New Server
           </a>
         </td>


### PR DESCRIPTION
The logic for starting/stopping/connecting to named servers is pretty repurpose-able for other ways of specifying the server name through the UI.  We are experimenting with a setup where we have a set of pre-defined names in hidden fields in another kind of UI layout for spawning.  Since there is more than one element involved for starting a new server, just changing this from ID to class selector appears to work just fine for the standard named-server implementation and our own.