### PR TITLE
Limit max named server per user

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -356,7 +356,13 @@ class UserServerAPIHandler(APIHandler):
             if self.named_server_limit_per_user > 0 and server_name not in user.orm_spawners:
                 named_spawners = list(user.all_spawners(include_default=False))
                 if self.named_server_limit_per_user <= len(named_spawners):
-                    raise web.HTTPError(400, "Named servers can not be created any more.")
+                    raise web.HTTPError(
+                        400,
+                        "User {} already has the maximum of {} named servers."
+                        "  One must be deleted before a new server can be created".format(
+                            name,
+                            self.named_server_limit_per_user
+                        ))
         spawner = user.spawners[server_name]
         pending = spawner.pending
         if pending == 'spawn':

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -803,6 +803,16 @@ class JupyterHub(Application):
         help="Allow named single-user servers per user"
     ).tag(config=True)
 
+    named_server_limit_per_user = Integer(0,
+        help="""
+        Maximum number of concurrent named servers that can be created by a user at a time.
+
+        Setting this can limit the total resources a user can consume.
+
+        If set to 0, no limit is enforced.
+        """
+    ).tag(config=True)
+
     # class for spawning single-user servers
     spawner_class = EntryPointType(
         default_value=LocalProcessSpawner,
@@ -1875,6 +1885,7 @@ class JupyterHub(Application):
             domain=self.domain,
             statsd=self.statsd,
             allow_named_servers=self.allow_named_servers,
+            named_server_limit_per_user=self.named_server_limit_per_user,
             oauth_provider=self.oauth_provider,
             concurrent_spawn_limit=self.concurrent_spawn_limit,
             spawn_throttle_retry_range=self.spawn_throttle_retry_range,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -104,6 +104,10 @@ class BaseHandler(RequestHandler):
         return self.settings.get('allow_named_servers', False)
 
     @property
+    def named_server_limit_per_user(self):
+        return self.settings.get('named_server_limit_per_user', 0)
+
+    @property
     def domain(self):
         return self.settings['domain']
 

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -58,6 +58,7 @@ class HomeHandler(BaseHandler):
             user=user,
             url=url,
             allow_named_servers=self.allow_named_servers,
+            named_server_limit_per_user=self.named_server_limit_per_user,
             url_path_join=url_path_join,
             # can't use user.spawners because the stop method of User pops named servers from user.spawners when they're stopped
             spawners = user.orm_user._orm_spawners,
@@ -230,6 +231,7 @@ class AdminHandler(BaseHandler):
             running=running,
             sort={s:o for s,o in zip(sorts, orders)},
             allow_named_servers=self.allow_named_servers,
+            named_server_limit_per_user=self.named_server_limit_per_user,
         )
         self.finish(html)
 

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -26,9 +26,11 @@
 
   <p>
   In addition to your default server,
-  you may have additional servers with names.
+  you may have additional {% if named_server_limit_per_user > 0 %}{{ named_server_limit_per_user }} {% endif %}server(s) with names.
   This allows you to have more than one server running at the same time.
   </p>
+
+  {% set named_spawners = user.all_spawners(include_default=False)|list %}
 
   <table class="server-table table table-striped">
     <thead>
@@ -48,7 +50,7 @@
           </a>
         </td>
       </tr>
-      {% for spawner in user.all_spawners(include_default=False) %}
+      {% for spawner in named_spawners %}
       <tr class="home-server-row" data-server-name="{{ spawner.name }}">
         {# name #}
         <td>{{ spawner.name }}</td>


### PR DESCRIPTION
I'd like to allow users to have more than one server but don't want them to make hundreds of servers because the resource is limited. This config allows us to set the limit on the number of named servers per user.