### PR TITLE
Fix travis CI failure

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ cryptography
 html5lib  # needed for beautifulsoup
 pytest-cov
 pytest-asyncio
-pytest>=3.3
+pytest>=3.6
 notebook
 requests-mock
 virtualenv


### PR DESCRIPTION
`pytest-cov` 2.6.1 which was release 2 weeks ago contains newer `pytest` version constraint. 
https://github.com/pytest-dev/pytest-cov/pull/253
So we should pin `pytest` newer than 3.6.