### PR TITLE
pam_normalize_username option: round-trip usernames through PAM to normalize

### DIFF
--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -106,6 +106,16 @@ c.Authenticator.username_map  = {
 }
 ```
 
+When using `PAMAuthenticator`, you can set
+`c.PAMAuthenticator.pam_normalize_username = True`, which will
+normalize usernames using PAM (basically round-tripping them: username
+to uid to username), which is useful in case you use some external
+service that allows multiple usernames mapping to the same user (such
+as ActiveDirectory, yes, this really happens).  When
+`pam_normalize_username` is on, usernames are *not* normalized to
+lowercase.
+
+
 #### Validate usernames
 
 In most cases, there is a very limited set of acceptable usernames.

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -787,7 +787,9 @@ class PAMAuthenticator(LocalAuthenticator):
             import pwd
             uid = pwd.getpwnam(username).pw_uid
             username = pwd.getpwuid(uid).pw_name
-        return super().normalize_username(username)
+            username = self.username_map.get(username, username)
+        else:
+            return super().normalize_username(username)
 
 class DummyAuthenticator(Authenticator):
     """Dummy Authenticator for testing

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -678,6 +678,16 @@ class PAMAuthenticator(LocalAuthenticator):
         """
     ).tag(config=True)
 
+    pam_normalize_username = Bool(False,
+        help="""
+        Round-trip the username via PAM lookups to make sure it is unique
+
+        PAM can accept multiple usernames that map to the same user,
+        for example DOMAIN\\username in some cases.  To prevent this,
+        convert username into uid, then back to uid to normalize.
+        """
+        ).tag(config=True)
+
     def __init__(self, **kwargs):
         if pamela is None:
             raise _pamela_error from None
@@ -769,6 +779,15 @@ class PAMAuthenticator(LocalAuthenticator):
             self.log.warning("Disabling PAM sessions from now on.")
             self.open_sessions = False
 
+    def normalize_username(self, username):
+        """Round-trip the username to normalize it with PAM
+
+        PAM can accept multiple usernames as the same user, normalize them."""
+        if self.pam_normalize_username:
+            import pwd
+            uid = pwd.getpwnam(username).pw_uid
+            username = pwd.getpwuid(uid).pw_name
+        return super().normalize_username(username)
 
 class DummyAuthenticator(Authenticator):
     """Dummy Authenticator for testing


### PR DESCRIPTION
I have had this semi-completed for months now.  I realized that #2129 (multiple servers per user, root problem was that usernames weren't normalized.).  This basically takes the solution of that issue and makes it a built-in option, which I think will be quite helpful to many people.

Other thoughts:
* I don't know how this can be tested - can we assume PAM is available on the test runners?  And the change is so short that mocking it or some such is almost short-circuting all relevant logic.  Advice requested.
* I seem to recall some other issue about normalizing usernames to lowercase breaks something or the other.  Could this PAM normalization be used as an alternative for lowercase normalization?  Currently lowercase normalization is also done even if `pam_normalize_username` is true.

I have gently tested this myself, but it's not yet in any of my production systems.