### PR TITLE
fix some deprecation warnings in tests

### DIFF
--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -76,7 +76,7 @@ def app(request, io_loop, ssl_tmpdir):
     """Mock a jupyterhub app for testing"""
     mocked_app = None
     ssl_enabled = getattr(request.module, "ssl_enabled", False)
-    kwargs = dict(log_level=logging.DEBUG)
+    kwargs = dict()
     if ssl_enabled:
         kwargs.update(
             dict(

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -40,7 +40,7 @@ from tornado import gen
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 
-from traitlets import Bool, default
+from traitlets import Bool, Dict, default
 
 from ..app import JupyterHub
 from ..auth import PAMAuthenticator
@@ -219,11 +219,14 @@ class MockPAMAuthenticator(PAMAuthenticator):
 class MockHub(JupyterHub):
     """Hub with various mock bits"""
 
+    # disable some inherited traits with hardcoded values
     db_file = None
     last_activity_interval = 2
     log_datefmt = '%M:%S'
-    external_certs = None
     log_level = 10
+
+    # MockHub additional traits
+    external_certs = Dict()
 
     def __init__(self, *args, **kwargs):
         if 'internal_certs_location' in kwargs:

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+from unittest import mock
 from urllib.parse import urlencode, urlparse
 
 from bs4 import BeautifulSoup
@@ -13,7 +14,6 @@ from ..utils import url_path_join as ujoin
 from .. import orm
 from ..auth import Authenticator
 
-import mock
 import pytest
 
 from .mocking import FormSpawner, public_url, public_host


### PR DESCRIPTION
Calling `HasTraits(attr=value)` is long-deprecated for non-trait attributes

1. remove one redundant assignment for a non-trait
2. make one attribute a trait