### PR TITLE
Allow callable options_form to return an empty form

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1209,7 +1209,7 @@ class UserSpawnHandler(BaseHandler):
                 status = 0
             # server is not running, trigger spawn
             if status is not None:
-                if spawner.options_form:
+                if await spawner.get_options_form():
                     url_parts = [self.hub.base_url, 'spawn']
                     if current_user.name != user.name:
                         # spawning on behalf of another user

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -74,11 +74,7 @@ class SpawnHandler(BaseHandler):
 
     Only enabled when Spawner.options_form is defined.
     """
-    async def _render_form(self, message='', for_user=None):
-        # Note that 'user' is the authenticated user making the request and
-        # 'for_user' is the user whose server is being spawned.
-        user = for_user or self.get_current_user()
-        spawner_options_form = await user.spawner.get_options_form()
+    def _render_form(self, for_user, spawner_options_form, message=''):
         return self.render_template('spawn.html',
             for_user=for_user,
             spawner_options_form=spawner_options_form,
@@ -107,10 +103,12 @@ class SpawnHandler(BaseHandler):
             self.log.debug("User is running: %s", url)
             self.redirect(url)
             return
-        if user.spawner.options_form:
+
+        spawner_options_form = await user.spawner.get_options_form()
+        if spawner_options_form:
             # Add handler to spawner here so you can access query params in form rendering.
             user.spawner.handler = self
-            form = await self._render_form(for_user=user)
+            form = self._render_form(for_user=user, spawner_options_form=spawner_options_form)
             self.finish(form)
         else:
             # Explicit spawn request: clear _spawn_future
@@ -154,7 +152,8 @@ class SpawnHandler(BaseHandler):
             await self.spawn_single_user(user, options=options)
         except Exception as e:
             self.log.error("Failed to spawn single-user server with form", exc_info=True)
-            form = await self._render_form(message=str(e), for_user=user)
+            spawner_options_form = await user.spawner.get_options_form()
+            form = self._render_form(for_user=user, spawner_options_form=spawner_options_form, message=str(e))
             self.finish(form)
             return
         if current_user is user:

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -167,6 +167,11 @@ class FormSpawner(MockSpawner):
             options['hello'] = form_data['hello_file'][0]
         return options
 
+class FalsyCallableFormSpawner(FormSpawner):
+    """A spawner that has a callable options form defined returning a falsy value"""
+
+    options_form = lambda a, b: ""
+
 
 class MockStructGroup:
     """Mock grp.struct_group"""

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -16,7 +16,7 @@ from ..auth import Authenticator
 
 import pytest
 
-from .mocking import FormSpawner
+from .mocking import FormSpawner, FalsyCallableFormSpawner
 from .utils import (
     async_requests,
     api_request,
@@ -205,6 +205,13 @@ async def test_spawn_page(app):
         r = await get_page('spawn?next=foo', app, cookies=cookies)
         assert r.url.endswith('/spawn?next=foo')
         assert FormSpawner.options_form in r.text
+
+
+async def test_spawn_page_falsy_callable(app):
+    with mock.patch.dict(app.users.settings, {'spawner_class': FalsyCallableFormSpawner}):
+        cookies = await app.login_user('erik')
+        r = await get_page('spawn', app, cookies=cookies)
+        assert 'user/erik' in r.url
 
 
 async def test_spawn_page_admin(app, admin_access):


### PR DESCRIPTION
This is meant to allow us dynamically decide to bypass the option form
even though `options_form` can be an async function that in itself always
evaluates truthy at the same time its returned value may be falsy.

closes #2390