### PR TITLE
Contributing: hint on pre-commiting commits that are already there

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,11 @@ and tell you about any errors it couldn't fix automatically.
 You may also install [black integration](https://github.com/ambv/black#editor-integration)
 into your text editor to format code automatically.
 
+If you have already committed files before setting up the pre-commit
+hook with `pre-commit install`, you can fix everything up using
+`pre-commit run --all-files`.  You need to make the fixing commit
+yourself after that.
+
 ## Testing
 
 It's a good idea to write tests to exercise any new features,


### PR DESCRIPTION
Hint based on my experience on using `pre-commit`.

When it did fix something, I had to `git add ` the changes and try the commit again.  I'm not sure if that was because I use `git add` first or just an artifact of my workflow.  Either way, seems like figuring that out is part of basics of git, so I didn't mention that.