### PR TITLE
persist user_options

### DIFF
--- a/ci/init-db.sh
+++ b/ci/init-db.sh
@@ -21,7 +21,7 @@ esac
 
 set -x
 
-for SUFFIX in '' _upgrade_072 _upgrade_081; do
+for SUFFIX in '' _upgrade_072 _upgrade_081 _upgrade_094; do
     $SQL "DROP DATABASE jupyterhub${SUFFIX};" 2>/dev/null || true
     $SQL "CREATE DATABASE jupyterhub${SUFFIX} ${EXTRA_CREATE};"
 done

--- a/jupyterhub/alembic/versions/4dc2d5a8c53c_user_options.py
+++ b/jupyterhub/alembic/versions/4dc2d5a8c53c_user_options.py
@@ -17,7 +17,9 @@ from jupyterhub.orm import JSONDict
 
 
 def upgrade():
-    op.add_column('spawners', sa.Column('user_options', JSONDict()))
+    tables = op.get_bind().engine.table_names()
+    if 'spawners' in tables:
+        op.add_column('spawners', sa.Column('user_options', JSONDict()))
 
 
 def downgrade():

--- a/jupyterhub/alembic/versions/4dc2d5a8c53c_user_options.py
+++ b/jupyterhub/alembic/versions/4dc2d5a8c53c_user_options.py
@@ -1,0 +1,24 @@
+"""persist user_options
+
+Revision ID: 4dc2d5a8c53c
+Revises: 896818069c98
+Create Date: 2019-02-28 14:14:27.423927
+
+"""
+# revision identifiers, used by Alembic.
+revision = '4dc2d5a8c53c'
+down_revision = '896818069c98'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from jupyterhub.orm import JSONDict
+
+
+def upgrade():
+    op.add_column('spawners', sa.Column('user_options', JSONDict()))
+
+
+def downgrade():
+    op.drop_column('spawners', sa.Column('user_options'))

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -216,6 +216,7 @@ class Spawner(Base):
 
     started = Column(DateTime)
     last_activity = Column(DateTime, nullable=True)
+    user_options = Column(JSONDict)
 
     # properties on the spawner wrapper
     # some APIs get these low-level objects

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -350,10 +350,24 @@ class Spawner(LoggingConfigurable):
         Override this function to understand single-values, numbers, etc.
 
         This should coerce form data into the structure expected by self.user_options,
-        which must be a dict.
+        which must be a dict, and should be JSON-serializeable,
+        though it can contain bytes in addition to standard JSON data types.
+
+        This method should not have any side effects.
+        Any handling of `user_options` should be done in `.start()`
+        to ensure consistent behavior across servers
+        spawned via the API and form submission page.
 
         Instances will receive this data on self.user_options, after passing through this function,
         prior to `Spawner.start`.
+
+        .. versionchanged:: 1.0
+            user_options are persisted in the JupyterHub database to be reused
+            on subsequent spawns if no options are given.
+            user_options is serialized to JSON as part of this persistence
+            (with additional support for bytes in case of uploaded file data),
+            and any non-bytes non-jsonable values will be replaced with None
+            if the user_options are re-used.
         """
         return form_data
 

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -35,7 +35,7 @@ def generate_old_db(env_dir, hub_version, db_url):
     check_call([env_py, populate_db, db_url])
 
 
-@pytest.mark.parametrize('hub_version', ['0.7.2', '0.8.1'])
+@pytest.mark.parametrize('hub_version', ['0.7.2', '0.8.1', '0.9.4'])
 async def test_upgrade(tmpdir, hub_version):
     db_url = os.getenv('JUPYTERHUB_TEST_DB_URL')
     if db_url:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -479,8 +479,17 @@ class User:
         # pass requesting handler to the spawner
         # e.g. for processing GET params
         spawner.handler = handler
+
         # Passing user_options to the spawner
-        spawner.user_options = options or {}
+        if options is None:
+            # options unspecified, load from db which should have the previous value
+            options = spawner.orm_spawner.user_options or {}
+        else:
+            # options specified, save for use as future defaults
+            spawner.orm_spawner.user_options = options
+            db.commit()
+
+        spawner.user_options = options
         # we are starting a new server, make sure it doesn't restore state
         spawner.clear_state()
 


### PR DESCRIPTION
remember user_options from the previous run

this allows user options set via spawn form (or previous api request) to be re-used when restarting e.g. a named server via the api