### PR TITLE
Allow for proper logging of IP addresses when using separate TLS termination

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -466,6 +466,18 @@ class JupyterHub(Application):
         """,
     ).tag(config=True)
 
+    trusted_downstream_ips = List(
+        Unicode(),
+        help="""Downstream proxy IP addresses to trust.
+
+        This sets the list of IP addresses that are trusted and skipped when processing
+        the `X-Forwarded-For` header. For example, if an external proxy is used for TLS
+        termination, its IP address should be added to this list to ensure the correct
+        client IP addresses are recorded in the logs instead of the proxy server's IP
+        address.
+        """,
+    ).tag(config=True)
+
     ip = Unicode(
         '',
         help="""The public facing ip of the whole JupyterHub application
@@ -2294,7 +2306,7 @@ class JupyterHub(Application):
             self.tornado_application,
             ssl_options=ssl_context,
             xheaders=True,
-            trusted_downstream=['127.0.0.1'],
+            trusted_downstream=self.trusted_downstream_ips,
         )
         bind_url = urlparse(self.hub.bind_url)
         try:

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2291,7 +2291,10 @@ class JupyterHub(Application):
 
         # start the webserver
         self.http_server = tornado.httpserver.HTTPServer(
-            self.tornado_application, ssl_options=ssl_context, xheaders=True
+            self.tornado_application,
+            ssl_options=ssl_context,
+            xheaders=True,
+            trusted_downstream=['127.0.0.1'],
         )
         bind_url = urlparse(self.hub.bind_url)
         try:


### PR DESCRIPTION
When using separate TLS termination, all IP addresses are currently logged as 127.0.0.1, since that's the last IP address in the `X-Forwarded-For` header (added by the Node HTTP proxy).

Trusting localhost (127.0.0.1) X-headers causes Tornado to use the next IP address in the header, the one added by the TLS termination proxy, as the `remote_ip`, resulting in the correct IP address being logged.

The potential risk to this approach is that local users could make local traffic look like it's coming from elsewhere, but I don't think this is a significant risk.