### PR TITLE
Fix server name parsing in UserUrlHandler

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1202,7 +1202,7 @@ class UserUrlHandler(BaseHandler):
             and self.current_user
             and user_name == self.current_user.name
         ):
-            server_name = user_path.split('/', 2)[1]
+            server_name = user_path.lstrip('/').split('/', 1)[0]
             if server_name not in self.current_user.orm_user.orm_spawners:
                 # no such server, assume default
                 server_name = ''
@@ -1292,7 +1292,7 @@ class UserUrlHandler(BaseHandler):
         server_name = ''
         if self.allow_named_servers:
             # check if url prefix matches an existing server name
-            server_name = user_path.split("/", 2)[1]
+            server_name = user_path.lstrip('/').split('/', 1)[0]
             if server_name not in user.orm_user.orm_spawners:
                 # not found, assume default server
                 server_name = ''

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1292,13 +1292,10 @@ class UserUrlHandler(BaseHandler):
         server_name = ''
         if self.allow_named_servers:
             # check if url prefix matches an existing server name
-            self.log.debug("user_path " + user_path)
             server_name = user_path.split("/", 2)[1]
-            self.log.debug("server_name " + server_name)
             if server_name not in user.orm_user.orm_spawners:
                 # not found, assume default server
                 server_name = ''
-            self.log.debug("server_name " + server_name)
         else:
             server_name = ''
         spawner = user.spawners[server_name]

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1202,7 +1202,7 @@ class UserUrlHandler(BaseHandler):
             and self.current_user
             and user_name == self.current_user.name
         ):
-            server_name = user_path.split('/', 1)[0]
+            server_name = user_path.split('/', 2)[1]
             if server_name not in self.current_user.orm_user.orm_spawners:
                 # no such server, assume default
                 server_name = ''
@@ -1293,7 +1293,7 @@ class UserUrlHandler(BaseHandler):
         if self.allow_named_servers:
             # check if url prefix matches an existing server name
             self.log.debug("user_path " + user_path)
-            server_name = user_path.split("/", 1)[0]
+            server_name = user_path.split("/", 2)[1]
             self.log.debug("server_name " + server_name)
             if server_name not in user.orm_user.orm_spawners:
                 # not found, assume default server

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1292,10 +1292,13 @@ class UserUrlHandler(BaseHandler):
         server_name = ''
         if self.allow_named_servers:
             # check if url prefix matches an existing server name
+            self.log.debug("user_path " + user_path)
             server_name = user_path.split("/", 1)[0]
+            self.log.debug("server_name " + server_name)
             if server_name not in user.orm_user.orm_spawners:
                 # not found, assume default server
                 server_name = ''
+            self.log.debug("server_name " + server_name)
         else:
             server_name = ''
         spawner = user.spawners[server_name]


### PR DESCRIPTION
Assuming named servers is enabled, the `user_path` when a user tries to go directly to a server seems to come in with a leading "/".  This was leading to the server name always ending up as "" which is the default.  I've changed the split to take this slash into account.

I've tested this gives the desired behavior (e.g. launch button page).  There might be a more right way to extract the server name from the `user_path` parameter. 