### PR TITLE
include retry link after failed spawn

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -290,6 +290,7 @@ class SpawnPendingHandler(BaseHandler):
                 server_name=server_name,
                 spawn_url=spawn_url,
                 failed=True,
+                failed_message=getattr(exc, 'jupyterhub_message', ''),
             )
             self.finish(html)
             return

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -291,6 +291,7 @@ class SpawnPendingHandler(BaseHandler):
                 spawn_url=spawn_url,
                 failed=True,
                 failed_message=getattr(exc, 'jupyterhub_message', ''),
+                exception=exc,
             )
             self.finish(html)
             return

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -281,13 +281,18 @@ class SpawnPendingHandler(BaseHandler):
             # Implicit spawn on /user/:name is not allowed if the user's last spawn failed.
             # We should point the user to Home if the most recent spawn failed.
             exc = spawner._spawn_future.exception()
-            self.log.error(
-                "Preventing implicit spawn for %s because last spawn failed: %s",
-                spawner._log_name,
-                exc,
+            self.log.error("Previous spawn for %s failed: %s", spawner._log_name, exc)
+            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name)
+            self.set_status(500)
+            html = self.render_template(
+                "not_running.html",
+                user=user,
+                server_name=server_name,
+                spawn_url=spawn_url,
+                failed=True,
             )
-            # raise a copy because each time an Exception object is re-raised, its traceback grows
-            raise copy.copy(exc).with_traceback(exc.__traceback__)
+            self.finish(html)
+            return
 
         # Check for pending events. This should usually be the case
         # when we are on this page.

--- a/share/jupyterhub/templates/not_running.html
+++ b/share/jupyterhub/templates/not_running.html
@@ -18,6 +18,9 @@
       <p>
         {% if failed %}
         The latest attempt to start your server {{ server_name }} has failed.
+        {% if failed_message %}
+          {{ failed_message }}
+        {% endif %}
         Would you like to retry starting it?
         {% else %}
         Your server {{ server_name }} is not running. Would you like to start it?

--- a/share/jupyterhub/templates/not_running.html
+++ b/share/jupyterhub/templates/not_running.html
@@ -5,12 +5,33 @@
 <div class="container">
   <div class="row">
     <div class="text-center">
+      {% block heading %}
+      <h1>
+      {% if failed %}
+      Spawn failed
+      {% else %}
+      Server not running
+      {% endif %}
+      </h1>
+      {% endblock %}
       {% block message %}
-      <p>Server {{ server_name }} is not running. Would you like to start it?</p>
+      <p>
+        {% if failed %}
+        The latest attempt to start your server {{ server_name }} has failed.
+        Would you like to retry starting it?
+        {% else %}
+        Your server {{ server_name }} is not running. Would you like to start it?
+        {% endif %}
+      </p>
       {% endblock %}
       {% block start_button %}
       <a id="start" role="button" class="btn btn-lg btn-primary" href="{{ spawn_url }}">
-      Launch Server {{ server_name }}
+        {% if failed %}
+        Relaunch
+        {% else %}
+        Launch
+        {% endif %}
+        Server {{ server_name }}
       </a>
       {% endblock %}
     </div>


### PR DESCRIPTION
implicit spawn check doesn't make sense anymore, since there are no implicit spawns

instead, render not_running page with error message and retry link:

<img width="580" alt="Screen Shot 2019-04-01 at 12 48 30" src="https://user-images.githubusercontent.com/151929/55322600-11ee8400-547d-11e9-82c3-1297e0727ed5.png">

closes #2492