### PR TITLE
ensure spawner for named servers is fully deleted

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -427,6 +427,7 @@ class UserServerAPIHandler(APIHandler):
                 return
             self.log.info("Deleting spawner %s", spawner._log_name)
             self.db.delete(spawner.orm_spawner)
+            user.spawners.pop(server_name, None)
             self.db.commit()
 
         if server_name:

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -162,8 +162,10 @@ async def test_delete_named_server(app, named_servers):
     )
     r.raise_for_status()
     assert r.status_code == 204
-    # low-level record is now removes
+    # low-level record is now removed
     assert servername not in user.orm_spawners
+    # and it's still not in the high-level wrapper dict
+    assert servername not in user.spawners
 
 
 async def test_named_server_disabled(app):


### PR DESCRIPTION
if spawner wasn't running, the wrapper could have been left in the user.spawners dict

closes #2507