### PR TITLE
fix flaky test_user_redirect

### DIFF
--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -393,7 +393,7 @@ async def test_user_redirect(app, username):
     path = urlparse(r.url).path
     while '/spawn-pending/' in path:
         await asyncio.sleep(0.1)
-        r = await get_page(r.url, app, cookies=cookies)
+        r = await async_requests.get(r.url, cookies=cookies)
         path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s/notebooks/test.ipynb' % name)
 

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -159,6 +159,10 @@ async def api_request(
 
 
 def get_page(path, app, hub=True, **kw):
+    if "://" in path:
+        raise ValueError(
+            "Not a hub page path: %r. Did you mean async_requests.get?" % path
+        )
     if hub:
         prefix = app.hub.base_url
     else:


### PR DESCRIPTION
when re-fetching the same url, use `requests.get`, not `get_page`

and add a check that would have caught this mistake more clearly