### PR TITLE
asyncio signal handling and loop cleanup by task cancelling

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2173,8 +2173,6 @@ class JupyterHub(Application):
             self.log.info("Cleaning up PID file %s", self.pid_file)
             os.remove(self.pid_file)
 
-        # finally stop the loop once we are all cleaned up
-        asyncio.get_event_loop().stop()
         self.log.info("...done")
 
     def write_config_file(self):
@@ -2415,7 +2413,7 @@ class JupyterHub(Application):
         self.init_signal()
 
     def init_signal(self):
-        loop = asyncio.get_event_loop()  # TODO: should use running loop
+        loop = asyncio.get_event_loop()
         for s in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(
                 s, lambda s=s: asyncio.ensure_future(self.shutdown_cancel_tasks(s))
@@ -2456,6 +2454,7 @@ class JupyterHub(Application):
             for t in tasks:
                 self.log.debug("Task status: %s", t)
         await self.cleanup()
+        asyncio.get_event_loop().stop()
 
     def stop(self):
         if not self.io_loop:


### PR DESCRIPTION
I deployed Jupyterhub with `wrapspawner/batchspawner` on our cluster and discovered that it consistently kept hanging during shutdown while executing the batch system commands for getting job-status and cancelling jobs using `Subprocess` from `tornado.process`.

This happens with

-   Jupyterhub-0.96 with batchSpawner-0.8.1 on python-3.6.7.final.0
-   current development versions from github (jupyterhub-1.0.0b1 batchspawner-0.9.0.dev0)
    on 3.6.7.final.0

Inspection showed that the problem was rooted in the way the current jupyterhub shuts down after using classic signal handling and creating a new event loop for the cleanup. The subprocesses (e.g. an "squeue" for getting the SLURM queue) would run fine in the original event loop, but after the creation of the new loop they hung. The Subprocess would be executed, but the parent jupyterhub process failed to correctly reap the child, resulting in an uncollected zombie process and jupyterhub being stuck. The singleuser sessions on the batch nodes were not cancelled.



Experiments

-   preventing the `atexit` function from creating a new event loop (using existing loop) resulted in clean shutdown.
-   interesting: including a short (non-async) `time.sleep` between the Suprocess initialization and the yield proc.wait<sub>for</sub><sub>exit</sub>() led to the correct reaping of the subprocess. This also worked if the sleep was induced by just defining by configuration variables.
    
        c.SlurmSpawner.batch_query_cmd = "squeue -h -j {job_id} -o '%T %B' && sleep 0.001"
        c.SlurmSpawner.batch_cancel_cmd = "scancel {job_id} && sleep 0.001"

I ended up suspecting that the current signal handling somehow interacted with the event loops. So I adapted the current code to use asyncio singal handling with add<sub>signal</sub><sub>handler</sub>. Before going into `cleanup()` I implemented cancelling of all remaining tasks. This resulted in consistently clean shutdowns.

The current Jupyterhub would exit with status 143 (128 + 15) on `SIGTERM`, but with status 0 on `SIGINT`. The code in this pull request has exit status 0 for both signals. This plays nicer with the standard way that systemd is stopping processes.

I added SIGUSR1 to invoke log<sub>status</sub> just as SIGINFO does, since on Linux SIGINFO is not available.

Test suite results: `test_connection_hub_wrong_certs` and `test_connection_notebook_wrong_certs` fail, but they also fail for the current master on my installation.
