### PR TITLE
Refactor Logout Handler

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -81,8 +81,6 @@ class LogoutHandler(BaseHandler):
         """Log the user out, call the custom action, forward the user
             to the logout page
         """
-        # TODO: when these can all be done concurrently, do all of them
-        #       concurrently?
         await self.default_handle_logout()
         await self.handle_logout()
         await self.render_logout_page()


### PR DESCRIPTION
AS A developer of a Logout handler
I WANT to be able to call a function to kill spawners and
do other backend logout stuff and a separate function to
forward the user along the logout chain.

I believe this PR adds (moderately private) methods to the
Logout Handler to do just that.

