### PR TITLE
[autodoc] move config sample to annotation

### DIFF
--- a/docs/sphinxext/autodoc_traits.py
+++ b/docs/sphinxext/autodoc_traits.py
@@ -38,17 +38,18 @@ class TraitDocumenter(AttributeDocumenter):
     def can_document_member(cls, member, membername, isattr, parent):
         return isinstance(member, TraitType)
 
-    def format_name(self):
-        return 'config c.' + super().format_name()
-
     def add_directive_header(self, sig):
         default = self.object.get_default_value()
         if default is Undefined:
             default_s = ''
         else:
             default_s = repr(default)
-        sig = ' = {}({})'.format(self.object.__class__.__name__, default_s)
-        return super().add_directive_header(sig)
+        self.options.annotation = 'c.{name} = {trait}({default})'.format(
+            name=self.format_name(),
+            trait=self.object.__class__.__name__,
+            default=default_s,
+        )
+        super().add_directive_header(sig)
 
 
 def setup(app):


### PR DESCRIPTION
preserves link targets, which mangling the directive header does not