### PR TITLE
Adding the use case of the Elucidata: How Jupyter Notebook is used in…

### DIFF
--- a/docs/source/gallery-jhub-deployments.md
+++ b/docs/source/gallery-jhub-deployments.md
@@ -142,7 +142,10 @@ easy to do with RStudio too.
 - Kristen Thyng - Oceanography
     - [Teaching with JupyterHub and nbgrader](http://kristenthyng.com/blog/2016/09/07/jupyterhub+nbgrader/)
 
-
+### Elucidata
+  - What's new in Jupyter Notebooks @[Elucidata](https://elucidata.io/):
+      - Using Jupyter Notebooks with Jupyterhub on GCP, managed by GKE
+            - https://medium.com/elucidata/why-you-should-be-using-a-jupyter-notebook-8385a4ccd93d
 
 ## Service Providers
 


### PR DESCRIPTION
Hi.
I have added the use case of the Jupyter Notebook deployment so that it can also be featured on the Gallery Page of Jupyterhub

Jupyter Notebooks are used heavily and quite frequent in Elucidata and in the Jupyterhub is playing a very crucial role. So as a developer in Elucidata, I am raising this PR, so that my company can also be featured on the Gallery Page