### PR TITLE
Add Spawner.auth_state_hook

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -68,7 +68,7 @@ class HomeHandler(BaseHandler):
             url = url_path_join(self.hub.base_url, 'spawn', user.escaped_name)
 
         auth_state = await user.get_auth_state()
-        user.spawner.handle_auth_state(auth_state)
+        user.spawner.run_auth_state_hook(auth_state)
 
         html = self.render_template(
             'home.html',

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -67,6 +67,9 @@ class HomeHandler(BaseHandler):
         else:
             url = url_path_join(self.hub.base_url, 'spawn', user.escaped_name)
 
+        auth_state = await user.get_auth_state()
+        user.spawner.handle_auth_state(auth_state)
+
         html = self.render_template(
             'home.html',
             user=user,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -628,6 +628,10 @@ class Spawner(LoggingConfigurable):
         """
     ).tag(config=True)
 
+    def handle_auth_state(self, auth_state):
+        """Pass optional auth_state to Spawner."""
+        pass
+
     def load_state(self, state):
         """Restore state of spawner from database.
 


### PR DESCRIPTION
Here's an example of what I'm thinking of as a solution for #2552.  Another idea I had was a custom handler, but in #1854 it was agreed not to override existing handlers.  Is there a better way to accomplish this, or, is there a reason it would be bad to directly pass this info to a spawner?