### PR TITLE
Make announcements visible without custom HTML

### DIFF
--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -148,7 +148,7 @@
 
 {% block announcement %}
 {% if announcement %}
-<div class="container text-center announcement">
+<div class="container text-center announcement alert alert-warning">
   {{ announcement | safe }}
 </div>
 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/jupyterhub/issues/2566 to some
degree by making the announcement stand out using twitter-bootstrap
classes `alert` and `alert-warning`. Perhaps we could theme twitter
bootstrap or this alert specifically with jupyter related colors as well
though?

See the issue for details on how the fix looks visually.