### PR TITLE
Hide Stop My Server red button after server stopped.

### DIFF
--- a/share/jupyterhub/static/js/home.js
+++ b/share/jupyterhub/static/js/home.js
@@ -90,6 +90,7 @@ require(["jquery", "moment", "jhapi", "utils"], function(
       });
     api.stop_server(user, {
       success: function() {
+        $("#stop").hide();
         $("#start")
           .text("Start My Server")
           .attr("title", "Start your default server")


### PR DESCRIPTION
Patch the issue #2575, hide stop sever button after server stopped for better ui response.