### PR TITLE
Define default values for HubAuth ssl traitlets

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -216,7 +216,7 @@ class HubAuth(SingletonConfigurable):
         return self.hub_host + url_path_join(self.hub_prefix, 'login')
 
     keyfile = Unicode(
-        '',
+        os.getenv('JUPYTERHUB_SSL_KEYFILE', ''),
         help="""The ssl key to use for requests
 
         Use with certfile
@@ -224,7 +224,7 @@ class HubAuth(SingletonConfigurable):
     ).tag(config=True)
 
     certfile = Unicode(
-        '',
+        os.getenv('JUPYTERHUB_SSL_CERTFILE', ''),
         help="""The ssl cert to use for requests
 
         Use with keyfile
@@ -232,7 +232,7 @@ class HubAuth(SingletonConfigurable):
     ).tag(config=True)
 
     client_ca = Unicode(
-        '',
+        os.getenv('JUPYTERHUB_SSL_CLIENT_CA', ''),
         help="""The ssl certificate authority to use to verify requests
 
         Use with keyfile and certfile


### PR DESCRIPTION
The default values are taken from environment variables defined by `Spawner.get_env`.

## Use-case

I am using `HubAuth` with batchspawner to send the singleuser port number back to the Hub before launching singleuser server. After activating internal_ssl, the HubAuth stopped working because I was not initializing `client_ca`, `certfile` and `keyfile`. I presumed HubAuth would read the JupyterHub SSL environment variables like singleuser does, but it did not. So I added, the initialization by reading the environment variable myself, but it would be nicer if HubAuth was in charge.

The example usage of HubAuth with batchspawner is available here:
https://github.com/cmd-ntrf/batchspawner/blob/singleuser_fix/batchspawner/singleuser.py