### PR TITLE
[WIP] Add support for Jupyter Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
     fi
   - |
     if [[ "$TEST" == "jupyter_server" ]]; then
-      pip uninstall notebook
+      pip uninstall notebook --yes
       pip install jupyter_server
       pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
       # Make sure that the notebook package is still not installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,10 @@ script:
     if [[ "$TEST" == "jupyter_server" ]]; then
       pip uninstall notebook
       pip install jupyter_server
-      export USE_JUPYTER_SERVER=True
       pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
+      # Make sure that the notebook package is still not installed
+      pip list | grep notebook
+      test $? -eq 1
     fi
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,13 @@ script:
       make html
       popd
     fi
+  - |
+    if [[ "$TEST" == "jupyter_server" ]]; then
+      pip uninstall notebook
+      pip install jupyter_server
+      export USE_JUPYTER_SERVER=True
+      pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
+    fi
 after_success:
   - codecov
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,8 @@ matrix:
     - python: 3.6
       env: TEST=lint
     - python: 3.6
+      env: TEST=jupyter_server
+    - python: 3.6
       env: TEST=docs
     - python: 3.6
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,8 @@ script:
     if [[ "$TEST" == "jupyter_server" ]]; then
       pip uninstall notebook --yes
       pip install jupyter_server
-      pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
+      # Run all tests regardless of failure, so we know what's up
+      pytest -v --cov=jupyterhub jupyterhub/tests
       # Make sure that the notebook package is still not installed
       pip list | grep notebook
       test $? -eq 1

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -931,7 +931,7 @@ class Spawner(LoggingConfigurable):
             args.append('--notebook-dir=%s' % _quote_safe(notebook_dir))
         if self.default_url:
             default_url = self.format_string(self.default_url)
-            args.append('--NotebookApp.default_url=%s' % _quote_safe(default_url))
+            args.append('--SingleUserNotebookApp.default_url=%s' % _quote_safe(default_url))
 
         if self.debug:
             args.append('--debug')


### PR DESCRIPTION
Use case:

1. We want to run something like https://github.com/QuantStack/voila or similar on JupyterHub
2. We *don't* want the Notebook API to be available, for security (and other) reasons

This applies to any server extension we might wanna run without running the Jupyter Notebook API itself.

## Current State

This adds jupyter_server support to jupyterhub-singleuser. It'll just use the notebook package if available, falling back to jupyter_server if not. I don't like this - it should probably be configurable somewhere.

Most of this is done with dynamic importing of libraries, since the code for Jupyter Notebook and Jupyter Server is pretty much the same in all the ways the singleuser server deals with it.

## TODO

1. Activity tracking?
2. Does user configuration disabling work with ServerApp?

## Alternative approaches considered

- Put this code in the jupyter_server package instead. There is practically 100% code sharing between what NotebookApp needs and what ServerApp needs, and magically patching jupyterhub-singleuser doesn't seem ideal. 
- Use voila and others purely as notebook serverextensions. You can already do this, but this is insecure - end users can easily call the notebook API directly to execute code.
- Put this code in voila. Putting it in jupyter_server makes it more generally useful to all the apps that can use it. There's a Jupyter Enhancement Proposal for Jupyter Server (https://github.com/jupyter/enhancement-proposals/blob/master/jupyter-server/jupyter-server.md), and @Zsailer / @SylvainCorlay  are working on it.
- Split the SingleUserNotebookApp class into two levels. Put everything common to both in base class, and subclass / customize in other forms. This is promising, and something I'll explore.