### PR TITLE
Replace existing redirect code by Tornado's addslash decorator

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -26,6 +26,7 @@ from tornado.httputil import HTTPHeaders
 from tornado.httputil import url_concat
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
+from tornado.web import addslash
 from tornado.web import MissingArgumentError
 from tornado.web import RequestHandler
 
@@ -1450,10 +1451,9 @@ class CSPReportHandler(BaseHandler):
 class AddSlashHandler(BaseHandler):
     """Handler for adding trailing slash to URLs that need them"""
 
-    def get(self, *args):
-        src = urlparse(self.request.uri)
-        dest = src._replace(path=src.path + '/')
-        self.redirect(urlunparse(dest))
+    @addslash
+    def get(self):
+        pass
 
 
 default_handlers = [


### PR DESCRIPTION
Recently our application (which uses JupyterHub but runs another application instead of `SingleUserNotebookApp`) needed to add slashes to URL's.

First tried to re-use the `AddSlashHandler` from JupyterHub, until a co-worker pointed me that Tornado provided it already. It appears to do similar work as the code in JupyterHub, but since Tornado is already a dependency of the project, I thought it would make sense to re-use their code.

Did some [manual testing](https://gist.github.com/kinow/cda18f38d66fd8fe48316782e2cb0be3) with a small application, and also tested by creating a virtual environment and installing the code from the branch, and testing with/without the change. The app seemed to behave the same before/after this change.

Cheers
Bruno