### PR TITLE
Fix running_servers prometheus metric

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -79,6 +79,7 @@ from .utils import (
     print_ps_info,
     make_ssl_context,
 )
+from .metrics import RUNNING_SERVERS
 
 # classes for config
 from .auth import Authenticator, PAMAuthenticator
@@ -1936,6 +1937,9 @@ class JupyterHub(Application):
         if self.log_level <= logging.DEBUG:
             user_summaries = map(_user_summary, self.users.values())
             self.log.debug("Loaded users:\n%s", '\n'.join(user_summaries))
+
+        active_counts = self.users.count_active_users()
+        RUNNING_SERVERS.set(active_counts['active'])
 
     def init_oauth(self):
         base_url = self.hub.base_url

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -39,9 +39,7 @@ RUNNING_SERVERS = Gauge(
     'running_servers', 'the number of user servers currently running'
 )
 
-RUNNING_SERVERS.set(0)
-
-TOTAL_USERS = Gauge('total_users', 'toal number of users')
+TOTAL_USERS = Gauge('total_users', 'total number of users')
 
 TOTAL_USERS.set(0)
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -21,6 +21,7 @@ from .crypto import decrypt
 from .crypto import encrypt
 from .crypto import EncryptionUnavailable
 from .crypto import InvalidToken
+from .metrics import RUNNING_SERVERS
 from .metrics import TOTAL_USERS
 from .objects import Server
 from .spawner import LocalProcessSpawner
@@ -753,6 +754,7 @@ class User:
                     self.db.delete(oauth_client)
             self.db.commit()
             self.log.debug("Finished stopping %s", spawner._log_name)
+            RUNNING_SERVERS.dec()
         finally:
             spawner.orm_spawner.started = None
             self.db.commit()


### PR DESCRIPTION
*RUNNING_SERVERS* is now
* initialized with the number of active servers
* decremented when a user's server is stopped
* incremented after the user's server has been successfully added to the proxy

Closes https://github.com/jupyterhub/jupyterhub/issues/2618