### PR TITLE
Fixed docs and testing code to use refactored SimpleLocalProcessSpawner

### DIFF
--- a/docs/source/contributing/setup.rst
+++ b/docs/source/contributing/setup.rst
@@ -112,13 +112,12 @@ happen.
 
 Happy developing!
 
-Using DummyAuthenticator & SimpleSpawner
-========================================
+Using DummyAuthenticator & SimpleLocalProcessSpawner
+====================================================
 
 To simplify testing of JupyterHub, it’s helpful to use
 :class:`~jupyterhub.auth.DummyAuthenticator` instead of the default JupyterHub
-authenticator and `SimpleSpawner <https://github.com/jupyterhub/simplespawner>`_ 
-instead of the default spawner.
+authenticator and SimpleLocalProcessSpawner instead of the default spawner.
 
 There is a sample configuration file that does this in
 ``testing/jupyterhub_config.py``. To launch jupyterhub with this
@@ -126,7 +125,6 @@ configuration:
 
 .. code:: bash
 
-   pip install jupyterhub-simplespawner
    jupyterhub -f testing/jupyterhub_config.py
 
 The default JupyterHub `authenticator
@@ -137,15 +135,15 @@ require your system to have user accounts for each user you want to log in to
 JupyterHub as.
 
 DummyAuthenticator allows you to log in with any username & password,
-while SimpleSpawner allows you to start servers without having to
+while SimpleLocalProcessSpawner allows you to start servers without having to
 create a unix user for each JupyterHub user. Together, these make it
 much easier to test JupyterHub.
 
 Tip: If you are working on parts of JupyterHub that are common to all
 authenticators & spawners, we recommend using both DummyAuthenticator &
-SimpleSpawner. If you are working on just authenticator related parts,
-use only SimpleSpawner. Similarly, if you are working on just spawner
-related parts, use only DummyAuthenticator.
+SimpleLocalProcessSpawner. If you are working on just authenticator related
+parts, use only SimpleLocalProcessSpawner. Similarly, if you are working on
+just spawner related parts, use only DummyAuthenticator.
 
 Troubleshooting
 ===============

--- a/testing/jupyterhub_config.py
+++ b/testing/jupyterhub_config.py
@@ -13,6 +13,6 @@ c.JupyterHub.authenticator_class = DummyAuthenticator
 # Optionally set a global password that all users must use
 # c.DummyAuthenticator.password = "your_password"
 
-from jupyterhub.spawners import SimpleSpawner
+from jupyterhub.spawner import SimpleLocalProcessSpawner
 
-c.JupyterHub.spawner_class = SimpleSpawner
+c.JupyterHub.spawner_class = SimpleLocalProcessSpawner


### PR DESCRIPTION
The docs at [Setting up a development install](https://jupyterhub.readthedocs.io/en/stable/contributing/setup.html) suggest installing the separate jupyterhub-simplespawner package for easy testing, but this now appears to have been refactored into the main jupyterhub repo (and the SimpleSpawner class also renamed to SimpleLocalProcessSpawner).

This PR fixes the documentation and also the sample testing/jupyterhub_config.py file so that it refers to the correct class.