### PR TITLE
corrected docker network create instructions in dockerfiles README

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -12,7 +12,7 @@ Dockerfile.alpine  contains base image for jupyterhub. It does not work independ
 
 * start configurable-http-proxy in another container
 * specify CONFIGPROXY_AUTH_TOKEN env in both containers
-* put both containers on the same network (e.g. docker create network jupyterhub; docker run ... --net jupyterhub)
+* put both containers on the same network (e.g. docker network create jupyterhub; docker run ... --net jupyterhub)
 * tell jupyterhub where CHP is (e.g. c.ConfigurableHTTPProxy.api_url = 'http://chp:8001')
 * tell jupyterhub not to start the proxy itself (c.ConfigurableHTTPProxy.should_start = False)
 * Use dummy authenticator for ease of testing. Update following in jupyterhub_config file


### PR DESCRIPTION
Hi jupyterhub folks!

While browsing documentation, I noticed that dockerfiles/README.md includes an incorrect step for testing:
put both containers on the same network (e.g. docker create network jupyterhub; docker run ... --net jupyterhub)

... should be 'docker network create' rather than 'docker create network'. Cutting and pasting the incorrect version leads to an unhelpful error message, so I thought this correction might be helpful to relative newbies to Docker like myself.

I think this follows your contribution guidelines since it isn't part of your official documentation but rather a file that resides on github, but happy to resubmit if there's another preferred way I should do that.

Thanks for your time!