### PR TITLE
Fix total_users prometheus metric

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -80,6 +80,7 @@ from .utils import (
     make_ssl_context,
 )
 from .metrics import RUNNING_SERVERS
+from .metrics import TOTAL_USERS
 
 # classes for config
 from .auth import Authenticator, PAMAuthenticator
@@ -1940,6 +1941,7 @@ class JupyterHub(Application):
 
         active_counts = self.users.count_active_users()
         RUNNING_SERVERS.set(active_counts['active'])
+        TOTAL_USERS.set(len(self.users))
 
     def init_oauth(self):
         base_url = self.hub.base_url

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -41,8 +41,6 @@ RUNNING_SERVERS = Gauge(
 
 TOTAL_USERS = Gauge('total_users', 'total number of users')
 
-TOTAL_USERS.set(0)
-
 CHECK_ROUTES_DURATION_SECONDS = Histogram(
     'check_routes_duration_seconds', 'Time taken to validate all routes in proxy'
 )


### PR DESCRIPTION
We might get more accurate results if we initialize *total_users* metric at startup with the number of users stored in the db. 