### PR TITLE
Update links for Hadoop-related subprojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ To start the Hub on a specific url and port ``10.0.1.2:443`` with **https**:
 
 ### Authenticators
 
-| Authenticator                                                               | Description                                       |
-| --------------------------------------------------------------------------- | ------------------------------------------------- |
-| PAMAuthenticator                                                            | Default, built-in authenticator                   |
-| [OAuthenticator](https://github.com/jupyterhub/oauthenticator)              | OAuth + JupyterHub Authenticator = OAuthenticator |
-| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)        | Simple LDAP Authenticator Plugin for JupyterHub   |
-| [kerberosauthenticator](https://github.com/jcrist/kerberosauthenticator)    | Kerberos Authenticator Plugin for JupyterHub      |
+| Authenticator                                                                | Description                                       |
+| ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| PAMAuthenticator                                                             | Default, built-in authenticator                   |
+| [OAuthenticator](https://github.com/jupyterhub/oauthenticator)               | OAuth + JupyterHub Authenticator = OAuthenticator |
+| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)         | Simple LDAP Authenticator Plugin for JupyterHub   |
+| [kerberosauthenticator](https://github.com/jupyterhub/kerberosauthenticator) | Kerberos Authenticator Plugin for JupyterHub      |
 
 ### Spawners
 
@@ -162,7 +162,7 @@ To start the Hub on a specific url and port ``10.0.1.2:443`` with **https**:
 | [sudospawner](https://github.com/jupyterhub/sudospawner)       | Spawn single-user servers without being root                               |
 | [systemdspawner](https://github.com/jupyterhub/systemdspawner) | Spawn single-user notebook servers using systemd                           |
 | [batchspawner](https://github.com/jupyterhub/batchspawner)     | Designed for clusters using batch scheduling software                      |
-| [yarnspawner](https://github.com/jcrist/yarnspawner)           | Spawn single-user notebook servers distributed on a Hadoop cluster         |
+| [yarnspawner](https://github.com/jupyterhub/yarnspawner)       | Spawn single-user notebook servers distributed on a Hadoop cluster         |
 | [wrapspawner](https://github.com/jupyterhub/wrapspawner)       | WrapSpawner and ProfilesSpawner enabling runtime configuration of spawners |
 
 ## Docker

--- a/docs/source/gallery-jhub-deployments.md
+++ b/docs/source/gallery-jhub-deployments.md
@@ -173,7 +173,7 @@ easy to do with RStudio too.
 
 ### Hadoop
 
-- [Deploying JupyterHub on Hadoop](https://jcrist.github.io/jupyterhub-on-hadoop/)
+- [Deploying JupyterHub on Hadoop](https://jupyterhub-on-hadoop.readthedocs.io)
 
 
 ## Miscellaneous

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -25,7 +25,7 @@ Some examples include:
   run without being root, by spawning an intermediate process via `sudo`
 - [BatchSpawner](https://github.com/jupyterhub/batchspawner) for spawning remote
   servers using batch systems
-- [YarnSpawner](https://github.com/jcrist/yarnspawner) for spawning notebook
+- [YarnSpawner](https://github.com/jupyterhub/yarnspawner) for spawning notebook
   servers in YARN containers on a Hadoop cluster
 - [RemoteSpawner](https://github.com/zonca/remotespawner) to spawn notebooks
   and a remote server and tunnel the port via SSH


### PR DESCRIPTION
These projects recently moved under the JupyterHub organization, updated the links accordingly.