### PR TITLE
fix: spawn redirect for users whose names need escaping

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1357,7 +1357,9 @@ class UserUrlHandler(BaseHandler):
             return
 
         pending_url = url_concat(
-            url_path_join(self.hub.base_url, 'spawn-pending', user.escaped_name, server_name),
+            url_path_join(
+                self.hub.base_url, 'spawn-pending', user.escaped_name, server_name
+            ),
             {'next': self.request.uri},
         )
         if spawner.pending or spawner._failed:
@@ -1459,7 +1461,8 @@ class UserRedirectHandler(BaseHandler):
             user_url = url_concat(user_url, parse_qsl(self.request.query))
 
         url = url_concat(
-            url_path_join(self.hub.base_url, "spawn", user.escaped_name), {"next": user_url}
+            url_path_join(self.hub.base_url, "spawn", user.escaped_name),
+            {"next": user_url},
         )
 
         self.redirect(url)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1357,7 +1357,7 @@ class UserUrlHandler(BaseHandler):
             return
 
         pending_url = url_concat(
-            url_path_join(self.hub.base_url, 'spawn-pending', user.name, server_name),
+            url_path_join(self.hub.base_url, 'spawn-pending', user.escaped_name, server_name),
             {'next': self.request.uri},
         )
         if spawner.pending or spawner._failed:
@@ -1371,7 +1371,7 @@ class UserUrlHandler(BaseHandler):
         # without explicit user action
         self.set_status(503)
         spawn_url = url_concat(
-            url_path_join(self.hub.base_url, "spawn", user.name, server_name),
+            url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
             {"next": self.request.uri},
         )
         html = self.render_template(
@@ -1459,7 +1459,7 @@ class UserRedirectHandler(BaseHandler):
             user_url = url_concat(user_url, parse_qsl(self.request.query))
 
         url = url_concat(
-            url_path_join(self.hub.base_url, "spawn", user.name), {"next": user_url}
+            url_path_join(self.hub.base_url, "spawn", user.escaped_name), {"next": user_url}
         )
 
         self.redirect(url)

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -61,9 +61,9 @@ class HomeHandler(BaseHandler):
         # to establish that this is an explicit spawn request rather
         # than an implicit one, which can be caused by any link to `/user/:name(/:server_name)`
         if user.active:
-            url = url_path_join(self.base_url, 'user', user.name)
+            url = url_path_join(self.base_url, 'user', user.escaped_name)
         else:
-            url = url_path_join(self.hub.base_url, 'spawn', user.name)
+            url = url_path_join(self.hub.base_url, 'spawn', user.escaped_name)
 
         html = self.render_template(
             'home.html',
@@ -132,7 +132,7 @@ class SpawnHandler(BaseHandler):
         # which may get handled by the default server if they aren't ready yet
 
         pending_url = url_path_join(
-            self.hub.base_url, "spawn-pending", user.name, server_name
+            self.hub.base_url, "spawn-pending", user.escaped_name, server_name
         )
 
         if self.get_argument('next', None):

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -219,7 +219,7 @@ class SpawnHandler(BaseHandler):
         next_url = self.get_next_url(
             user,
             default=url_path_join(
-                self.hub.base_url, "spawn-pending", user.name, server_name
+                self.hub.base_url, "spawn-pending", user.escaped_name, server_name
             ),
         )
         self.redirect(next_url)


### PR DESCRIPTION
The 302 redirect served after the spawn POST was not escaping the username, causing issues with a backslash.

