### PR TITLE
[Discussion] Add options to validate HTML before sending to the page.

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1073,7 +1073,13 @@ class BaseHandler(RequestHandler):
         template_ns.update(self.template_namespace)
         template_ns.update(ns)
         template = self.get_template(name)
-        return template.render(**template_ns)
+        rendered = template.render(**template_ns)
+
+        if self.settings['validate_html']:
+            from AdvancedHTMLParser import ValidatingAdvancedHTMLParser
+            ValidatingAdvancedHTMLParser().parseStr(rendered)
+        return rendered
+
 
     @property
     def template_namespace(self):


### PR DESCRIPTION
While obviously this is a lot of extra work; This is mostly to get the
conversation started; and think as whether this should be set for – for
example – testing.

That would allow to catch earlier miss-matched tags; or issues in
templates.

I'm not quite sure AdvancedHTMLParser is the best for that; but I
haven't found a better library.

