### PR TITLE
Update flask hub authentication services example in doc

### DIFF
--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -249,7 +249,7 @@ prefix = os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '/')
 
 auth = HubAuth(
     api_token=os.environ['JUPYTERHUB_API_TOKEN'],
-    cookie_cache_max_age=60,
+    cache_max_age=60,
 )
 
 app = Flask(__name__)


### PR DESCRIPTION
The flask example in the documentation was still using the input argument `cookie_cache_max_age` when instantiating `HubAuth` object. `cookie_cache_max_age` is deprecated sinceJupyterHub 0.8 and should be replaced by `cache_max_age`.

