### PR TITLE
Update spawn-form example

### DIFF
--- a/examples/spawn-form/jupyterhub_config.py
+++ b/examples/spawn-form/jupyterhub_config.py
@@ -10,10 +10,15 @@ class DemoFormSpawner(LocalProcessSpawner):
     def _options_form_default(self):
         default_env = "YOURNAME=%s\n" % self.user.name
         return """
-        <label for="args">Extra notebook CLI arguments</label>
-        <input name="args" placeholder="e.g. --debug"></input>
-        <label for="env">Environment variables (one per line)</label>
-        <textarea name="env">{env}</textarea>
+        <div class="form-group">
+            <label for="args">Extra notebook CLI arguments</label>
+            <input name="args" class="form-control"
+                placeholder="e.g. --debug"></input>
+        </div>
+        <div class="form-group">
+            <label for="env">Environment variables (one per line)</label>
+            <textarea class="form-control" name="env">{env}</textarea>
+        </div>
         """.format(
             env=default_env
         )


### PR DESCRIPTION
Hi,

The current example does not match the screen shot. I think it was due a Bootstrap update. I used the first example from [Bootstrap Forms component](https://getbootstrap.com/docs/4.3/components/forms/) to update the example.

Before:

![image](https://user-images.githubusercontent.com/304786/61921666-fcfcaa00-afb1-11e9-941f-f93a26d2dd9f.png)

After:

![image](https://user-images.githubusercontent.com/304786/61921620-d2125600-afb1-11e9-9a8a-270ee579d2a1.png)

Thanks
Bruno
