### PR TITLE
/hub/admin redirect to login

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -349,6 +349,7 @@ class SpawnPendingHandler(BaseHandler):
 class AdminHandler(BaseHandler):
     """Render the admin page."""
 
+    @web.authenticated
     @admin_only
     def get(self):
         available = {'name', 'admin', 'running', 'last_activity'}

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -92,8 +92,9 @@ async def test_home_auth(app):
 
 
 async def test_admin_no_auth(app):
-    r = await get_page('admin', app)
-    assert r.status_code == 403
+    r = await get_page('admin', app, allow_redirects=False)
+    assert r.status_code == 302
+    assert '/hub/login' in r.headers['Location']
 
 
 async def test_admin_not_admin(app):


### PR DESCRIPTION
This should close https://github.com/jupyterhub/jupyterhub/issues/2667.
 */hub/admin* without login redirects to the login page and throws a 403 if the user is not an admin.