### PR TITLE
Add jupyterhub logo over Server options

### DIFF
--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -8,6 +8,7 @@
 <div class="container">
   {% block heading %}
   <div class="row text-center">
+    <img src="/hub/static/images/jupyterhub-80.png" />
     <h1>Server Options</h1>
   </div>
   {% endblock %}


### PR DESCRIPTION
Do we want a logo like this to show on top of the "Server options" header? I added it within my deployment as it was a helpful distinction I think between the user pod and the JupyterHub domain.

This PR is related to #2672.

## This PR
It adds the big JupyterHub logo to the template that is shown to users arriving to the server options menu pre-spawn.
![image](https://user-images.githubusercontent.com/3837114/62463488-70f53a00-b78a-11e9-94c6-04ce02f3d235.png)
