### PR TITLE
Replace header logo: jupyter -> jupyterhub

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -592,7 +592,9 @@ class JupyterHub(Application):
 
     @default('logo_file')
     def _logo_file_default(self):
-        return os.path.join(self.data_files_path, 'static', 'images', 'jupyterhub-80.png')
+        return os.path.join(
+            self.data_files_path, 'static', 'images', 'jupyterhub-80.png'
+        )
 
     jinja_environment_options = Dict(
         help="Supply extra arguments that will be passed to Jinja environment."

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -592,7 +592,7 @@ class JupyterHub(Application):
 
     @default('logo_file')
     def _logo_file_default(self):
-        return os.path.join(self.data_files_path, 'static', 'images', 'jupyter.png')
+        return os.path.join(self.data_files_path, 'static', 'images', 'jupyterhub-80.png')
 
     jinja_environment_options = Dict(
         help="Supply extra arguments that will be passed to Jinja environment."

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -611,7 +611,7 @@ async def test_static_files(app):
     r = await async_requests.get(ujoin(base_url, 'logo'))
     r.raise_for_status()
     assert r.headers['content-type'] == 'image/png'
-    r = await async_requests.get(ujoin(base_url, 'static', 'images', 'jupyter.png'))
+    r = await async_requests.get(ujoin(base_url, 'static', 'images', 'jupyterhub-80.png'))
     r.raise_for_status()
     assert r.headers['content-type'] == 'image/png'
     r = await async_requests.get(ujoin(base_url, 'static', 'css', 'style.min.css'))

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -611,7 +611,9 @@ async def test_static_files(app):
     r = await async_requests.get(ujoin(base_url, 'logo'))
     r.raise_for_status()
     assert r.headers['content-type'] == 'image/png'
-    r = await async_requests.get(ujoin(base_url, 'static', 'images', 'jupyterhub-80.png'))
+    r = await async_requests.get(
+        ujoin(base_url, 'static', 'images', 'jupyterhub-80.png')
+    )
     r.raise_for_status()
     assert r.headers['content-type'] == 'image/png'
     r = await async_requests.get(ujoin(base_url, 'static', 'css', 'style.min.css'))


### PR DESCRIPTION
I like the header to reflect that we are in the JupyterHub domain rather than Jupyter generic domain or for example the JupyterLab domain. This is somewhat related to #2671 that adds a JupyterHub logo to the spawning page options.

I think if we merge something like this PR, it would reduce the need for #2671.

## Current
![image](https://user-images.githubusercontent.com/3837114/62462929-fb3c9e80-b788-11e9-9c1d-6320d45a587f.png)

## This PR
![image](https://user-images.githubusercontent.com/3837114/62462974-14454f80-b789-11e9-9688-3432c733a531.png)

Perhaps @jupyterhub/designers got input on this?