### PR TITLE
Add `server_name` to `spawn_url`

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -283,8 +283,9 @@ class SpawnPendingHandler(BaseHandler):
             # We should point the user to Home if the most recent spawn failed.
             exc = spawner._spawn_future.exception()
             self.log.error("Previous spawn for %s failed: %s", spawner._log_name, exc)
-            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name,
-                    server_name)
+            spawn_url = url_path_join(
+                self.hub.base_url, "spawn", user.escaped_name, server_name
+            )
             self.set_status(500)
             html = self.render_template(
                 "not_running.html",
@@ -329,8 +330,9 @@ class SpawnPendingHandler(BaseHandler):
         # further, set status to 404 because this is not
         # serving the expected page
         if status is not None:
-            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name,
-                    server_name)
+            spawn_url = url_path_join(
+                self.hub.base_url, "spawn", user.escaped_name, server_name
+            )
             html = self.render_template(
                 "not_running.html",
                 user=user,

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -283,7 +283,8 @@ class SpawnPendingHandler(BaseHandler):
             # We should point the user to Home if the most recent spawn failed.
             exc = spawner._spawn_future.exception()
             self.log.error("Previous spawn for %s failed: %s", spawner._log_name, exc)
-            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name)
+            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name,
+                    server_name)
             self.set_status(500)
             html = self.render_template(
                 "not_running.html",
@@ -328,7 +329,8 @@ class SpawnPendingHandler(BaseHandler):
         # further, set status to 404 because this is not
         # serving the expected page
         if status is not None:
-            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name)
+            spawn_url = url_path_join(self.hub.base_url, "spawn", user.escaped_name,
+                    server_name)
             html = self.render_template(
                 "not_running.html",
                 user=user,


### PR DESCRIPTION
The `server_name` is missing from `spawn_url` here in `SpawnPendingHandler` when the `not_running.html` template is rendered.  This causes the template to render the retry button with `/hub/spawn/<user>` with the default server as the target, and not the named server that the user probably intended to spawn.  The user then clicks and starts the wrong server.  In the `UserUrlHandler` this is already taken care of, I think it just didn't get propagated to the `pages` module.

Addresses #2657 