### PR TITLE
Added support for consistent UIDs at user creation time

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -778,7 +778,7 @@ class LocalAuthenticator(Authenticator):
         except AttributeError:
             pass
         except KeyError:
-            self.log.warning("No UID for user %s" % name)
+            self.log.debug("No UID for user %s" % name)
         cmd += [name]
         self.log.info("Creating user: %s", ' '.join(map(pipes.quote, cmd)))
         p = Popen(cmd, stdout=PIPE, stderr=STDOUT)

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1,4 +1,4 @@
-"""Base Authenticator class and the default PAM Authenticator"""
+ """Base Authenticator class and the default PAM Authenticator"""
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 import inspect
@@ -775,8 +775,6 @@ class LocalAuthenticator(Authenticator):
         try:
             uid = self.uids[name]
             cmd += ['--uid', '%d' % uid]
-        except AttributeError:
-            pass
         except KeyError:
             self.log.debug("No UID for user %s" % name)
         cmd += [name]

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -660,6 +660,15 @@ class LocalAuthenticator(Authenticator):
             # This appears to be the Linux non-interactive adduser command:
             return ['adduser', '-q', '--gecos', '""', '--disabled-password']
 
+    uids = Dict(
+        help="""
+        Dictionary of uids to use at user creation time.
+        This helps ensure that users created from the database
+        get the same uid each time they are created
+        in temporary deployments or containers.
+        """
+    ).tag(config=True)
+
     group_whitelist = Set(
         help="""
         Whitelist all users from this UNIX group.
@@ -762,7 +771,15 @@ class LocalAuthenticator(Authenticator):
         Tested to work on FreeBSD and Linux, at least.
         """
         name = user.name
-        cmd = [arg.replace('USERNAME', name) for arg in self.add_user_cmd] + [name]
+        cmd = [arg.replace('USERNAME', name) for arg in self.add_user_cmd]
+        try:
+            uid = self.uids[name]
+            cmd += ['--uid', '%d' % uid]
+        except AttributeError:
+            pass
+        except KeyError:
+            self.log.warning("No UID for user %s" % name)
+        cmd += [name]
         self.log.info("Creating user: %s", ' '.join(map(pipes.quote, cmd)))
         p = Popen(cmd, stdout=PIPE, stderr=STDOUT)
         p.wait()

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1,4 +1,4 @@
- """Base Authenticator class and the default PAM Authenticator"""
+"""Base Authenticator class and the default PAM Authenticator"""
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 import inspect


### PR DESCRIPTION
This PR solves the issue in #2378.  It gives the user the option of adding a `uids` dictionary as a `LocalAuthenticator` configuration attribute.  If that `uids` attribute is found, then any user in the DB or whitelist that is added as a local user at spawn time will be added with the specific matching uid found there.  

For example, if I have:
```
c.JupyterHub.authenticator_class = LocalGitHubOAuthenticator
c.LocalGitHubOAuthenticator.uids = {'smith': 1547}
```
in my jupyterhub_config.py file, then when the user `smith` (if they are also in the db or whitelist) is added to the local system, they will be added with uid 1547.  My code assumes the `useradd` command (the provided default) is being used.  

This PR is required to solve #2378, and ensures that users can be added with consistent uids each time the hub spawns, which is important for avoid file permissions issues or orphaned files especially with mounted volumes.  