### PR TITLE
Fix failing travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
     - MYSQL_HOST=127.0.0.1
     - MYSQL_TCP_PORT=13306
 services:
-  - postgres
+  - postgresql
+  - mysql
   - docker
 
 # installing dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - MYSQL_TCP_PORT=13306
 services:
   - postgresql
-  - mysql
   - docker
 
 # installing dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
       DB=mysql bash ci/init-db.sh
       # FIXME: mysql-connector-python 8.0.16 incorrectly decodes bytes to str
       # ref: https://bugs.mysql.com/bug.php?id=94944
-      pip install 'mysql-connector-python==8.0.15'
+      pip install 'mysql-connector-python==8.0.11'
     elif [[ $JUPYTERHUB_TEST_DB_URL == postgresql* ]]; then
       psql -c "CREATE USER $PGUSER WITH PASSWORD '$PGPASSWORD';" -U postgres
       DB=postgres bash ci/init-db.sh


### PR DESCRIPTION
Posgresql and MySql tests are failing on Travis :( and I believe it's related to the Xenial migration (https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment).

- [x] fix postgres test
- [x] fix mysql test