### PR TITLE
Add Jupyter community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ our JupyterHub [Gitter](https://gitter.im/jupyterhub/jupyterhub) channel.
 - [Documentation for JupyterHub's REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
 - [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
 - [Project Jupyter website](https://jupyter.org)
+- [Project Jupyter community](https://jupyter.org/community)
 
 JupyterHub follows the Jupyter [Community Guides](https://jupyter.readthedocs.io/en/latest/community/content-community.html).
 


### PR DESCRIPTION
This addresses issue #2403, adding a link to the Jupyter Community page to the main repo readme. I've added the link under the "Help and resources" section.

Before:
...
- [Project Jupyter website](https://jupyter.org)

After:
...
- [Project Jupyter website](https://jupyter.org)
- [Project Jupyter community](https://jupyter.org/community)

This is my first contribution, so please let me know if I've overlooked an item or made a mistake. Thank you.