### PR TITLE
Reset _jupyterhub_user after login cookie cleared

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -484,6 +484,8 @@ class BaseHandler(RequestHandler):
             path=url_path_join(self.base_url, 'services'),
             **kwargs
         )
+        # Reset _jupyterhub_user
+        self._jupyterhub_user = None
 
     def _set_cookie(self, key, value, encrypted=True, **overrides):
         """Setting any cookie should go through here


### PR DESCRIPTION
This change will fix #1765
<img width="1676" alt="Screen Shot 2019-08-27 at 10 12 05 PM" src="https://user-images.githubusercontent.com/935988/63778642-c6e77880-c917-11e9-86d8-e58bd88fa0fc.png">
