### PR TITLE
ORM: allow removed MySQL variables to not exist

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -770,8 +770,8 @@ def mysql_large_prefix_check(engine):
         ).fetchall()
     )
     if (
-        variables['innodb_file_format'] == 'Barracuda'
-        and variables['innodb_large_prefix'] == 'ON'
+        variables.get('innodb_file_format', 'Barracuda') == 'Barracuda'
+        and variables.get('innodb_large_prefix', 'ON') == 'ON'
     ):
         return True
     else:


### PR DESCRIPTION
In current versions of MySQL and MariaDB `innodb_file_format`
and `innodb_large_prefix` have been removed. This allows them to not
exist and makes sure the format for the rows are `Dynamic` (default
for current versions).

Starting Jupyterhub with a current version of MySQL or MariaDB results in a `KeyError`. This was a bug introduced by me, hopefully I get it right this time.