### PR TITLE
Add New Server: change redirecting to relative to home page in js

### DIFF
--- a/share/jupyterhub/static/js/home.js
+++ b/share/jupyterhub/static/js/home.js
@@ -103,7 +103,7 @@ require(["jquery", "moment", "jhapi", "utils"], function(
   $(".new-server-btn").click(function() {
     var row = getRow($(this));
     var serverName = row.find(".new-server-name").val();
-    window.location.href = "../spawn/" + user + "/" + serverName;
+    window.location.href = "./spawn/" + user + "/" + serverName;
   });
 
   $(".stop-server").click(stopServer);


### PR DESCRIPTION
When named servers are enabled, in the home page there is "Add New Server" button. When it is clicked, it spawns a new named server:

https://github.com/jupyterhub/jupyterhub/blob/917786f2f5abdd5163770949c04f507ea0c23d84/share/jupyterhub/static/js/home.js#L103-L107

As seen in js code, it changes `window.location.href` like this: it goes 1 level/directory up and then appends `/spawn/<username>/<servername>`. This happens in home page, where the url is `/<base_url>/hub/home`, so 1 level/directory up is `/<base_url>/`. This means user is first redirected to `/<base_url>/spawn/<username>/<servername>`, and then to `/<base_url>/hub/spawn/<username>/<servername>`.

I thought it would make sense to change 

https://github.com/jupyterhub/jupyterhub/blob/917786f2f5abdd5163770949c04f507ea0c23d84/share/jupyterhub/static/js/home.js#L106

with 

```js
window.location.href = "./spawn/" + user + "/" + serverName; 
```
and we get rid of 1 redirection. But I am not completely sure.

