### PR TITLE
Non empty default server names (useful for profiles?)

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -911,6 +911,22 @@ class JupyterHub(Application):
         """,
     ).tag(config=True)
 
+    default_server_name = Unicode(
+        "",
+        help="If named servers are enabled, default name of server to spawn or open, e.g. by user-redirect.",
+    ).tag(config=True)
+    # Ensure that default_server_name doesn't do anything if named servers aren't allowed
+    _default_server_name = Unicode(
+        help="Non-configurable version exposed to JupyterHub."
+    )
+
+    @default('_default_server_name')
+    def _set_default_server_name(self):
+        if self.allow_named_servers:
+            return self.default_server_name
+        else:
+            return ""
+
     # class for spawning single-user servers
     spawner_class = EntryPointType(
         default_value=LocalProcessSpawner,
@@ -2060,6 +2076,7 @@ class JupyterHub(Application):
             domain=self.domain,
             statsd=self.statsd,
             allow_named_servers=self.allow_named_servers,
+            default_server_name=self._default_server_name,
             named_server_limit_per_user=self.named_server_limit_per_user,
             oauth_provider=self.oauth_provider,
             concurrent_spawn_limit=self.concurrent_spawn_limit,

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -389,9 +389,14 @@ class User:
         Full name.domain/path if using subdomains, otherwise just my /base/url
         """
         if self.settings.get('subdomain_host'):
-            return '{host}{path}'.format(host=self.host, path=self.base_url)
+            url = '{host}{path}'.format(host=self.host, path=self.base_url)
         else:
-            return self.base_url
+            url = self.base_url
+
+        if self.settings.get('default_server_name'):
+            return url_path_join(url, self.settings.get('default_server_name'))
+        else:
+            return url
 
     def server_url(self, server_name=''):
         """Get the url for a server with a given name"""


### PR DESCRIPTION
Added configurable default server name attribute to better match behavior described for user-redirect in [urls.md in the docs](https://github.com/jupyterhub/jupyterhub/blob/071e375d5fd038e70c29c619d199bf2c9c090d5c/docs/source/reference/urls.md#user-redirect). In particular something in this direction should allow default servers besides `""`, and thus allow `/url-redirect` to redirect to a user server besides `""`. This is helpful e.g. for people using profile spawners where there is a default profile, and so by default someone would want to launch a notebook using the default profile rather than using the `""` server. Thus this PR is _somewhat_ related to this JupyterHub issue:  https://github.com/jupyterhub/jupyterhub/issues/2724

That being said I feel like this is a somewhat kludgy implementation (which is why it was important to me that this does nothing by default, which it does at least according to my testing), so suggestions for improvement would be much appreciated.