### PR TITLE
Remove duplicate hub and authenticator traitlets from Spawner

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -207,8 +207,6 @@ class Spawner(LoggingConfigurable):
             return self.orm_spawner.name
         return ''
 
-    hub = Any()
-    authenticator = Any()
     internal_ssl = Bool(False)
     internal_trust_bundles = Dict()
     internal_certs_location = Unicode('')


### PR DESCRIPTION
The hub and authenticator traitlets are defined twice in Spawner.  They're clearly not hurting anything, but I thought this was a good opportunity to dip my toe in the water of contributing to jupyterhub...