### PR TITLE
Fix deprecated call and true comparison

### DIFF
--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -213,8 +213,4 @@ class Hub(Server):
         return url_path_join(self.url, 'api')
 
     def __repr__(self):
-        return "<%s %s:%s>" % (
-            self.__class__.__name__,
-            self.server.ip,
-            self.server.port,
-        )
+        return "<%s %s:%s>" % (self.__class__.__name__, self.ip, self.port)


### PR DESCRIPTION
Hi,

Just replacing a `if var == True` by simply `if var` (faster, but not important here I think), and two deprecated calls.

The deprecated calls were fixed according to the deprecation message, that says to access the properties directly now, instead of using the `.server` member.

Formatting performed by `black` + `git commit` hook.

Cheers
Bruno