### PR TITLE
Remove tornado deprecated/unnecessary AsyncIOMainLoop().install() call

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -36,7 +36,6 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.log import app_log, access_log, gen_log
 import tornado.options
 from tornado import gen, web
-from tornado.platform.asyncio import AsyncIOMainLoop
 
 from traitlets import (
     Unicode,
@@ -2538,7 +2537,6 @@ class JupyterHub(Application):
     @classmethod
     def launch_instance(cls, argv=None):
         self = cls.instance()
-        AsyncIOMainLoop().install()
         loop = IOLoop.current()
         task = asyncio.ensure_future(self.launch_instance_async(argv))
         try:


### PR DESCRIPTION
Hi,

`AsyncIOMainLoop().install()` is not necessary after Tornado 5.

JupyterHub requires [`tornado>=5`](https://github.com/jupyterhub/jupyterhub/blob/fafbe86b55d667e48556fc88f57e970ba83c5716/requirements.txt#L12).

Tornado deprecated the `AsyncIOMainLoop().install()` call in 5.0: https://www.tornadoweb.org/en/stable/asyncio.html#tornado.platform.asyncio.AsyncIOMainLoop

> Deprecated since version 5.0: Now used automatically when appropriate; it is no longer necessary to refer to this class directly.

It may be easier to understand looking at what that method does in the latest versions of Tornado after 5.0: 

- `install` will simply call `make_current`: https://github.com/tornadoweb/tornado/blob/ff985fe509513325462441e017f1ec31dda737c1/tornado/ioloop.py#L213 (`tornado.platform.AsyncIOMainLoop` extends `tornado.platform.asyncio.BaseAsyncIOLoop`, which in turn extends `tornado.ioloop.IOLoop` that contains the `install` method)
- `make_current()` does nothing since 5.0: https://github.com/tornadoweb/tornado/blob/ff985fe509513325462441e017f1ec31dda737c1/tornado/platform/asyncio.py#L225

So it should be safe to remove this deprecated method :+1: 