### PR TITLE
blacklist urllib3 versions with encoding bug

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,4 +14,7 @@ pytest-asyncio
 pytest-cov
 pytest>=3.3
 requests-mock
+# blacklist urllib3 releases affected by https://github.com/urllib3/urllib3/issues/1683
+# I *think* this should only affect testing, not production
+urllib3!=1.25.4,!=1.25.5
 virtualenv


### PR DESCRIPTION
I *think* this should only affect testing, not production

blacklists urllib3 releases affected by https://github.com/urllib3/urllib3/issues/1683 on CI

A fix is already [open](https://github.com/urllib3/urllib3/pull/1684), so expect the next release to be fine.

It's possible this is a real production issue, in which case we could move the same blacklist to the actual package requirements.