### PR TITLE
Reduce verbosity for "Failing suspected API request to not-running server"

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1228,6 +1228,7 @@ class UserUrlHandler(BaseHandler):
         )
         self.set_status(503)
         self.set_header("Content-Type", "application/json")
+        self.failing_non_running_server = True
 
         spawn_url = urlparse(self.request.full_url())._replace(query="")
         spawn_path_parts = [self.hub.base_url, "spawn", user_name]


### PR DESCRIPTION
- API requests to non-running servers are not uncommon when you cull
  servers and people leave tabs open and active.  It returns with 503
  and *logs all headers*, which can take up half of our total log
  lines
- This adds logic to reduce verbosity of these logs by making a note
  of the failure on the handler and then overriding the log handling.

Unresolved questions:

- Is there a better way to do this?  This is kind of hacky and
  probably there's a more elegant way.
- I welcome nits on naming of the variable and the chosen override log
  level, since I'm not very happy with it now.