### PR TITLE
Reduce verbosity for "Failing suspected API request to not-running server" (new)

### DIFF
--- a/jupyterhub/log.py
+++ b/jupyterhub/log.py
@@ -162,7 +162,7 @@ def log_request(handler):
         location='',
     )
     msg = "{status} {method} {uri}{location} ({user}@{ip}) {request_time:.2f}ms"
-    if status >= 500 and status != 502:
+    if status >= 500 and status not in {502, 503}:
         log_method(json.dumps(headers, indent=2))
     elif status in {301, 302}:
         # log redirect targets


### PR DESCRIPTION
- API requests to non-running servers are not uncommon when you cull
  servers and people leave tabs open and active. It returns with 503
  and logs all headers, which can take up half of our total log lines
- This avoids logging headers for all 502 and 503 return statuses.
  #2747 presented an alternative (more complex) implementation, but this
  turned out to be appropriate.
- Closes: #2747