### PR TITLE
Expose spawner.user_options in REST API.

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -141,6 +141,7 @@ class APIHandler(BaseHandler):
             'ready': spawner.ready,
             'state': spawner.get_state() if include_state else None,
             'url': url_path_join(spawner.user.url, spawner.name, '/'),
+            'user_options': spawner.user_options,
             'progress_url': spawner._progress_url,
         }
 

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -57,6 +57,7 @@ async def test_default_server(app, named_servers):
                         username
                     ),
                     'state': {'pid': 0},
+                    'user_options': {},
                 }
             },
         }
@@ -116,6 +117,7 @@ async def test_create_named_server(app, named_servers):
                         username, servername
                     ),
                     'state': {'pid': 0},
+                    'user_options': {},
                 }
                 for name in [servername]
             },


### PR DESCRIPTION
This adds `spawner.user_options` to the `server_model`, meaing that an admin or owner who requests `GET /users/{name}/` can see how each running server was spawned.

The motivating use case is the Hub Service [https://github.com/danielballan/jupyterhub-share-link](jupyterhub-share-link) which enables short-term sharing between users on the same Hub. See the [discourse thread](https://discourse.jupyter.org/t/request-for-early-feedback-on-jupyterhub-share-link/1543/16) for details and discussion.

The service aims to share the _environment_ as well as a notebook document. It does this by encoding some information about the sender's server in the share link and attempting to start a similar server for the recipient (or find one that is already running). This approach requires, of course, that `allow_named_servers = True`.

Currently, the Hub Service relies on a small server extension that understands how to extract the relevant details from the environment (i.e. `JUPYTER_IMAGE_SPEC`). It is fairly coupled to specific spawners. I believe that this PR would remove the need for a server extension and also generalize it to support most spawners.