### PR TITLE
Link services

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1107,10 +1107,21 @@ class BaseHandler(RequestHandler):
             logout_url=self.settings['logout_url'],
             static_url=self.static_url,
             version_hash=self.version_hash,
+            services=self.get_accessible_services(user),
         )
         if self.settings['template_vars']:
             ns.update(self.settings['template_vars'])
         return ns
+
+    def get_accessible_services(self, user):
+        accessible_services = list()
+        for service in self.services.values():
+            if not service.url:
+                continue
+            if service.admin and not user.admin:
+                continue
+            accessible_services.append(service)
+        return accessible_services
 
     def write_error(self, status_code, **kwargs):
         """render custom error pages"""

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1114,7 +1114,9 @@ class BaseHandler(RequestHandler):
         return ns
 
     def get_accessible_services(self, user):
-        accessible_services = list()
+        accessible_services = []
+        if user is None:
+            return accessible_services
         for service in self.services.values():
             if not service.url:
                 continue

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1120,8 +1120,6 @@ class BaseHandler(RequestHandler):
         for service in self.services.values():
             if not service.url:
                 continue
-            if service.admin and not user.admin:
-                continue
             accessible_services.append(service)
         return accessible_services
 

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -118,6 +118,16 @@
             {% if user.admin %}
             <li><a href="{{base_url}}admin">Admin</a></li>
             {% endif %}
+            {% if services %}
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Services<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+              {% for service in services %}
+                <li><a class="dropdown-item" href="{{service.prefix}}">{{service.name}}</a></li>
+              {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
           {% endblock %}
         </ul>
         {% endif %}


### PR DESCRIPTION
Adds a list element to the navbar that presents a list of links to accessible services.  If no services are accessible the list element is not shown.

For a service to be accessible it must have a URL.  Also, if the service runs with admin privileges, then the user must be an admin for it to be accessible.

An issue is that while a service may have a URL, it may not be desirable to expose that service as a link.  For instance the service may just be a REST API that doesn't need to be surfaced to normal users.  One way to address this would be to add a property to service configuration that would prevent a service from appearing in the list if set.  I could add that the PR if it sounds like a good suggestion but am open to alternatives.

Another issue is that, in principle, services may be accessible without users being authenticated at all but the login page won't present them.  I'm not terribly worried about this inconsistency but thought I would mention it; I'm willing to let it go for now.