### PR TITLE
add `service.oauth_no_confirm` configuration

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2034,7 +2034,7 @@ class JupyterHub(Application):
         for service in self._service_map.values():
             if service.oauth_no_confirm:
                 self.log.warning(
-                    "Allowing service %s to complete OAuth without confirmation",
+                    "Allowing service %s to complete OAuth without confirmation on an authorization web page",
                     service.name,
                 )
                 oauth_no_confirm_whitelist.add(service.oauth_client_id)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2030,6 +2030,15 @@ class JupyterHub(Application):
         else:
             version_hash = datetime.now().strftime("%Y%m%d%H%M%S")
 
+        oauth_no_confirm_whitelist = set()
+        for service in self._service_map.values():
+            if service.oauth_no_confirm:
+                self.log.warning(
+                    "Allowing service %s to complete OAuth without confirmation",
+                    service.name,
+                )
+                oauth_no_confirm_whitelist.add(service.oauth_client_id)
+
         settings = dict(
             log_function=log_request,
             config=self.config,
@@ -2062,6 +2071,7 @@ class JupyterHub(Application):
             allow_named_servers=self.allow_named_servers,
             named_server_limit_per_user=self.named_server_limit_per_user,
             oauth_provider=self.oauth_provider,
+            oauth_no_confirm_whitelist=oauth_no_confirm_whitelist,
             concurrent_spawn_limit=self.concurrent_spawn_limit,
             spawn_throttle_retry_range=self.spawn_throttle_retry_range,
             active_server_limit=self.active_server_limit,

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -209,9 +209,9 @@ class Service(LoggingConfigurable):
         By default, when users authenticate with a service using JupyterHub,
         they are prompted to confirm that they want to grant that service
         access to their credentials.
-        Setting oauth_no_confirm=True skips the confirmation for this service.
-        Useful for admin-managed services that are considered part of the Hub,
-        which shouldn't need extra prompts for login.
+        Setting oauth_no_confirm=True skips the confirmation web page for this service.
+        Skipping the confirmation page is useful for admin-managed services that are considered part of the Hub
+        and shouldn't need extra prompts for login.
 
         .. versionadded: 1.1
         """,

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -147,11 +147,15 @@ class Service(LoggingConfigurable):
 
     - name: str
         the name of the service
-    - admin: bool(false)
+    - admin: bool(False)
         whether the service should have administrative privileges
     - url: str (None)
         The URL where the service is/should be.
         If specified, the service will be added to the proxy at /services/:name
+    - oauth_no_confirm: bool(False)
+        .. versionadded:: 1.1
+        Whether this service should be allowed to complete oauth
+        with logged-in users without prompting for confirmation.
 
     If a service is to be managed by the Hub, it has a few extra options:
 
@@ -184,6 +188,7 @@ class Service(LoggingConfigurable):
         If managed, will be passed as JUPYTERHUB_SERVICE_URL env.
         """
     ).tag(input=True)
+
     api_token = Unicode(
         help="""The API token to use for the service.
 
@@ -195,6 +200,21 @@ class Service(LoggingConfigurable):
         help="""Provide a place to include miscellaneous information about the service,
         provided through the configuration
         """
+    ).tag(input=True)
+
+    oauth_no_confirm = Bool(
+        False,
+        help="""Skip OAuth confirmation when users access this service.
+
+        By default, when users authenticate with a service using JupyterHub,
+        they are prompted to confirm that they want to grant that service
+        access to their credentials.
+        Setting oauth_no_confirm=True skips the confirmation for this service.
+        Useful for admin-managed services that are considered part of the Hub,
+        which shouldn't need extra prompts for login.
+
+        .. versionadded: 1.1
+        """,
     ).tag(input=True)
 
     # Managed service API:

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -153,7 +153,6 @@ class Service(LoggingConfigurable):
         The URL where the service is/should be.
         If specified, the service will be added to the proxy at /services/:name
     - oauth_no_confirm: bool(False)
-        .. versionadded:: 1.1
         Whether this service should be allowed to complete oauth
         with logged-in users without prompting for confirmation.
 


### PR DESCRIPTION
allows services to be explicitly blessed to skip the extra oauth confirmation page

added in 1.0

This confirmation page is unhelpful for many admin-managed services,
and is mainly intended for cross-user access.

The default behavior is unchanged, but services can now opt-out of confirmation
(as is done already for the user's own servers).

Use with caution, as this eliminates users' ability to confirm that a service
should be able to authenticate them.