### PR TITLE
Update to default slow_spawn_timeout

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -714,7 +714,7 @@ class BaseHandler(RequestHandler):
 
     @property
     def slow_spawn_timeout(self):
-        return self.settings.get('slow_spawn_timeout', 10)
+        return self.settings.get('slow_spawn_timeout', 30)
 
     @property
     def slow_stop_timeout(self):


### PR DESCRIPTION
With heavy containers, first launch fails with a warning "User <name> is slow to become responsive (timeout=10)" 
Hence setting this timeout default to 30 seconds making it consistent with Spawner.start_timeout  and Spawner.http_timeout
Further, setting this config  e.g. c.JupyterHub.tornado_settings = {'slow_spawn_timeout': 30} is not easily available on the documentation