### PR TITLE
fix named server checks

### DIFF
--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -232,7 +232,7 @@ async def test_named_server_limit(app, named_servers):
     assert r.text == ''
 
 
-async def test_named_server_spawn_form(app, username):
+async def test_named_server_spawn_form(app, username, named_servers):
     server_name = "myserver"
     base_url = public_url(app)
     cookies = await app.login_user(username)


### PR DESCRIPTION
Currently checks for named servers (if named servers are allowed and limit for named servers) are only checked in API handler (`UserServerAPIHandler`). They are not checked in `SpawnHandler` which is called when user interacts with buttons in home page. So even named servers are not allowed, user can enter this url `/hub/spawn/<user_name>/<server_name>` manually and jhub creates this named server. User can even create as many many named servers in the same way (https://github.com/jupyterhub/jupyterhub/issues/2758).

In this PR I copied code piece, which does these checks, from `UserServerAPIHandler` to `SpawnHandler`. And also fixed the test `test_named_server_spawn_form()`, it was not using the fixture which enables named servers.

I have 1 question for my education: Isn't it better to raise 409 error when user tries to launch more than allowed number of named servers?