### PR TITLE
Handle the protocol when ssl is enabled and log the right URL

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -576,6 +576,22 @@ class JupyterHub(Application):
         """,
     ).tag(config=True)
 
+    @validate('bind_url')
+    def _validate_bind_url(self, proposal):
+        """ensure protocol field of bind_url matches ssl"""
+        v = proposal['value']
+        proto, sep, rest = v.partition('://')
+        if self.ssl_cert and proto != 'https':
+            return 'https' + sep + rest
+        elif proto != 'http' and not self.ssl_cert:
+            return 'http' + sep + rest
+        return v
+
+    @default('bind_url')
+    def _bind_url_default(self):
+        proto = 'https' if self.ssl_cert else 'http'
+        return proto + '://:8000'
+
     subdomain_host = Unicode(
         '',
         help="""Run single-user servers on subdomains of this host.


### PR DESCRIPTION
Uses traitlets `@validate` and `@default` (thanks @minrk !) to define the `.bind_url` of a JupyterHub application, also handling when SSL is enabled - in which case, we want the `bind_url` to have `https`, not `http`.

(updated the description of this PR to reflect the latest comments, so some of the discussion below is out of sync)

<!--
Tentative fix for #2621

Simply adds a new `@property` that handles the protocol. 
Output of `jupyterhub --debug`:

```bash
$ jupyterhub --debug
[D 2019-10-12 12:34:12.386 JupyterHub application:555] Looking for jupyterhub_config in /home/kinow/Development/python/workspace/jupyterhub
[D 2019-10-12 12:34:12.386 JupyterHub application:577] Loaded config file: /home/kinow/Development/python/workspace/jupyterhub/jupyterhub_config.py
[I 2019-10-12 12:34:12.387 JupyterHub app:2187] Running JupyterHub version 1.0.1dev
[I 2019-10-12 12:34:12.387 JupyterHub app:2218] Using Authenticator: jupyterhub.auth.PAMAuthenticator-1.0.1dev
[I 2019-10-12 12:34:12.387 JupyterHub app:2218] Using Spawner: jupyterhub.spawner.LocalProcessSpawner-1.0.1dev
[D 2019-10-12 12:34:12.391 JupyterHub app:2159] Could not load pycurl: No module named 'pycurl'
    pycurl is recommended if you have a large number of users.
[I 2019-10-12 12:34:12.392 JupyterHub app:1316] Loading cookie_secret from /home/kinow/Development/python/workspace/jupyterhub/jupyterhub_cookie_secret
[D 2019-10-12 12:34:12.392 JupyterHub app:1483] Connecting to db: sqlite:///jupyterhub.sqlite
[D 2019-10-12 12:34:12.404 JupyterHub orm:749] database schema version found: 4dc2d5a8c53c
[I 2019-10-12 12:34:12.408 JupyterHub proxy:468] Generating new CONFIGPROXY_AUTH_TOKEN
[W 2019-10-12 12:34:12.409 JupyterHub app:1591] No admin users, admin interface will be unavailable.
[W 2019-10-12 12:34:12.409 JupyterHub app:1593] Add any administrative users to `c.Authenticator.admin_users` in config.
[I 2019-10-12 12:34:12.409 JupyterHub app:1622] Not using whitelist. Any authenticated user will be allowed.
10
[D 2019-10-12 12:34:12.438 JupyterHub app:1881] Initializing spawners
[D 2019-10-12 12:34:12.438 JupyterHub app:2005] Loaded users:
    
[I 2019-10-12 12:34:12.439 JupyterHub app:2255] Initialized 0 spawners in 0.001 seconds
[I 2019-10-12 12:34:12.441 JupyterHub proxy:653] Starting proxy @ https://:8000
[D 2019-10-12 12:34:12.441 JupyterHub proxy:654] Proxy cmd: ['configurable-http-proxy', '--ip', '', '--port', '8000', '--api-ip', '127.0.0.1', '--api-port', '8001', '--error-target', 'http://127.0.0.1:8081/hub/error', '--ssl-key', './internal-ssl/hub-ca/hub-ca.key', '--ssl-cert', './internal-ssl/hub-ca/hub-ca.crt']
[D 2019-10-12 12:34:12.444 JupyterHub proxy:569] Writing proxy pid file: jupyterhub-proxy.pid
12:34:12.562 [ConfigProxy] info: Proxying https://*:8000 to (no default)
12:34:12.565 [ConfigProxy] info: Proxy API at http://127.0.0.1:8001/api/routes
[D 2019-10-12 12:34:12.612 JupyterHub proxy:689] Proxy started and appears to be up
[D 2019-10-12 12:34:12.617 JupyterHub proxy:773] Proxy: Fetching GET http://127.0.0.1:8001/api/routes
12:34:12.632 [ConfigProxy] info: 200 GET /api/routes 
[I 2019-10-12 12:34:12.633 JupyterHub app:2500] Hub API listening on http://127.0.0.1:8081/hub/
[D 2019-10-12 12:34:12.633 JupyterHub proxy:322] Fetching routes to check
[D 2019-10-12 12:34:12.633 JupyterHub proxy:773] Proxy: Fetching GET http://127.0.0.1:8001/api/routes
12:34:12.635 [ConfigProxy] info: 200 GET /api/routes 
[I 2019-10-12 12:34:12.636 JupyterHub proxy:327] Checking routes
[I 2019-10-12 12:34:12.636 JupyterHub proxy:407] Adding default route for Hub: / => http://127.0.0.1:8081
[D 2019-10-12 12:34:12.636 JupyterHub proxy:773] Proxy: Fetching POST http://127.0.0.1:8001/api/routes/
12:34:12.638 [ConfigProxy] info: Adding route / -> http://127.0.0.1:8081
12:34:12.639 [ConfigProxy] info: 201 POST /api/routes/ 
[I 2019-10-12 12:34:12.639 JupyterHub app:2575] JupyterHub is now running at https://:8000
```

These are the two lines that changed:

```
[I 2019-10-12 12:34:12.441 JupyterHub proxy:653] Starting proxy @ https://:8000
[I 2019-10-12 12:34:12.639 JupyterHub app:2575] JupyterHub is now running at https://:8000
```

Tested this and the other URL's in the browser and it apparently worked with no issues. Tried writing a unit test for this by using the `ssl_enabled` module flag for the `app` fixture, but that appears to be for the hub/internal use, and does not set the `ssl_key` and `ssl_crt`.

When `internal_ssl = True`, the value will have `https` so the property won't alter it. So everything should still work as before.

Works if `bind_url` is specified for something like `http://:4000` too, fixing the protocol without change to the port.
-->

Closes #2621 