### PR TITLE
Remove unused  setupegg.py

### DIFF
--- a/setupegg.py
+++ b/setupegg.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""Wrapper to run setup.py using setuptools."""
-# Import setuptools and call the actual setup
-import setuptools
-
-with open('setup.py', 'rb') as f:
-    exec(compile(f.read(), 'setup.py', 'exec'))


### PR DESCRIPTION
Hi,

Looks like the `setuptools` module is no longer used, but instead a command is executed calling `setup.py`. This PR simply removes the unused import and the related comment :+1: 