### PR TITLE
Fix header project name typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # coding: utf-8
-# Copyright (c) Juptyer Development Team.
+# Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 # -----------------------------------------------------------------------------
 # Minimal Python version sanity check (from IPython)

--- a/share/jupyterhub/static/js/utils.js
+++ b/share/jupyterhub/static/js/utils.js
@@ -2,7 +2,7 @@
 // Original Copyright (c) IPython Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// Modifications Copyright (c) Juptyer Development Team.
+// Modifications Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
 define(["jquery"], function($) {


### PR DESCRIPTION
Hi,

Was looking at the requirements in `setup.py` for another issue when I noticed this typo. Searched and found another one in this repo, and the same issue in other jupyter-related projects (PR's on the way).

Cheers
Bruno