### PR TITLE
Add docs for fixtures in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,35 @@ and other collections of tests for different components.
 When writing a new test, there should usually be a test of
 similar functionality already written and related tests should
 be added nearby.
-When in doubt, feel free to ask.
 
-TODO: describe some details about fixtures, etc.
+The fixtures live in `jupyterhub/tests/conftest.py`. There are
+fixtures that can be used for JupyterHub components, such as:
+
+- `app`: an instance of JupyterHub with mocked parts
+- `auth_state_enabled`: enables persisting auth_state (like authentication tokens)
+- `db`: a sqlite in-memory DB session
+- `io_loop`: a Tornado event loop
+- `event_loop`: a new asyncio event loop
+- `user`: creates a new temporary user
+- `admin_user`: creates a new temporary admin user
+- single user servers
+  - `cleanup_after`: allows cleanup of single user servers between tests
+- mocked service
+  - `MockServiceSpawner`: a spawner that mocks services for testing with a short poll interval
+  - `mockservice`: mocked service with no external service url
+  - `mockservice_url`: mocked service with a url to test external services
+
+And fixtures to add functionality or spawning behavior:
+
+- `admin_access`: grants admin access
+- `no_patience`: sets slow-spawning timeouts to zero
+- `slow_spawn`: enables the SlowSpawner (a spawner that takes a few seconds to start)
+- `never_spawn`: enables the NeverSpawner (a spawner that will never start)
+- `bad_spawn`: enables the BadSpawner (a spawner that fails immediately)
+- `slow_bad_spawn`: enables the SlowBadSpawner (a spawner that fails after a short delay)
+
+To read more about fixtures check out the
+[pytest docs](https://docs.pytest.org/en/latest/fixture.html)
+for how to use the existing fixtures, and how to create new ones.
+
+When in doubt, feel free to ask.


### PR DESCRIPTION
Hi,

Was learning about pytest fixtures to use in another project, and decided to have a look at how it was done in JupyterHub.

Noticed that there was a `TODO` mark in the `CONTRIBUTING.md`, but the `conftest.py` file had some good docstrings. So adapted those to the `CONTRIBUTING.md` document and prepared this quick PR.

Hope it helps, and thanks for the great examples on how to use fixtures :)

Bruno