### PR TITLE
Add prometheus metric to measure proxy route deletion times

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1013,10 +1013,11 @@ class BaseHandler(RequestHandler):
             PROXY_DELETE_DURATION_SECONDS.labels(
                 status=ProxyDeleteStatus.success
             ).observe(time.perf_counter() - proxy_deletion_start_time)
-        except:
+        except Exception:
             PROXY_DELETE_DURATION_SECONDS.labels(
                 status=ProxyDeleteStatus.failure
             ).observe(time.perf_counter() - proxy_deletion_start_time)
+            raise
 
         await user.stop(server_name)
 

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -135,6 +135,29 @@ for s in ServerStopStatus:
     SERVER_STOP_DURATION_SECONDS.labels(status=s)
 
 
+PROXY_DELETE_DURATION_SECONDS = Histogram(
+    'proxy_delete_duration_seconds',
+    'duration for deleting user routes from proxy',
+    ['status'],
+)
+
+
+class ProxyDeleteStatus(Enum):
+    """
+    Possible values for 'status' label of PROXY_DELETE_DURATION_SECONDS
+    """
+
+    success = 'success'
+    failure = 'failure'
+
+    def __str__(self):
+        return self.value
+
+
+for s in ProxyDeleteStatus:
+    PROXY_DELETE_DURATION_SECONDS.labels(status=s)
+
+
 def prometheus_log_method(handler):
     """
     Tornado log handler for recording RED metrics.


### PR DESCRIPTION
This PR exposes `proxy_delete_duration_seconds` prometheus metric, partially completing #1585

Kindly review and suggest any improvements I can make 🙏 