### PR TITLE
Fix deprecation warnings

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1718,7 +1718,7 @@ class JupyterHub(Application):
                     raise ValueError("Token name %r is not valid" % name)
             if kind == 'service':
                 if not any(service["name"] == name for service in self.services):
-                    self.log.warn(
+                    self.log.warning(
                         "Warning: service '%s' not in services, creating implicitly. It is recommended to register services using services list."
                         % name
                     )
@@ -2449,7 +2449,7 @@ class JupyterHub(Application):
         if self.generate_certs:
             self.load_config_file(self.config_file)
             if not self.internal_ssl:
-                self.log.warn(
+                self.log.warning(
                     "You'll need to enable `internal_ssl` "
                     "in the `jupyterhub_config` file to use "
                     "these certs."

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -428,7 +428,7 @@ class HubAuth(SingletonConfigurable):
         )
 
     auth_header_name = 'Authorization'
-    auth_header_pat = re.compile('token\s+(.+)', re.IGNORECASE)
+    auth_header_pat = re.compile(r'token\s+(.+)', re.IGNORECASE)
 
     def get_token(self, handler):
         """Get the user token from a request


### PR DESCRIPTION
* `logger.warn` is deprecated and `logger.warning` is recommended.
* Invalid escape sequences emit `DeprecationWarning`. Using raw string literals fixes them.

I found these warnings while running tests locally. This is my first PR so let me know if I have missed something.