### PR TITLE
Allow admins to customize /user-redirect/ behavior

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1264,15 +1264,15 @@ class JupyterHub(Application):
         help="""
         Callable to affect behavior of /user-redirect/
 
-        A callable that receives two parameters - the authenticated user and
-        the tornado request object for the current request passed to
-        `/user-redirect/<path>`, and returns a URL to redirect the user to.
-        This can be used to customize how the `user-redirect` URL works.
+        Receives 3 parameters:
+        1. path - URL path that was provided after /user-redirect/
+        2. request - A Tornado HTTPServerRequest object representing the
+           current request.
+        3. user - The currently authenticated user.
+        4. app - The JupyterHub object
 
-        Could be async or not.
-
-        To get the default behavior of /user-redirect/ leave this property unset
-        or return None from your callable.
+        It should return the new URL to redirect to, or None to preserve
+        current behavior.
         """,
     ).tag(config=True)
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1269,7 +1269,8 @@ class JupyterHub(Application):
         2. request - A Tornado HTTPServerRequest object representing the
            current request.
         3. user - The currently authenticated user.
-        4. app - The JupyterHub object
+        4. base_url - The base_url of the current hub, to allow for relative
+                      redirects
 
         It should return the new URL to redirect to, or None to preserve
         current behavior.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -76,7 +76,7 @@ from .oauth.provider import make_provider
 from ._data import DATA_FILES_PATH
 from .log import CoroutineLogFormatter, log_request
 from .proxy import Proxy, ConfigurableHTTPProxy
-from .traitlets import URLPrefix, Command, EntryPointType
+from .traitlets import URLPrefix, Command, EntryPointType, Callable
 from .utils import (
     maybe_future,
     url_path_join,
@@ -1258,6 +1258,21 @@ class JupyterHub(Application):
         """
     ).tag(config=True)
 
+    user_redirect_hook = Callable(
+        None,
+        allow_none=True,
+        help="""
+        Callable to affect behavior of /user-redirect/
+
+        A callable that receives two parameters - a handler and the path passed to
+        `/user-redirect/<path>`, and returns a URL to redirect the user to. This
+        can be used to customize how the `user-redirect` URL works.
+
+        To get the default behavior of /user-redirect/ leave this property unset
+        or return None from your callable.
+        """
+    ).tag(config=True)
+
     def init_handlers(self):
         h = []
         # load handlers from the authenticator
@@ -2144,6 +2159,7 @@ class JupyterHub(Application):
             trusted_alt_names=self.trusted_alt_names,
             shutdown_on_logout=self.shutdown_on_logout,
             eventlog=self.eventlog,
+            app=self
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1264,7 +1264,7 @@ class JupyterHub(Application):
         help="""
         Callable to affect behavior of /user-redirect/
 
-        Receives 3 parameters:
+        Receives 4 parameters:
         1. path - URL path that was provided after /user-redirect/
         2. request - A Tornado HTTPServerRequest object representing the
            current request.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1264,9 +1264,12 @@ class JupyterHub(Application):
         help="""
         Callable to affect behavior of /user-redirect/
 
-        A callable that receives two parameters - a handler and the path passed to
-        `/user-redirect/<path>`, and returns a URL to redirect the user to. This
-        can be used to customize how the `user-redirect` URL works.
+        A callable that receives two parameters - the authenticated user and
+        the tornado request object for the current request passed to
+        `/user-redirect/<path>`, and returns a URL to redirect the user to.
+        This can be used to customize how the `user-redirect` URL works.
+
+        Could be async or not.
 
         To get the default behavior of /user-redirect/ leave this property unset
         or return None from your callable.
@@ -2159,7 +2162,7 @@ class JupyterHub(Application):
             trusted_alt_names=self.trusted_alt_names,
             shutdown_on_logout=self.shutdown_on_logout,
             eventlog=self.eventlog,
-            app=self
+            app=self,
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1273,7 +1273,7 @@ class JupyterHub(Application):
 
         To get the default behavior of /user-redirect/ leave this property unset
         or return None from your callable.
-        """
+        """,
     ).tag(config=True)
 
     def init_handlers(self):

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1266,11 +1266,9 @@ class JupyterHub(Application):
 
         Receives 4 parameters:
         1. path - URL path that was provided after /user-redirect/
-        2. request - A Tornado HTTPServerRequest object representing the
-           current request.
+        2. request - A Tornado HTTPServerRequest representing the current request.
         3. user - The currently authenticated user.
-        4. base_url - The base_url of the current hub, to allow for relative
-                      redirects
+        4. base_url - The base_url of the current hub, for relative redirects
 
         It should return the new URL to redirect to, or None to preserve
         current behavior.

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1489,7 +1489,9 @@ class UserRedirectHandler(BaseHandler):
         url = None
         if self.app.user_redirect_hook:
             url = await maybe_future(
-                self.app.user_redirect_hook(self.request, self.current_user)
+                self.app.user_redirect_hook(
+                    path, self.request, self.current_user, self.app
+                )
             )
         if url is None:
             user = self.current_user

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1490,7 +1490,7 @@ class UserRedirectHandler(BaseHandler):
         if self.app.user_redirect_hook:
             url = await maybe_future(
                 self.app.user_redirect_hook(
-                    path, self.request, self.current_user, self.app
+                    path, self.request, self.current_user, self.base_url
                 )
             )
         if url is None:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1488,7 +1488,9 @@ class UserRedirectHandler(BaseHandler):
         # processing
         url = None
         if self.app.user_redirect_hook:
-            url = await maybe_future(self.app.user_redirect_hook(self.request, self.current_user))
+            url = await maybe_future(
+                self.app.user_redirect_hook(self.request, self.current_user)
+            )
         if url is None:
             user = self.current_user
             user_url = url_path_join(user.url, path)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1488,7 +1488,7 @@ class UserRedirectHandler(BaseHandler):
         # processing
         url = None
         if self.app.user_redirect_hook:
-            url = await self.app.user_redirect_hook(self, path)
+            url = await maybe_future(self.app.user_redirect_hook(self.request, self.current_user))
         if url is None:
             user = self.current_user
             user_url = url_path_join(user.url, path)

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -406,11 +406,11 @@ async def test_user_redirect_hook(app, username):
     name = username
     cookies = await app.login_user(name)
 
-    async def dummy_redirect(path, request, user, passed_app):
-        assert passed_app == app
+    async def dummy_redirect(path, request, user, base_url):
+        assert base_url == app.base_url
         assert path == 'redirect-to-terminal'
         assert request.uri == ujoin(
-            app.hub.base_url, 'user-redirect', 'redirect-to-terminal'
+            base_url, 'hub', 'user-redirect', 'redirect-to-terminal'
         )
         url = ujoin(user.url, '/terminals/1')
         return url

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -398,6 +398,36 @@ async def test_user_redirect(app, username):
         path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s/notebooks/test.ipynb' % name)
 
+async def test_user_redirect_hook(app, username):
+    """
+    Test proper behavior of user_redirect_hook
+    """
+    name = username
+    cookies = await app.login_user(name)
+
+    async def dummy_redirect(handler, path):
+        assert path == 'redirect-to-terminal'
+        url = ujoin(handler.current_user.url, '/terminals/1')
+        return url
+
+    app.user_redirect_hook = dummy_redirect
+
+    r = await get_page('/user-redirect/redirect-to-terminal', app)
+    r.raise_for_status()
+    print(urlparse(r.url))
+    path = urlparse(r.url).path
+    assert path == ujoin(app.base_url, '/hub/login')
+    query = urlparse(r.url).query
+    assert query == urlencode(
+        {'next': ujoin(app.hub.base_url, '/user-redirect/redirect-to-terminal')}
+    )
+
+    # We don't actually want to start the server by going through spawn - just want to make sure
+    # the redirect is to the right place
+    r = await get_page('/user-redirect/redirect-to-terminal', app, cookies=cookies, allow_redirects=False)
+    r.raise_for_status()
+    redirected_url = urlparse(r.headers['Location'])
+    assert redirected_url.path == ujoin(app.base_url, f'/user/{username}/terminals/1')
 
 async def test_user_redirect_deprecated(app, username):
     """redirecting from /user/someonelse/ URLs (deprecated)"""

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -427,7 +427,7 @@ async def test_user_redirect_hook(app, username):
     r = await get_page('/user-redirect/redirect-to-terminal', app, cookies=cookies, allow_redirects=False)
     r.raise_for_status()
     redirected_url = urlparse(r.headers['Location'])
-    assert redirected_url.path == ujoin(app.base_url, f'/user/{username}/terminals/1')
+    assert redirected_url.path == ujoin(app.base_url, 'user', username, 'terminals/1')
 
 async def test_user_redirect_deprecated(app, username):
     """redirecting from /user/someonelse/ URLs (deprecated)"""

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -406,7 +406,9 @@ async def test_user_redirect_hook(app, username):
     name = username
     cookies = await app.login_user(name)
 
-    async def dummy_redirect(request, user):
+    async def dummy_redirect(path, request, user, passed_app):
+        assert passed_app == app
+        assert path == 'redirect-to-terminal'
         assert request.uri == ujoin(
             app.hub.base_url, 'user-redirect', 'redirect-to-terminal'
         )

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -405,9 +405,9 @@ async def test_user_redirect_hook(app, username):
     name = username
     cookies = await app.login_user(name)
 
-    async def dummy_redirect(handler, path):
-        assert path == 'redirect-to-terminal'
-        url = ujoin(handler.current_user.url, '/terminals/1')
+    async def dummy_redirect(request, user):
+        assert request.uri == ujoin(app.hub.base_url, 'user-redirect', 'redirect-to-terminal')
+        url = ujoin(user.url, '/terminals/1')
         return url
 
     app.user_redirect_hook = dummy_redirect

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -398,6 +398,7 @@ async def test_user_redirect(app, username):
         path = urlparse(r.url).path
     assert path == ujoin(app.base_url, '/user/%s/notebooks/test.ipynb' % name)
 
+
 async def test_user_redirect_hook(app, username):
     """
     Test proper behavior of user_redirect_hook
@@ -406,7 +407,9 @@ async def test_user_redirect_hook(app, username):
     cookies = await app.login_user(name)
 
     async def dummy_redirect(request, user):
-        assert request.uri == ujoin(app.hub.base_url, 'user-redirect', 'redirect-to-terminal')
+        assert request.uri == ujoin(
+            app.hub.base_url, 'user-redirect', 'redirect-to-terminal'
+        )
         url = ujoin(user.url, '/terminals/1')
         return url
 
@@ -424,10 +427,16 @@ async def test_user_redirect_hook(app, username):
 
     # We don't actually want to start the server by going through spawn - just want to make sure
     # the redirect is to the right place
-    r = await get_page('/user-redirect/redirect-to-terminal', app, cookies=cookies, allow_redirects=False)
+    r = await get_page(
+        '/user-redirect/redirect-to-terminal',
+        app,
+        cookies=cookies,
+        allow_redirects=False,
+    )
     r.raise_for_status()
     redirected_url = urlparse(r.headers['Location'])
     assert redirected_url.path == ujoin(app.base_url, 'user', username, 'terminals/1')
+
 
 async def test_user_redirect_deprecated(app, username):
     """redirecting from /user/someonelse/ URLs (deprecated)"""


### PR DESCRIPTION
/user-redirect/ is used to help link to a particular url
in the logged in user's authenticated notebook. For example,
if I'm logged in as user 'yuvipanda' and hit the URL
/hub/user-redirect/git-pull, it'll redirect me to
/user/yuvipanda/git-pull. This is extremely useful in
connecting hub links to notebook server extensions, such
as nbgitpuller.

Admins might want to customize how this redirection is done -
for example, redirect users to different running servers
based on the nbgitpuller repository they are linking from.
Adding a hook here helps accomplish that.