### PR TITLE
cull_idle_servers.py: rebind max_age and inactive_limit locally

### DIFF
--- a/examples/cull-idle/cull_idle_servers.py
+++ b/examples/cull-idle/cull_idle_servers.py
@@ -117,7 +117,7 @@ def cull_idle(
     futures = []
 
     @coroutine
-    def handle_server(user, server_name, server):
+    def handle_server(user, server_name, server, max_age, inactive_limit):
         """Handle (maybe) culling a single server
 
         "server" is the entire server model from the API.
@@ -252,7 +252,7 @@ def cull_idle(
                     'url': user['server'],
                 }
         server_futures = [
-            handle_server(user, server_name, server)
+            handle_server(user, server_name, server, max_age, inactive_limit)
             for server_name, server in servers.items()
         ]
         results = yield multi(server_futures)


### PR DESCRIPTION
- In the cull script, the max_age and inactive_limit are used from the
  outer scope.  In the case that you add extra logic, one may want to
  modify these values.
- In that case, you either have to rename them locally, or access the
  outer scope with "nonlocal", the first of which is too much work,
  the second of which has a high chance of introducing bugs (as it did
  for me).
- This change introduces a fix for everyone.  It doesn't change basic
  functionality, but makes local modifications simpler.