### PR TITLE
The proxy's REST API listens on port `8001`

### DIFF
--- a/docs/source/getting-started/networking-basics.md
+++ b/docs/source/getting-started/networking-basics.md
@@ -41,7 +41,7 @@ port.
 
 ## Set the Proxy's REST API communication URL (optional)
 
-By default, this REST API listens on port 8081 of `localhost` only.
+By default, this REST API listens on port 8001 of `localhost` only.
 The Hub service talks to the proxy via a REST API on a secondary port. The
 API URL can be configured separately and override the default settings.
 


### PR DESCRIPTION
By default, the proxy's REST API listens on port `8001` instead of `8081` and the hub service listens on port `8081`.