### PR TITLE
adding docs preview to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,57 @@ jobs:
           name: smoke test jupyterhub
           command: |
             docker run --rm -it jupyterhub/jupyterhub jupyterhub --help
+
+  docs:
+    # This is the base environment that Circle will use
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+      # Update our path
+      - run: echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV
+      # Restore cached files to speed things up
+      - restore_cache:
+          keys:
+            - cache-pip
+      # Install the packages needed to build our documentation
+      - run:
+          name: Install NodeJS
+          command: |
+            # From https://github.com/nodesource/distributions/blob/master/README.md#debinstall
+            curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+
+      - run:
+          name: Install dependencies
+          command: |
+            python3 -m pip install --user -r dev-requirements.txt
+            python3 -m pip install --user -r docs/requirements.txt
+            sudo npm install -g configurable-http-proxy
+            sudo python3 -m pip install --editable .
+
+      # Cache some files for a speedup in subsequent builds
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            cd docs
+            make html
+      # Tell Circle to store the documentation output in a folder that we can access later
+      - store_artifacts:
+          path: docs/build/html/
+          destination: html
+
+# Tell CircleCI to use this workflow when it builds the site
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build
+      - docs


### PR DESCRIPTION
This adds a step to build and preview the documentation in CircleCI. It is a little bit hard for me to test, because I still can't get the jupyterhub docs to build, I keep running into NPM errors :-(