### PR TITLE
chore: Bump package versions used in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v1.8.0
   hooks:
   - id: reorder-python-imports
-    language_version: python3
+    language_version: python3.6
 - repo: https://github.com/ambv/black
   rev: 19.10b0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.3.5
+  rev: v1.8.0
   hooks:
   - id: reorder-python-imports
-    language_version: python3.6
+    language_version: python3
 - repo: https://github.com/ambv/black
-  rev: 18.9b0
+  rev: 19.10b0
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.1.0
+  rev: v2.4.0
   hooks:
   - id: end-of-file-fixer
   - id: check-json

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -152,8 +152,8 @@ flags = {
 }
 
 COOKIE_SECRET_BYTES = (
-    32
-)  # the number of bytes to use when generating new cookie secrets
+    32  # the number of bytes to use when generating new cookie secrets
+)
 
 HEX_RE = re.compile('^([a-f0-9]{2})+$', re.IGNORECASE)
 

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -334,8 +334,8 @@ class SingleUserNotebookApp(NotebookApp):
     login_handler_class = JupyterHubLoginHandler
     logout_handler_class = JupyterHubLogoutHandler
     port_retries = (
-        0
-    )  # disable port-retries, since the Spawner will tell us what port to use
+        0  # disable port-retries, since the Spawner will tell us what port to use
+    )
 
     disable_user_config = Bool(
         False,


### PR DESCRIPTION
- reorder_python_imports v1.8.0
- black v19.10b0
- pre-commit-hooks v2.4.0