### PR TITLE
Raise error on missing specified config

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -57,6 +57,7 @@ from traitlets import (
     Float,
     observe,
     default,
+    validate,
 )
 from traitlets.config import Application, Configurable, catch_config_error
 
@@ -310,6 +311,19 @@ class JupyterHub(Application):
     config_file = Unicode('jupyterhub_config.py', help="The config file to load").tag(
         config=True
     )
+
+    @validate("config_file")
+    def _validate_config_file(self, proposal):
+        if not os.path.isfile(proposal.value):
+            print(
+                "ERROR: Failed to find specified config file: {}".format(
+                    proposal.value
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return proposal.value
+
     generate_config = Bool(False, help="Generate default config file").tag(config=True)
     generate_certs = Bool(False, help="Generate certs used for internal ssl").tag(
         config=True

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -3,13 +3,13 @@ import binascii
 import os
 import re
 import sys
+import time
 from subprocess import check_output
 from subprocess import PIPE
 from subprocess import Popen
 from subprocess import run
 from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
-import time
 from unittest.mock import patch
 
 import pytest

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -6,8 +6,10 @@ import sys
 from subprocess import check_output
 from subprocess import PIPE
 from subprocess import Popen
+from subprocess import run
 from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
+import time
 from unittest.mock import patch
 
 import pytest
@@ -37,6 +39,24 @@ def test_token_app():
             f.write("c.Authenticator.admin_users={'user'}")
         out = check_output(cmd + ['user'], cwd=td).decode('utf8', 'replace').strip()
     assert re.match(r'^[a-z0-9]+$', out)
+
+
+def test_raise_error_on_missing_specified_config():
+    """
+    Using the -f or --config flag when starting JupyterHub should require the
+    file to be found and exit if it isn't.
+    """
+    process = Popen(
+        [sys.executable, '-m', 'jupyterhub', '--config', 'not-available.py']
+    )
+    # wait inpatiently for the process to exit
+    for i in range(100):
+        time.sleep(0.1)
+        returncode = process.poll()
+        if returncode is not None:
+            break
+    process.kill()
+    assert returncode == 1
 
 
 def test_generate_config():


### PR DESCRIPTION
Closes #2819 by exiting JupyterHub directly with an error if a config
file has been specified for the config_file traitlet, for example
through the -f or --config flag, but isn't available on the file system.