### PR TITLE
docker: fix onbuild image arg

### DIFF
--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -4,9 +4,8 @@
 #
 # Derivative images must have jupyterhub_config.py next to the Dockerfile.
 
-ARG BASE_IMAGE=jupyterhub/jupyterhub
-ARG BASE_IMAGE_TAG=latest
-FROM "${BASE_IMAGE}:${BASE_IMAGE_TAG}"
+ARG BASE_IMAGE=jupyterhub/jupyterhub:latest
+FROM $BASE_IMAGE
 
 ONBUILD COPY jupyterhub_config.py /srv/jupyterhub/jupyterhub_config.py
 


### PR DESCRIPTION
args in dockerfile didn't match how they were used

separating a base image from its tag in two arguments isn't necessary. We can (and do in docker hooks) use a single argument to specify the base image, which already has the form REPO:TAG. 