### PR TITLE
simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@
 # from your docker directory.
 
 # https://github.com/tianon/docker-brew-ubuntu-core/commit/3c462555392cb188830b7c91e29311b5fad90cfe
-ARG BASE_CONTAINER=ubuntu:bionic-20190612@sha256:9b1702dcfe32c873a770a32cfd306dd7fc1c4fd134adfb783db68defc8894b3c
-FROM $BASE_CONTAINER
+ARG BASE_IMAGE=ubuntu:bionic-20190612@sha256:9b1702dcfe32c873a770a32cfd306dd7fc1c4fd134adfb783db68defc8894b3c
+FROM $BASE_IMAGE
 
 USER root
 
@@ -50,7 +50,7 @@ RUN python3 -m pip install --upgrade setuptools pip wheel
 RUN python3 -m pip wheel -v --wheel-dir wheelhouse .
 
 
-FROM $BASE_CONTAINER
+FROM $BASE_IMAGE
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,71 +25,73 @@
 ARG BASE_CONTAINER=ubuntu:bionic-20190612@sha256:9b1702dcfe32c873a770a32cfd306dd7fc1c4fd134adfb783db68defc8894b3c
 FROM $BASE_CONTAINER
 
-LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
-
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get install -yq --no-install-recommends \
-    wget \
-    bzip2 \
+RUN apt-get update \
+ && apt-get install -yq --no-install-recommends \
     ca-certificates \
     locales \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    python3-dev \
+    python3-pip \
+    python3-pycurl \
+    nodejs \
+    npm \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
-# Configure environment
-ENV CONDA_DIR=/opt/conda \
-    SHELL=/bin/bash \
+# copy only what we need to avoid unnecessary rebuilds
+COPY README.md setup.py requirements.txt pyproject.toml package.json /src/jupyterhub/
+COPY jupyterhub/ /src/jupyterhub/jupyterhub
+COPY share/ /src/jupyterhub/share
+
+WORKDIR /src/jupyterhub
+RUN python3 -m pip install --upgrade setuptools pip wheel
+RUN python3 -m pip wheel -v --wheel-dir wheelhouse .
+
+
+FROM $BASE_CONTAINER
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -yq --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    locales \
+    python3-pip \
+    python3-pycurl \
+    nodejs \
+    npm \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV SHELL=/bin/bash \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8 \
-    MINICONDA_VERSION=4.7.10 \
-    MINICONDA_MD5=1c945f2b3335c7b2b15130b1b2dc5cf4 \
-    CONDA_VERSION=4.7.12
-ENV PATH=$CONDA_DIR/bin:$PATH
+    LANGUAGE=en_US.UTF-8
 
-# Install Conda and Miniconda
-RUN cd /tmp && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "${MINICONDA_MD5} *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
-    /bin/bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
-    $CONDA_DIR/bin/conda config --system --prepend channels conda-forge && \
-    $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
-    $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
-    $CONDA_DIR/bin/conda install --quiet --yes conda && \
-    $CONDA_DIR/bin/conda update --all --quiet --yes && \
-    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
-    conda clean --all -f -y
+RUN  locale-gen $LC_ALL
 
-# Install python and nodejs packages
-RUN conda install --yes -c conda-forge \
-      configurable-http-proxy \
-      jinja2 \
-      nodejs=12 \
-      pip \
-      pycurl \
-      python=3.7 \
-      requests \
-      sqlalchemy \
-      tornado  \
-      traitlets && \
-      conda clean --all -f -y
+# always make sure pip is up to date!
+RUN python3 -m pip install --no-cache --upgrade setuptools pip
 
-COPY . /src/jupyterhub
-WORKDIR /src/jupyterhub
+RUN npm install -g configurable-http-proxy@^4.2.0 \
+ && rm -rf ~/.npm
 
-RUN pip install --no-cache . && \
-    rm -rf $PWD ~/.cache ~/.npm && \
-    rm -rf /src/jupyterhub
+# install the wheels we built in the first stage
+COPY --from=0 /src/jupyterhub/wheelhouse /tmp/wheelhouse
+RUN python3 -m pip install --no-cache /tmp/wheelhouse/*
 
 RUN mkdir -p /srv/jupyterhub/
 WORKDIR /srv/jupyterhub/
+
 EXPOSE 8000
 
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 LABEL org.jupyter.service="jupyterhub"
 
 CMD ["jupyterhub"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,18 +29,13 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 USER root
 
-# Install all OS dependencies for notebook server that starts but lacks all
-# features (e.g., download as all possible file formats)
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
     wget \
     bzip2 \
     ca-certificates \
-    sudo \
     locales \
-    fonts-liberation \
-    run-one && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -74,10 +69,10 @@ RUN cd /tmp && \
 RUN conda install --yes -c conda-forge \
       configurable-http-proxy \
       jinja2 \
-      nodejs \
+      nodejs=12 \
       pip \
       pycurl \
-      python=3.6 \
+      python=3.7 \
       requests \
       sqlalchemy \
       tornado  \
@@ -87,8 +82,9 @@ RUN conda install --yes -c conda-forge \
 COPY . /src/jupyterhub
 WORKDIR /src/jupyterhub
 
-RUN pip install . && \
-    rm -rf $PWD ~/.cache ~/.npm
+RUN pip install --no-cache . && \
+    rm -rf $PWD ~/.cache ~/.npm && \
+    rm -rf /src/jupyterhub
 
 RUN mkdir -p /srv/jupyterhub/
 WORKDIR /srv/jupyterhub/


### PR DESCRIPTION
- use apt to get Python, nodejs
- use two-stage builds for wheels so build dependencies aren't added to the runtime image
- shrinks image by ~70% from ~900MB to ~270
- pin CHP version