### PR TITLE
Cleanup if spawner stop fails

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -770,6 +770,7 @@ class User:
             self.log.debug("Finished stopping %s", spawner._log_name)
             RUNNING_SERVERS.dec()
         finally:
+            spawner.server = None
             spawner.orm_spawner.started = None
             self.db.commit()
             # trigger post-stop hook


### PR DESCRIPTION
If spawner.stop throws an exception `spawner.server` is not set to None and _stop_pending is set to False leading to redirect to a url bound to fail.