### PR TITLE
Dockerfile: Copy share/ to the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN npm install -g configurable-http-proxy@^4.2.0 \
 
 # install the wheels we built in the first stage
 COPY --from=builder /src/jupyterhub/wheelhouse /tmp/wheelhouse
+COPY --from=builder /src/jupyterhub/share /src/jupyterhub/share
 RUN python3 -m pip install --no-cache /tmp/wheelhouse/*
 
 RUN mkdir -p /srv/jupyterhub/


### PR DESCRIPTION
- When the Dockerfile was turned into a multi-stage build, it seems
  the share/ directory was not copied to the final image.  This
  resulted in certain components (static/components/, static/css/)
  being missing, which resulted in the JupyterHub share directory not
  being findable (in jupyterhub/_data.py).  This led to all kinds of
  weird havoc, like templates not being findable (#2852).
- I am still unsure if this is the right fix, please check this well.
- Closes: #2852