### PR TITLE
Dockerfile: add build-essential to builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ USER root
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
  && apt-get install -yq --no-install-recommends \
+    build-essential \
     ca-certificates \
     locales \
     python3-dev \


### PR DESCRIPTION
- While debugging another problem, I noticed some failures to build
  the C extensions in the logs.  Adding build-essential should fix
  that (also as mentioned in the logs themselves).
- Extensions failed for tornado, sqlalchemy, and pyrsistent(pvectorc)
  and can be found by searching the previous output for "fail".