### PR TITLE
Fixup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: bionic
 language: python
-sudo: false
 cache:
   - pip
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
-dist: bionic
+dist: xenial
 language: python
 cache:
   - pip
-python:
-  # These lines will yield additional jobs, and they will be separated out as
-  # allowed to fail in the Travis web user interface as compared to if we would
-  # add them in the matrix.include below instead.
-  - &allowed_failure_1 3.8
-  - &allowed_failure_2 nightly
 env:
   global:
     - MYSQL_HOST=127.0.0.1
     - MYSQL_TCP_PORT=13306
+
+# request additional services for the jobs to access
 services:
   - postgresql
   - docker
 
-# installing dependencies
+# install dependencies for running pytest (but not linting)
 before_install:
   - set -e
   - nvm install 6; nvm use 6
@@ -36,58 +32,64 @@ before_install:
       DB=postgres bash ci/init-db.sh
       pip install psycopg2-binary
     fi
+
+# install general dependencies
 install:
   - pip install --upgrade pip
   - pip install --upgrade --pre -r dev-requirements.txt .
   - pip freeze
 
-# running tests
+# run tests
 script:
-  - |
-    # run tests
-    if [[ -z "$TEST" ]]; then
-      pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
-    fi
-  - |
-    # run autoformat
-    if [[ "$TEST" == "lint" ]]; then
-      pre-commit run --all-files
-    fi
+  - pytest -v --maxfail=2 --cov=jupyterhub jupyterhub/tests
+
+# collect test coverage information
 after_success:
   - codecov
-after_failure:
-  - |
-    # point to auto-lint-fix
-    if [[ "$TEST" == "lint" ]]; then
-      echo "You can install pre-commit hooks to automatically run formatting"
-      echo "on each commit with:"
-      echo "    pre-commit install"
-      echo "or you can run by hand on staged files with"
-      echo "    pre-commit run"
-      echo "or after-the-fact on already committed files with"
-      echo "    pre-commit run --all-files"
-    fi
-matrix:
+
+# list the jobs
+jobs:
   include:
-    # With TEST=lint and TEST=docs we won't run pytest
-    - python: 3.7
-      env: TEST=lint
+    - python: 3.6
+      env: ONLY_LINT=true
+      # NOTE: It does not suffice to override to: null, [], or [""]. Travis will
+      #       fall back to the default if we do.
+      before_install: echo "Do nothing before install."
+      script:
+        - pre-commit run --all-files
+      after_success: echo "Do nothing after success."
+      after_failure:
+        - |
+          echo "You can install pre-commit hooks to automatically run formatting"
+          echo "on each commit with:"
+          echo "    pre-commit install"
+          echo "or you can run by hand on staged files with"
+          echo "    pre-commit run"
+          echo "or after-the-fact on already committed files with"
+          echo "    pre-commit run --all-files"
     # When we run pytest, we want to run it with python>=3.5 as well as with
     # various configurations. We increment the python version at the same time
     # as we test new configurations in order to reduce the number of test jobs.
     - python: 3.5
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
     - python: 3.6
-      dist: xenial
       env:
         - JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://root@127.0.0.1:$MYSQL_TCP_PORT/jupyterhub
     - python: 3.7
       env:
         - PGUSER=jupyterhub
         - PGPASSWORD=hub[test/:?
-        # password in url is url-encoded (urllib.parse.quote($PGPASSWORD, safe=''))
+        # The password in url below is url-encoded with: urllib.parse.quote($PGPASSWORD, safe='')
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
+    - &allowed_failure_1
+      python: 3.8
+    - &allowed_failure_2
+      python: nightly
+    - &allowed_failure_3
+      python: 3.7
+      dist: bionic
   allow_failures:
-    - python: *allowed_failure_1
-    - python: *allowed_failure_2
+    - *allowed_failure_1
+    - *allowed_failure_2
+    - *allowed_failure_3
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 cache:
   - pip
 python:
+  # These lines will yield additional jobs, and they will be separated out as
+  # allowed to fail in the Travis web user interface as compared to if we would
+  # add them in the matrix.include below instead.
   - &allowed_failure_1 3.8
   - &allowed_failure_2 nightly
 env:
@@ -51,15 +54,6 @@ script:
     if [[ "$TEST" == "lint" ]]; then
       pre-commit run --all-files
     fi
-  - |
-    # build docs
-    if [[ "$TEST" == "docs" ]]; then
-      pushd docs
-      pip install --upgrade -r requirements.txt
-      pip install --upgrade alabaster_jupyterhub
-      make html
-      popd
-    fi
 after_success:
   - codecov
 after_failure:
@@ -79,8 +73,6 @@ matrix:
     # With TEST=lint and TEST=docs we won't run pytest
     - python: 3.7
       env: TEST=lint
-    - python: 3.7
-      env: TEST=docs
     # When we run pytest, we want to run it with python>=3.5 as well as with
     # various configurations. We increment the python version at the same time
     # as we test new configurations in order to reduce the number of test jobs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ after_success:
 # list the jobs
 jobs:
   include:
-    - python: 3.6
-      env: ONLY_LINT=true
+    - name: autoformatting check
+      python: 3.6
       # NOTE: It does not suffice to override to: null, [], or [""]. Travis will
       #       fall back to the default if we do.
       before_install: echo "Do nothing before install."
@@ -70,24 +70,30 @@ jobs:
     # When we run pytest, we want to run it with python>=3.5 as well as with
     # various configurations. We increment the python version at the same time
     # as we test new configurations in order to reduce the number of test jobs.
-    - python: 3.5
+    - name: python:3.5 + subdomain
+      python: 3.5
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
-    - python: 3.6
+    - name: python:3.6 + mysql
+      python: 3.6
       env:
         - JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://root@127.0.0.1:$MYSQL_TCP_PORT/jupyterhub
-    - python: 3.7
+    - name: python:3.7 + postgresql
+      python: 3.7
       env:
         - PGUSER=jupyterhub
         - PGPASSWORD=hub[test/:?
         # The password in url below is url-encoded with: urllib.parse.quote($PGPASSWORD, safe='')
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
     - &allowed_failure_1
-      python: 3.8
-    - &allowed_failure_2
-      python: nightly
-    - &allowed_failure_3
+      name: python:3.7 + dist:bionic
       python: 3.7
       dist: bionic
+    - &allowed_failure_2
+      name: python:3.8
+      python: 3.8
+    - &allowed_failure_3
+      name: python:nightly
+      python: nightly
   allow_failures:
     - *allowed_failure_1
     - *allowed_failure_2

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,10 @@ jobs:
         # The password in url below is url-encoded with: urllib.parse.quote($PGPASSWORD, safe='')
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
     - &allowed_failure_1
-      name: python:3.7 + dist:bionic
-      python: 3.7
+      # Using an python version older than 3.7 on bionic has issues, but bionic
+      # comes with Python 3.7 so let's accept that.
+      name: python:3.8 + dist:bionic
+      python: 3.8
       dist: bionic
     - &allowed_failure_2
       name: python:3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 sudo: false
 cache:
   - pip
+python:
+  - &allowed_failure_1 3.8
+  - &allowed_failure_2 nightly
 env:
   global:
     - MYSQL_HOST=127.0.0.1
@@ -93,9 +96,7 @@ matrix:
         - PGPASSWORD=hub[test/:?
         # password in url is url-encoded (urllib.parse.quote($PGPASSWORD, safe=''))
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
-    - &allowed_failure_1 python: 3.8
-    - &allowed_failure_2 python: nightly
   allow_failures:
-    - *allowed_failure_1
-    - *allowed_failure_2
+    - python: *allowed_failure_1
+    - python: *allowed_failure_2
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
+dist: bionic
 language: python
 sudo: false
 cache:
   - pip
-python:
-  - 3.6
-  - 3.5
-  - nightly
 env:
   global:
     - MYSQL_HOST=127.0.0.1
@@ -75,26 +72,30 @@ after_failure:
       echo "    pre-commit run --all-files"
     fi
 matrix:
-  fast_finish: true
   include:
-    - python: 3.6
+    # With TEST=lint and TEST=docs we won't run pytest
+    - python: 3.7
       env: TEST=lint
-    - python: 3.6
+    - python: 3.7
       env: TEST=docs
-    - python: 3.6
+    # When we run pytest, we want to run it with python>=3.5 as well as with
+    # various configurations. We increment the python version at the same time
+    # as we test new configurations in order to reduce the number of test jobs.
+    - python: 3.5
       env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
     - python: 3.6
+      dist: xenial
       env:
         - JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://root@127.0.0.1:$MYSQL_TCP_PORT/jupyterhub
-    - python: 3.6
+    - python: 3.7
       env:
         - PGUSER=jupyterhub
         - PGPASSWORD=hub[test/:?
         # password in url is url-encoded (urllib.parse.quote($PGPASSWORD, safe=''))
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
-    - python: 3.7
-      dist: xenial
-    - python: 3.8
-      if: tag IS present
+    - &allowed_failure_1 python: 3.8
+    - &allowed_failure_2 python: nightly
   allow_failures:
-    - python: nightly
+    - *allowed_failure_1
+    - *allowed_failure_2
+  fast_finish: true


### PR DESCRIPTION
Closes #2862 that I ran into while releasing the JupyterHub beta and made a tagged commit that Travis built with failures. I ended up doing quite a bit of experimentation and testing until I understood things and got them to work.

## Key findings
- bionic + Python versions less than 3.7 run into issues, see #2870 
- we don't support Python 3.8, see #2869 

## PR change highlights
- We now test with bionic and python 3.8 but allow them to fail
- I removed the `make html` build test as CircleCI tests that already
- I removed plain Py35 and Py36 tests and integrated Py35 and Py36 testing with other test cases
- I added names that describe the tests somewhat instead of relying on environment variables to help us figure it out in a too technical manner, the downside is that it hides some information about the environment variables that you need to inspect the build logs in order to see them. I consider it worth it anyhow as the jobs suddenly are or at least can be made more understandable to a broad audience now.
- I removed some deprecated travis logic (`sudo: false`)