### PR TITLE
Bugfix: pam_normalize_username didn't return username

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -981,6 +981,7 @@ class PAMAuthenticator(LocalAuthenticator):
             uid = pwd.getpwnam(username).pw_uid
             username = pwd.getpwuid(uid).pw_name
             username = self.username_map.get(username, username)
+            return username
         else:
             return super().normalize_username(username)
 


### PR DESCRIPTION
- A trivial bug caused by my last change to #2397 - made possible by
  the fact we didn't have a way to reliable test PAM stuff.
- Thanks to @narnish for noticing.
- Closes: #2875