### PR TITLE
Pass tests on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,20 +84,12 @@ jobs:
         - PGPASSWORD=hub[test/:?
         # The password in url below is url-encoded with: urllib.parse.quote($PGPASSWORD, safe='')
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
-    - &allowed_failure_1
-      # Using an python version older than 3.7 on bionic has issues, but bionic
-      # comes with Python 3.7 so let's accept that.
-      name: python:3.8 + dist:bionic
+    - name: python:3.8
+      python: 3.8
+  allow_failures:
+    - name: python:3.8 + dist:bionic
       python: 3.8
       dist: bionic
-    - &allowed_failure_2
-      name: python:3.8
-      python: 3.8
-    - &allowed_failure_3
-      name: python:nightly
+    - name: python:nightly
       python: nightly
-  allow_failures:
-    - *allowed_failure_1
-    - *allowed_failure_2
-    - *allowed_failure_3
   fast_finish: true

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -76,7 +76,8 @@ async def test_spawner(db, request):
     assert status is None
     await spawner.stop()
     status = await spawner.poll()
-    assert status == 1
+    assert status is not None
+    assert isinstance(status, int)
 
 
 async def wait_for_spawner(spawner, timeout=10):


### PR DESCRIPTION
We appear to already support Python 3.8 just fine, we only needed to update some testing code.

Closes #2869