### PR TITLE
trigger auth_state_hook prior to options form, add auth_state to template namespace

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -223,7 +223,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
         return True
 
     @web.authenticated
-    def get(self):
+    async def get(self):
         """GET /oauth/authorization
 
         Render oauth confirmation page:
@@ -251,8 +251,14 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
                 return
 
             # Render oauth 'Authorize application...' page
+            auth_state = await self.current_user.get_auth_state()
             self.write(
-                self.render_template("oauth.html", scopes=scopes, oauth_client=client)
+                self.render_template(
+                    "oauth.html",
+                    auth_state=auth_state,
+                    scopes=scopes,
+                    oauth_client=client,
+                )
             )
 
         # Errors that should be shown to the user on the provider website

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1431,8 +1431,13 @@ class UserUrlHandler(BaseHandler):
             url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
             {"next": self.request.uri},
         )
+        auth_state = await user.get_auth_state()
         html = self.render_template(
-            "not_running.html", user=user, server_name=server_name, spawn_url=spawn_url
+            "not_running.html",
+            user=user,
+            server_name=server_name,
+            spawn_url=spawn_url,
+            auth_state=auth_state,
         )
         self.finish(html)
 

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -186,7 +186,7 @@ class SpawnHandler(BaseHandler):
         spawner_options_form = await spawner.get_options_form()
         if spawner_options_form:
             self.log.debug("Serving options form for %s", spawner._log_name)
-            form = self._render_form(
+            form = await self._render_form(
                 for_user=user, spawner_options_form=spawner_options_form
             )
             self.finish(form)
@@ -248,7 +248,7 @@ class SpawnHandler(BaseHandler):
                 "Failed to spawn single-user server with form", exc_info=True
             )
             spawner_options_form = await user.spawner.get_options_form()
-            form = self._render_form(
+            form = await self._render_form(
                 for_user=user, spawner_options_form=spawner_options_form, message=str(e)
             )
             self.finish(form)

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -972,11 +972,11 @@ class Spawner(LoggingConfigurable):
             except Exception:
                 self.log.exception("post_stop_hook failed with exception: %s", self)
 
-    def run_auth_state_hook(self, auth_state):
+    async def run_auth_state_hook(self, auth_state):
         """Run the auth_state_hook if defined"""
         if self.auth_state_hook is not None:
             try:
-                return self.auth_state_hook(self, auth_state)
+                await maybe_future(self.auth_state_hook(self, auth_state))
             except Exception:
                 self.log.exception("auth_stop_hook failed with exception: %s", self)
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -535,12 +535,17 @@ class User:
         # trigger pre-spawn hook on authenticator
         authenticator = self.authenticator
         try:
+            spawner._start_pending = True
+
             if authenticator:
                 # pre_spawn_start can thow errors that can lead to a redirect loop
                 # if left uncaught (see https://github.com/jupyterhub/jupyterhub/issues/2683)
                 await maybe_future(authenticator.pre_spawn_start(self, spawner))
 
-            spawner._start_pending = True
+            # trigger auth_state hook
+            auth_state = await self.get_auth_state()
+            await spawner.run_auth_state_hook(auth_state)
+
             # update spawner start time, and activity for both spawner and user
             self.last_activity = (
                 spawner.orm_spawner.started


### PR DESCRIPTION
- allow auth_state_hook to be async
- trigger it prior to start and options_form serving, rather than on visit to home page

closes #2860
closes #2552
closes #2885