### PR TITLE
LocalProcessSpawner should work on windows by using psutil.pid_exists

### DIFF
--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -74,7 +74,7 @@ It should return `None` if it is still running,
 and an integer exit status, otherwise.
 
 For the local process case, `Spawner.poll` uses `os.kill(PID, 0)`
-to check if the local process is still running.
+to check if the local process is still running. On Windows, it uses `psutil.pid_exists`.
 
 ### Spawner.stop
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -18,6 +18,7 @@ from tempfile import mkdtemp
 
 from async_generator import async_generator
 from async_generator import yield_
+import psutil
 from sqlalchemy import inspect
 from tornado.ioloop import PeriodicCallback
 from traitlets import Any
@@ -1468,21 +1469,12 @@ class LocalProcessSpawner(Spawner):
             self.clear_state()
             return 0
 
-        alive = await self._is_single_user_process_alive()
+        alive = psutil.pid_exists(self.pid)
         if not alive:
             self.clear_state()
             return 0
         else:
             return None
-
-    async def _is_single_user_process_alive(self):
-        """Returns True if the process still exists, False otherwise.
-        
-        Allows subclasses to implement this in a platform specific manner.
-        """
-        # send signal 0 to check if PID exists
-        # this doesn't work on Windows, but that's okay because we don't support Windows.
-        return await self._signal(0)
 
     async def _signal(self, sig):
         """Send given signal to a single-user server's process.

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1468,14 +1468,21 @@ class LocalProcessSpawner(Spawner):
             self.clear_state()
             return 0
 
-        # send signal 0 to check if PID exists
-        # this doesn't work on Windows, but that's okay because we don't support Windows.
-        alive = await self._signal(0)
+        alive = await self._is_single_user_process_alive()
         if not alive:
             self.clear_state()
             return 0
         else:
             return None
+
+    async def _is_single_user_process_alive(self):
+        """Returns True if the process still exists, False otherwise.
+        
+        Allows subclasses to implement this in a platform specific manner.
+        """
+        # send signal 0 to check if PID exists
+        # this doesn't work on Windows, but that's okay because we don't support Windows.
+        return await self._signal(0)
 
     async def _signal(self, sig):
         """Send given signal to a single-user server's process.

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -16,7 +16,8 @@ import warnings
 from subprocess import Popen
 from tempfile import mkdtemp
 
-import psutil
+if os.name == 'nt':
+    import psutil
 from async_generator import async_generator
 from async_generator import yield_
 from sqlalchemy import inspect
@@ -1469,7 +1470,11 @@ class LocalProcessSpawner(Spawner):
             self.clear_state()
             return 0
 
-        alive = psutil.pid_exists(self.pid)
+        # We use pustil.pid_exists on windows
+        if os.name == 'nt':
+            alive = psutil.pid_exists(self.pid)
+        else:
+            alive = await self._signal(0)
         if not alive:
             self.clear_state()
             return 0

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -16,9 +16,9 @@ import warnings
 from subprocess import Popen
 from tempfile import mkdtemp
 
+import psutil
 from async_generator import async_generator
 from async_generator import yield_
-import psutil
 from sqlalchemy import inspect
 from tornado.ioloop import PeriodicCallback
 from traitlets import Any

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1490,11 +1490,10 @@ class LocalProcessSpawner(Spawner):
         """
         try:
             os.kill(self.pid, sig)
+        except ProcessLookupError:
+            return False  # process is gone
         except OSError as e:
-            if e.errno == errno.ESRCH:
-                return False  # process is gone
-            else:
-                raise
+            raise  # Can be EPERM or EINVAL
         return True  # process exists
 
     async def stop(self, now=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ jupyter_telemetry
 oauthlib>=3.0
 pamela
 prometheus_client>=0.0.21
+psutil>=5.6.5
 python-dateutil
 requests
 SQLAlchemy>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jupyter_telemetry
 oauthlib>=3.0
 pamela
 prometheus_client>=0.0.21
-psutil>=5.6.5
+psutil>=5.6.5; sys_platform == 'win32'
 python-dateutil
 requests
 SQLAlchemy>=1.1


### PR DESCRIPTION
Hi there!

I'm taking advantage of the policy you've stated previously that you accept patches that make windows implementations like WinLocalProcessSpawner possible, without looking to add win-specific code to jupyterhub.

In this patch, I want to allow subclasses of LocalProcessSpawner  to have a working poll method without reimplementing the whole poll method, but just the call to _signal, which, as its comment says, is not expected to work on Windows.

After this MR, WinLocalProcessSpawner will implement its own win-specific version of the new _is_single_user_process_alive method, instead of the whole poll.

Cheers, hope this helps.