### PR TITLE
Run auth_state_hook on spawner before spawning

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -112,6 +112,9 @@ class SpawnHandler(BaseHandler):
         """
 
         user = current_user = self.current_user
+        auth_state = await user.get_auth_state()
+        user.spawner.run_auth_state_hook(auth_state)
+
         if for_user is not None and for_user != user.name:
             if not user.admin:
                 raise web.HTTPError(


### PR DESCRIPTION
Authenticators may have a [hook function](https://github.com/jupyterhub/jupyterhub/pull/2555/commits) that passes `auth_state` information to the spawner.  It is therefore important to run such a hook in the `SpawnHandler` page handler before spawning.

It might also be a good idea to run `auth_state_hook` in the `SpawnPendingHandler` page handler as well.