### PR TITLE
Fix implementation of default server name

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1526,14 +1526,30 @@ class UserRedirectHandler(BaseHandler):
             )
         if url is None:
             user = self.current_user
-            user_url = url_path_join(user.url, path)
+            user_url = user.url
+
+            if self.app.default_server_name:
+                user_url = url_path_join(user_url, self.app.default_server_name)
+
+            user_url = url_path_join(user_url, path)
             if self.request.query:
                 user_url = url_concat(user_url, parse_qsl(self.request.query))
 
-            url = url_concat(
-                url_path_join(self.hub.base_url, "spawn", user.escaped_name),
-                {"next": user_url},
-            )
+            if self.app.default_server_name:
+                url = url_concat(
+                    url_path_join(
+                        self.hub.base_url,
+                        "spawn",
+                        user.escaped_name,
+                        self.app.default_server_name,
+                    ),
+                    {"next": user_url},
+                )
+            else:
+                url = url_concat(
+                    url_path_join(self.hub.base_url, "spawn", user.escaped_name),
+                    {"next": user_url},
+                )
 
         self.redirect(url)
 

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -27,6 +27,17 @@ def named_servers(app):
         yield
 
 
+@pytest.fixture
+def default_server_name(app, named_servers):
+    """configure app to use a default server name"""
+    server_name = 'myserver'
+    try:
+        app.default_server_name = server_name
+        yield server_name
+    finally:
+        app.default_server_name = ''
+
+
 async def test_default_server(app, named_servers):
     """Test the default /users/:user/server handler when named servers are enabled"""
     username = 'rosie'
@@ -269,10 +280,11 @@ async def test_named_server_spawn_form(app, username, named_servers):
     spawner.user_options == {'energy': '938MeV', 'bounds': [-10, 10], 'notspecified': 5}
 
 
-async def test_user_redirect_default_server_name(app, username, default_server_name):
+async def test_user_redirect_default_server_name(
+    app, username, named_servers, default_server_name
+):
     name = username
     server_name = default_server_name
-    app.default_server_name = default_server_name
     cookies = await app.login_user(name)
 
     r = await api_request(app, 'users', username, 'servers', server_name, method='post')
@@ -311,7 +323,6 @@ async def test_user_redirect_hook_default_server_name(
     """
     name = username
     server_name = default_server_name
-    app.default_server_name = default_server_name
     cookies = await app.login_user(name)
 
     r = await api_request(app, 'users', username, 'servers', server_name, method='post')

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -338,6 +338,8 @@ async def test_user_redirect_hook_default_server_name(
         assert request.uri == url_path_join(
             base_url, 'hub', 'user-redirect', 'redirect-to-terminal'
         )
+        # exclude custom server_name
+        # custom hook is respected exactly
         url = url_path_join(user.url, '/terminals/1')
         return url
 
@@ -364,5 +366,5 @@ async def test_user_redirect_hook_default_server_name(
     r.raise_for_status()
     redirected_url = urlparse(r.headers['Location'])
     assert redirected_url.path == url_path_join(
-        app.base_url, 'user', username, server_name, 'terminals/1'
+        app.base_url, 'user', username, 'terminals/1'
     )

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -389,14 +389,9 @@ class User:
         Full name.domain/path if using subdomains, otherwise just my /base/url
         """
         if self.settings.get('subdomain_host'):
-            url = '{host}{path}'.format(host=self.host, path=self.base_url)
+            return '{host}{path}'.format(host=self.host, path=self.base_url)
         else:
-            url = self.base_url
-
-        if self.settings.get('default_server_name'):
-            return url_path_join(url, self.settings.get('default_server_name'))
-        else:
-            return url
+            return self.base_url
 
     def server_url(self, server_name=''):
         """Get the url for a server with a given name"""


### PR DESCRIPTION
Having the modification to the default user-redirect behavior be contained inside of `UserRedirectHandler` seems more transparent to me. Also this worked as intended in more cases than the previous version when I tested it.