### PR TITLE
Optimize CI jobs and default to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 cache:
   - pip
@@ -70,25 +70,23 @@ jobs:
     # When we run pytest, we want to run it with python>=3.5 as well as with
     # various configurations. We increment the python version at the same time
     # as we test new configurations in order to reduce the number of test jobs.
-    - name: python:3.5 + subdomain
+    - name: python:3.5 + dist:xenial
       python: 3.5
-      env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
-    - name: python:3.6 + mysql
+      dist: xenial
+    - name: python:3.6 + subdomain
       python: 3.6
+      env: JUPYTERHUB_TEST_SUBDOMAIN_HOST=http://localhost.jovyan.org:8000
+    - name: python:3.7 + mysql
+      python: 3.7
       env:
         - JUPYTERHUB_TEST_DB_URL=mysql+mysqlconnector://root@127.0.0.1:$MYSQL_TCP_PORT/jupyterhub
-    - name: python:3.7 + postgresql
-      python: 3.7
+    - name: python:3.8 + postgresql
+      python: 3.8
       env:
         - PGUSER=jupyterhub
         - PGPASSWORD=hub[test/:?
         # The password in url below is url-encoded with: urllib.parse.quote($PGPASSWORD, safe='')
         - JUPYTERHUB_TEST_DB_URL=postgresql://jupyterhub:hub%5Btest%2F%3A%3F@127.0.0.1/jupyterhub
-    - name: python:3.8
-      python: 3.8
-    - name: python:3.8 + dist:bionic
-      python: 3.8
-      dist: bionic
     - name: python:nightly
       python: nightly
   allow_failures:


### PR DESCRIPTION
Reducing the amount of builds running has some value with regards to speed. Slimming away a single job can make all the jobs that need to build run in parallel instead of needing to wait for a straggler job.

In this PR i made the default job CI distribution be bionic (2018 ubuntu), but still let one job test with xenial (2016 ubuntu). The job I trimmed away was to dedicate a job to isolate a test of bionic. Now we instead test bionic by default and let the python 3.5 test also test if use of xenial still works.

We test four python versions
Py 3.5
Py 3.6
Py 3.7
Py 3.8

And we test four scenarios
- xenial dist used
- subdomain used
- mysql database used
- postgresql database used

In this PR, all python versions get a scenario along with them, and we don't run a dedicated test without a scenario any more.