### PR TITLE
bump reorder-imports hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 repos:
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.8.0
+  rev: v1.9.0
   hooks:
   - id: reorder-python-imports
-    language_version: python3.6
 - repo: https://github.com/ambv/black
   rev: 19.10b0
   hooks:


### PR DESCRIPTION
removes (hopefully) unnecessarily specified language version