### PR TITLE
fix: 'Non-ASCII character '\xc3'

### DIFF
--- a/examples/cull-idle/cull_idle_servers.py
+++ b/examples/cull-idle/cull_idle_servers.py
@@ -61,7 +61,7 @@ def parse_date(date_string):
     """
     dt = dateutil.parser.parse(date_string)
     if not dt.tzinfo:
-        # assume naïve timestamps are UTC
+        # assume naive timestamps are UTC
         dt = dt.replace(tzinfo=timezone.utc)
     return dt
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -625,14 +625,14 @@ def _parse_timestamp(timestamp):
 
     - raise HTTPError(400) on parse error
     - handle and strip tz info for internal consistency
-      (we use naïve utc timestamps everywhere)
+      (we use naive utc timestamps everywhere)
     """
     try:
         dt = parse_date(timestamp)
     except Exception:
         raise web.HTTPError(400, "Not a valid timestamp: %r", timestamp)
     if dt.tzinfo:
-        # strip timezone info to naïve UTC datetime
+        # strip timezone info to naive UTC datetime
         dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
 
     now = datetime.utcnow()

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2452,7 +2452,7 @@ class JupyterHub(Application):
                 continue
             dt = parse_date(route_data['last_activity'])
             if dt.tzinfo:
-                # strip timezone info to naïve UTC datetime
+                # strip timezone info to naive UTC datetime
                 dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
 
             if user.last_activity:

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -175,9 +175,9 @@ def prometheus_log_method(handler):
     Tornado log handler for recording RED metrics.
 
     We record the following metrics:
-       Rate – the number of requests, per second, your services are serving.
-       Errors – the number of failed requests per second.
-       Duration – The amount of time each request takes expressed as a time interval.
+       Rate: the number of requests, per second, your services are serving.
+       Errors: the number of failed requests per second.
+       Duration: the amount of time each request takes expressed as a time interval.
 
     We use a fully qualified name of the handler as a label,
     rather than every url path to reduce cardinality.

--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -490,7 +490,7 @@ class SingleUserNotebookApp(NotebookApp):
             # protect against mixed timezone comparisons
             if not last_activity.tzinfo:
                 # assume naive timestamps are utc
-                self.log.warning("last activity is using naïve timestamps")
+                self.log.warning("last activity is using naive timestamps")
                 last_activity = last_activity.replace(tzinfo=timezone.utc)
 
         if self._last_activity_sent and last_activity < self._last_activity_sent:

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -50,7 +50,7 @@ ISO8601_s = '%Y-%m-%dT%H:%M:%SZ'
 def isoformat(dt):
     """Render a datetime object as an ISO 8601 UTC timestamp
 
-    Naïve datetime objects are assumed to be UTC
+    Naive datetime objects are assumed to be UTC
     """
     # allow null timestamps to remain None without
     # having to check if isoformat should be called


### PR DESCRIPTION
Code comments that have non-ASCII characters sometimes create encoding issues when not [adding encoding headers to the source files](https://www.python.org/dev/peps/pep-0263/).

- Change `naïve` to `naive` in all files. The `diaerisis` isn't [used in English that much anymore anyway](https://www.merriam-webster.com/words-at-play/mary-norris-diaeresis).
- Change `-` to `:` in the `metrics.py --> prometheus_log_method()` comments.