### PR TITLE
Add what we need with some margin to Dockerfile's build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,10 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# copy only what we need to avoid unnecessary rebuilds
-COPY bower-lite \
-     package.json \
-     pyproject.toml \
-     README.md \
-     requirements.txt \
-     setup.py \
-     /src/jupyterhub/
+# copy everything except whats in .dockerignore, its a
+# compromise between needing to rebuild and maintaining
+# what needs to be part of the build
+COPY . /src/jupyterhub/
 COPY jupyterhub/ /src/jupyterhub/jupyterhub
 COPY share/ /src/jupyterhub/share
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # copy only what we need to avoid unnecessary rebuilds
-COPY package.json \
+COPY bower-lite \
+     package.json \
      pyproject.toml \
      README.md \
      requirements.txt \


### PR DESCRIPTION
This fixes #2852 by adding a script referenced by package.json. But is this
enough? Should we perhaps look in MANIFEST.in and copy some more files
listed there?

This is all thanks to people coming together and helping out figuring
out the issue in https://github.com/jupyterhub/jupyterhub/issues/2852.
Thank you @shingo78 for spotting that we missed bower-lite and its role
and all others who reported and helped debug this!

---

I have never learned what a MANIFEST.in file does etc, but I think it relates to what is packaged in a PyPI package for example. So, then it may be a suitable source to align with when we copy things into the Dockerfile's build step where we package the JupyterHub package as well.