### PR TITLE
Fix --generate-config bug when specifying a filename

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -316,7 +316,7 @@ class JupyterHub(Application):
 
     @validate("config_file")
     def _validate_config_file(self, proposal):
-        if not os.path.isfile(proposal.value):
+        if not self.generate_config and not os.path.isfile(proposal.value):
             print(
                 "ERROR: Failed to find specified config file: {}".format(
                     proposal.value


### PR DESCRIPTION
This commit fixes #2906 that was introduced due to #2824. See analysis
of issue in https://github.com/jupyterhub/jupyterhub/issues/2906#issuecomment-577303510.