### PR TITLE
Add favicon to the base page template

### DIFF
--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -35,7 +35,7 @@
     <link rel="stylesheet" href="{{ static_url("css/style.min.css") }}" type="text/css"/>
     {% endblock %}
     {% block favicon %}
-    <link rel="shortcut icon" href="{{ static_url("favicon.ico") }}">
+    <link rel="icon" href="{{ static_url("favicon.ico") }}" type="image/x-icon">
     {% endblock %}
     {% block scripts %}
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -34,6 +34,9 @@
     {% block stylesheet %}
     <link rel="stylesheet" href="{{ static_url("css/style.min.css") }}" type="text/css"/>
     {% endblock %}
+    {% block favicon %}
+    <link rel="shortcut icon" href="{{ static_url("favicon.ico") }}">
+    {% endblock %}
     {% block scripts %}
     <script src="{{static_url("components/requirejs/require.js") }}" type="text/javascript" charset="utf-8"></script>
     <script src="{{static_url("components/jquery/dist/jquery.min.js") }}" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
This was missing before. Giving it its own named block will let users customize it if they wish.

Having the favicon present makes it much easier to navigate a sea of open tabs :) 