### PR TITLE
[doc] Fix link to SSL encryption from troubleshooting page

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -269,7 +269,7 @@ where `ssl_cert` is example-chained.crt and ssl_key to your private key.
 
 Then restart JupyterHub.
 
-See also [JupyterHub SSL encryption](getting-started.md#ssl-encryption).
+See also [JupyterHub SSL encryption](./getting-started/security-basics.html#ssl-encryption).
 
 ### Install JupyterHub without a network connection
 


### PR DESCRIPTION
Hi, not sure if the syntax is 100%. Tested locally with `make html` and confirming that the link redirected to the right page+section.

Thanks!
Bruno