### PR TITLE
[doc] Use fixed commit plus line number in github link

### DIFF
--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -360,7 +360,7 @@ and taking note of the following process:
 
 An example of using an Externally-Managed Service and authentication is
 in [nbviewer README][nbviewer example] section on securing the notebook viewer,
-and an example of its configuration is found [here](https://github.com/jupyter/nbviewer/blob/master/nbviewer/providers/base.py#L94).
+and an example of its configuration is found [here](https://github.com/jupyter/nbviewer/blob/ed942b10a52b6259099e2dd687930871dc8aac22/nbviewer/providers/base.py#L95).
 nbviewer can also be run as a Hub-Managed Service as described [nbviewer README][nbviewer example]
 section on securing the notebook viewer.
 


### PR DESCRIPTION
Not sure if the best approach, or if we should include some sample code instead.

The link currently points to an empty string. Used `git blame`, looks like the link was added in 2016. Going back to last commit in November 2016, line 94 points to the `prepare` function.

Simply got the most recent commit for that function by going to GitHub UI, clicking on the line number, and then pressing `y`.

This way the docs will always point to this line. Users should be able to learn that that's the function referenced, then just click on `master` in GitHub UI to see the latest if available.

Cheers
Bruno