### PR TITLE
Allow implicit spawn via javascript redirect

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -917,9 +917,36 @@ class JupyterHub(Application):
     def _authenticator_default(self):
         return self.authenticator_class(parent=self, db=self.db)
 
+    allow_implicit_spawn = Bool(
+        False,
+        help="""Allow implicit spawning
+
+        When a user visits a URL for a server that's not running,
+        instead of confirming the spawn request,
+        automatically begin the spawn process.
+
+        Warning: not compatible with named servers,
+        and known to cause issues with redirect loops,
+        server errors, and infinitely respawning servers.
+        """,
+    ).tag(config=True)
+
+    @validate('allow_implicit_spawn')
+    def _allow_named_changed(self, proposal):
+        if proposal.value and self.allow_named_servers:
+            self.log.warning("Implicit spawn cannot work with named servers")
+            return False
+        return proposal.value
+
     allow_named_servers = Bool(
         False, help="Allow named single-user servers per user"
     ).tag(config=True)
+
+    @observe('allow_named_servers')
+    def _allow_named_changed(self, change):
+        if change.new and self.allow_implicit_spawn:
+            self.log.warning("Implicit spawn cannot work with named servers")
+            self.allow_implicit_spawn = False
 
     named_server_limit_per_user = Integer(
         0,
@@ -2158,6 +2185,7 @@ class JupyterHub(Application):
             subdomain_host=self.subdomain_host,
             domain=self.domain,
             statsd=self.statsd,
+            allow_implicit_spawn=self.allow_implicit_spawn,
             allow_named_servers=self.allow_named_servers,
             default_server_name=self._default_server_name,
             named_server_limit_per_user=self.named_server_limit_per_user,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1426,11 +1426,17 @@ class UserUrlHandler(BaseHandler):
         # serve a page prompting for spawn and 503 error
         # visiting /user/:name no longer triggers implicit spawn
         # without explicit user action
-        self.set_status(503)
         spawn_url = url_concat(
             url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
             {"next": self.request.uri},
         )
+        if self.settings["allow_implicit_spawn"]:
+            self.log.warning("Allowing implicit spawn for %s", self.request.path)
+            self.redirect(spawn_url)
+            return
+        else:
+            self.set_status(503)
+
         auth_state = await user.get_auth_state()
         html = self.render_template(
             "not_running.html",

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1430,12 +1430,7 @@ class UserUrlHandler(BaseHandler):
             url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
             {"next": self.request.uri},
         )
-        if self.settings["allow_implicit_spawn"]:
-            self.log.warning("Allowing implicit spawn for %s", self.request.path)
-            self.redirect(spawn_url)
-            return
-        else:
-            self.set_status(503)
+        self.set_status(503)
 
         auth_state = await user.get_auth_state()
         html = self.render_template(
@@ -1444,6 +1439,7 @@ class UserUrlHandler(BaseHandler):
             server_name=server_name,
             spawn_url=spawn_url,
             auth_state=auth_state,
+            implicit_spawn_seconds=self.settings.get("implicit_spawn_seconds", 0),
         )
         self.finish(html)
 

--- a/share/jupyterhub/templates/not_running.html
+++ b/share/jupyterhub/templates/not_running.html
@@ -23,7 +23,14 @@
         {% endif %}
         Would you like to retry starting it?
         {% else %}
-        Your server {{ server_name }} is not running. Would you like to start it?
+        Your server {{ server_name }} is not running.
+          {% if implicit_spawn_seconds %}
+          It will be restarted automatically.
+          If you are not redirected in a few seconds,
+          click below to launch your server.
+          {% else %}
+          Would you like to start it?
+          {% endif %}
         {% endif %}
       </p>
       {% endblock %}
@@ -42,3 +49,18 @@
 </div>
 
 {% endblock %}
+{% block script %}
+{{ super () }}
+{% if implicit_spawn_seconds %}
+<script type="text/javascript">
+  var spawn_url = "{{ spawn_url }}";
+  var implicit_spawn_seconds = {{ implicit_spawn_seconds }};
+  setTimeout(function () {
+      console.log("redirecting to spawn at", spawn_url);
+      window.location = spawn_url;
+    },
+    1000 * implicit_spawn_seconds
+  );
+</script>
+{% endif %}
+{% endblock script %}


### PR DESCRIPTION
Draft for design discussion.

there are deployments that are frustrated by the extra click required since 1.0 when ambiguous links are shared to notebook servers that aren't running (#2924).

Removing the Location-based redirect is important to fixing lots of issues and I don't want to remove that, but this PR allows deployments to opt-in to removing that user interaction by effectively automatically clicking that one button for the user after a delay.

The javascript redirect is much better than the Location redirect because it will only happen to "real" browser visits, not API requests, scripts and the like.

Screenshot when `JupyterHub.implicit_spawn_seconds` is defined:

<img width="493" alt="Screen Shot 2020-02-20 at 12 45 44" src="https://user-images.githubusercontent.com/151929/74931255-83aa2600-53df-11ea-9a25-5dcde8f7c5a6.png">

Default behavior is unchanged.