### PR TITLE
docs: use metachannel for faster environment solve

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,10 @@
 # if you change the dependencies of JupyterHub in the various `requirements.txt`
 name: jhub_docs
 channels:
-  - conda-forge
+  # use metachannel for faster solves / less memory on RTD
+  # which has memory issues with full conda-forge
+  # only need to list 'leaf' dependencies here
+  - https://metachannel.conda-forge.org/conda-forge/jupyterhub,sphinx,recommonmark
 dependencies:
 - pip
 - nodejs=12


### PR DESCRIPTION
rtd is having memory issues with conda-forge, which should hopefully be fixed by metachannel

this should also make things quicker for anyone