### PR TITLE
make spawner:server relationship explicitly one to one

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2019,7 +2019,7 @@ class JupyterHub(Application):
         for orm_server in db.query(orm.Server):
             orm_spawner = orm_server.spawner
             if not orm_spawner:
-                # sanity check for orphaned Server rows
+                # check for orphaned Server rows
                 # this shouldn't happen if we've got our sqlachemy right
                 if not orm_server.service:
                     self.log.warning("deleting orphaned server %s", orm_server)

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -634,7 +634,10 @@ def _expire_relationship(target, relationship_prop):
         return
     # many-to-many and one-to-many have a list of peers
     # many-to-one has only one
-    if relationship_prop.direction is interfaces.MANYTOONE:
+    if (
+        relationship_prop.direction is interfaces.MANYTOONE
+        or not relationship_prop.uselist
+    ):
         peers = [peers]
     for obj in peers:
         if inspect(obj).persistent:

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -26,6 +26,7 @@ from sqlalchemy import select
 from sqlalchemy import Table
 from sqlalchemy import Unicode
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import backref
 from sqlalchemy.orm import interfaces
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm import relationship
@@ -230,7 +231,12 @@ class Spawner(Base):
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
 
     server_id = Column(Integer, ForeignKey('servers.id', ondelete='SET NULL'))
-    server = relationship(Server, backref='spawner', cascade="all")
+    server = relationship(
+        Server,
+        backref=backref('spawner', uselist=False),
+        single_parent=True,
+        cascade="all, delete-orphan",
+    )
 
     state = Column(JSONDict)
     name = Column(Unicode(255))
@@ -282,7 +288,12 @@ class Service(Base):
 
     # service-specific interface
     _server_id = Column(Integer, ForeignKey('servers.id', ondelete='SET NULL'))
-    server = relationship(Server, backref='service', cascade='all')
+    server = relationship(
+        Server,
+        backref=backref('service', uselist=False),
+        single_parent=True,
+        cascade="all, delete-orphan",
+    )
     pid = Column(Integer)
 
     def new_api_token(self, token=None, **kwargs):


### PR DESCRIPTION
in #2936 I hadn't figured out how to make a backref not have a list on one side, but this is a 1:1 relationship. Turns out `uselist=False` is the way to tell it not to use a list.