### PR TITLE
[doc] Fix couple typos in the documentation

### DIFF
--- a/docs/source/contributing/tests.rst
+++ b/docs/source/contributing/tests.rst
@@ -64,5 +64,5 @@ Troubleshooting Test Failures
 All the tests are failing
 -------------------------
 
-Make sure you have completed all the steps in :ref:`contributing/setup` sucessfully, and
+Make sure you have completed all the steps in :ref:`contributing/setup` successfully, and
 can launch ``jupyterhub`` from the terminal.

--- a/docs/source/getting-started/security-basics.rst
+++ b/docs/source/getting-started/security-basics.rst
@@ -239,7 +239,7 @@ jupyterhub-session-id
 This is a random string, meaningless in itself, and the only cookie
 shared by the Hub and single-user servers.
 
-Its sole purpose is to to coordinate logout of the multiple OAuth cookies.
+Its sole purpose is to coordinate logout of the multiple OAuth cookies.
 
 This cookie is set to ``/`` so all endpoints can receive it, or clear it, etc.
 


### PR DESCRIPTION
Hi,

Was reading the security docs again in PyCharm when noticed it had found a typo there. So scanned the docs folder for more, and found just another one.

Cheers
Bruno