### PR TITLE
Keep the URL fragments after spawning an application

### DIFF
--- a/share/jupyterhub/static/js/not_running.js
+++ b/share/jupyterhub/static/js/not_running.js
@@ -1,0 +1,13 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+require(["jquery", "utils"], function($, utils) {
+  "use strict";
+
+  var hash = utils.parse_url(window.location.href).hash;
+  if (hash !== undefined && hash !== '') {
+      var el = $("#start");
+      var current_spawn_url = el.attr("href");
+      el.attr("href", current_spawn_url + hash);
+  }
+});

--- a/share/jupyterhub/templates/not_running.html
+++ b/share/jupyterhub/templates/not_running.html
@@ -63,4 +63,7 @@
   );
 </script>
 {% endif %}
+<script type="text/javascript">
+require(["not_running"]);
+</script>
 {% endblock script %}


### PR DESCRIPTION
Hi,

We are currently using JupyterHub to spawn a Python Tornado app, that uses JupyterHub auth classes and Vue.js for the user interface.

In Vue.js, normally you have two options, history mode where URL's that behave like ordinary URL's (i.e. `http://hub/user/account/workflows`) that requires extra web server configuration, and what they call the hash mode where URL's are handled by fragments (i.e. `http://hub/user/account/#/workflows`).

The issue is that when the spawned application goes offline for some reason, then the hub will display a message that allows the user to re-spawn the application. But the fragments are then ignored and the user is always redirected back to the main screen.

That means that if the user was browsing `http://hub/user/account/#/workflows/workflows-1/tree` and the application went down, re-spawning it would take the user to `http://hub/user/account/`, which is a bit inconvenient.

I wrote a quick fix, to use the URL hash (fragments) if available. It seems to work fine with the notebook, and also with our application. I wonder if someone here would be able to review and check if this is something that could be incorporated in the hub. I still haven't found a solution that doesn't require changing something at the hub/proxy level.

Thanks
Bruno

p.s.: I understand it's a very specific use case, and it would be fine if it was too risky to incorporate this change in the Hub :+1: 