### PR TITLE
Add trailing slash to server_name

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -398,7 +398,7 @@ class User:
         if not server_name:
             return self.url
         else:
-            return url_path_join(self.url, server_name)
+            return url_path_join(self.url, server_name) + '/'
 
     def progress_url(self, server_name=''):
         """API URL for progress endpoint for a server with a given name"""


### PR DESCRIPTION
Without this trailing '/', traefik-proxy doesn't know how to route to a named server.

As reported by https://github.com/jupyterhub/traefik-proxy/issues/91, traefik-proxy adds the routespec received from JH (that ends with a '/') to the routing table and routes properly to the named server only when the server_url ends with '/' as well.

I think CHP doesn't have this problem because when it builds its routing table it strips the trailing slashes. I believe that instead of making traefik-proxy do the same, since we're adding a trailing slash to the `server_url` for the default servers anyway, we should do the same for the named servers.