### PR TITLE
Merge pull request #2966 from mriedem/issues/2965-doc-user-options

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -802,6 +802,9 @@ definitions:
       state:
         type: object
         description: Arbitrary internal state from this server's spawner.  Only available on the hub's users list or get-user-by-name method, and only if a hub admin.  None otherwise.
+      user_options:
+        type: object
+        description: User specified options for the user's spawned instance of a single-user server.
   Group:
     type: object
     properties:


### PR DESCRIPTION
`APIHandler.server_model` unconditionally returns the Spawner's
`user_options` dict but it wasn't mentioned in the API reference
so it's added here. The description is taken from the docstring
on `Spawner.user_options`.

Closes #2965