### PR TITLE
[WIP] Start work on the DELETE /servers/{id} API

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -405,6 +405,16 @@ paths:
           description: The authenticated user's model is returned.
           schema:
             $ref: '#/definitions/User'
+  /servers:
+    get:
+      summary: List servers
+      responses:
+        '200':
+          description: The Hub's server list
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Server'
   /groups:
     get:
       summary: List groups
@@ -768,6 +778,9 @@ definitions:
   Server:
     type: object
     properties:
+      id:
+        type: integer
+        description: The unique internal ID of the server.
       name:
         type: string
         description: The server's name. The user's default server has an empty name ('')
@@ -787,6 +800,14 @@ definitions:
         description: |
           The URL where the server can be accessed
           (typically /user/:name/:server.name/).
+      user:
+        type: object
+        description: |
+          Contains information about the user that owns the server.
+          Only available on ``GET /servers``.
+          Includes fields:
+
+          - ``name``: The name of the user that owns the server.
       progress_url:
         type: string
         description: |

--- a/jupyterhub/apihandlers/__init__.py
+++ b/jupyterhub/apihandlers/__init__.py
@@ -2,10 +2,11 @@ from . import auth
 from . import groups
 from . import hub
 from . import proxy
+from . import servers
 from . import services
 from . import users
 from .base import *
 
 default_handlers = []
-for mod in (auth, hub, proxy, users, groups, services):
+for mod in (auth, hub, proxy, users, groups, services, servers):
     default_handlers.extend(mod.default_handlers)

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -133,6 +133,15 @@ class APIHandler(BaseHandler):
 
     def server_model(self, spawner, include_state=False):
         """Get the JSON model for a Spawner"""
+        # TODO(mriedem): Need to convert orm.Spawner to spawner.Spawner
+        # to use the `get_state` method, but how to do that conversion?
+        if hasattr(spawner, 'user') and hasattr(spawner.user, 'url'):
+            url = url_path_join(spawner.user.url, spawner.name, '/')
+        else:
+            url = None
+        progress_url = (
+            spawner._progress_url if hasattr(spawner, '_progress_url') else None
+        )
         return {
             'name': spawner.name,
             'last_activity': isoformat(spawner.orm_spawner.last_activity),
@@ -140,9 +149,9 @@ class APIHandler(BaseHandler):
             'pending': spawner.pending,
             'ready': spawner.ready,
             'state': spawner.get_state() if include_state else None,
-            'url': url_path_join(spawner.user.url, spawner.name, '/'),
+            'url': url,
             'user_options': spawner.user_options,
-            'progress_url': spawner._progress_url,
+            'progress_url': progress_url,
         }
 
     def token_model(self, token):

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -27,6 +27,15 @@ class ServerListAPIHandler(APIHandler):
 
 
 class ServerAPIHandler(APIHandler):
+    # FIXME(mriedem): This should be admin_or_self so non-admin users can delete their
+    # own servers just like in DELETE /users/{name}/servers/{server_name} but the only
+    # API that returns the server id is GET /servers which is an admin-only API so how
+    # would a non-admin get the server id? Do we need to modify the response to
+    # GET /user and GET /users/{name} to return the id of each server in the list?
+    # Maybe we just don't need this DELETE /servers/{id} API since GET /servers returns
+    # everything you need (user name and server name) to delete the server via
+    # DELETE /users/{name}/server/{server_name}. That would avoid the duplication below
+    # as well which would be good.
     @admin_only
     async def delete(self, id):
         spawner = self.find_spawner_by_id(id)

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -95,5 +95,5 @@ class ServerAPIHandler(APIHandler):
 
 default_handlers = [
     (r"/api/servers", ServerListAPIHandler),
-    (r"/api/users/([^/]+)", ServerAPIHandler),
+    (r"/api/servers/([^/]+)", ServerAPIHandler),
 ]

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -1,0 +1,27 @@
+"""Server handlers"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import json
+
+from .. import orm
+from ..utils import admin_only
+from .base import APIHandler
+
+
+class ServerListAPIHandler(APIHandler):
+    @admin_only
+    def get(self):
+        # TODO(mriedem): Should include_state be conditional on
+        # `spawner.active` like how `user_model` works for
+        # `GET /users`?
+        include_state = False
+        data = [
+            self.server_model(spawner, include_state=include_state)
+            for spawner in self.db.query(orm.Spawner)
+        ]
+        self.write(json.dumps(data))
+
+
+default_handlers = [
+    (r"/api/servers", ServerListAPIHandler),
+]

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -14,9 +14,11 @@ class ServerListAPIHandler(APIHandler):
         # TODO(mriedem): Should include_state be conditional on
         # `spawner.active` like how `user_model` works for
         # `GET /users`?
-        include_state = False
+        include_state = True
         data = [
-            self.server_model(spawner, include_state=include_state)
+            self.server_model(
+                spawner, include_state=include_state, include_user_and_id=True
+            )
             for spawner in self.db.query(orm.Spawner)
         ]
         self.write(json.dumps(data))

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of the Modified BSD License.
 import json
 
+from tornado import web
+
 from .. import orm
 from ..utils import admin_only
 from .base import APIHandler
@@ -24,6 +26,74 @@ class ServerListAPIHandler(APIHandler):
         self.write(json.dumps(data))
 
 
+class ServerAPIHandler(APIHandler):
+    @admin_only
+    async def delete(self, id):
+        spawner = self.find_spawner_by_id(id)
+        if not spawner:
+            raise web.HTTPError(404)
+
+        # TODO(mriedem): Rather than provide a body to the DELETE /servers/{id} API
+        # like DELETE /users/{name}/servers/{server_name} to toggle whether or not
+        # to just stop the server or delete it, should we instead have a
+        # POST /servers/{id}/stop API for stopping a server and leave
+        # DELETE /servers/{id} to actually deleting (not stopping) a server/spawner?
+        options = self.get_json_body() or {}
+        remove = options.get('remove', True)
+        server_name = spawner.name
+
+        if remove and not server_name:
+            raise web.HTTPError(400, "Cannot delete the default server")
+
+        # TODO(mriedem): The rest of this below is copied from
+        # UserServerAPIHandler.delete and we should figure out a way to make this
+        # common code (a mixin, parent or utils method?).
+        def _remove_spawner(f=None):
+            """Removes the spawner from the database.
+
+            :param f: When used as a callback this is a Future. If the Future failed
+            with an exception then the spawner is not deleted.
+            """
+            if f and f.exception():
+                return
+            self.log.info("Deleting spawner %s", spawner._log_name)
+            self.db.delete(spawner.orm_spawner)
+            self.users[spawner.user_id].spawners.pop(server_name, None)
+            self.db.commit()
+
+        if spawner.pending == 'stop':
+            self.log.debug("%s already stopping", spawner._log_name)
+            self.set_header('Content-Type', 'text/plain')
+            self.set_status(202)
+            if remove:
+                spawner._stop_future.add_done_callback(_remove_spawner)
+            return
+
+        if spawner.pending:
+            raise web.HTTPError(
+                400,  # TODO(mriedem): Seems this should be a 409.
+                "%s is pending %s, please wait" % (spawner._log_name, spawner.pending),
+            )
+
+        stop_future = None
+        if spawner.ready:
+            # include notify, so that a server that died is noticed immediately
+            status = await spawner.poll_and_notify()
+            if status is None:
+                stop_future = await self.stop_single_user(spawner.user, server_name)
+
+        if remove:
+            if stop_future:
+                stop_future.add_done_callback(_remove_spawner)
+            else:
+                _remove_spawner()
+
+        status = 202 if spawner._stop_pending else 204
+        self.set_header('Content-Type', 'text/plain')
+        self.set_status(status)
+
+
 default_handlers = [
     (r"/api/servers", ServerListAPIHandler),
+    (r"/api/users/([^/]+)", ServerAPIHandler),
 ]

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -45,6 +45,7 @@ from ..metrics import ServerSpawnStatus
 from ..metrics import ServerStopStatus
 from ..objects import Server
 from ..spawner import LocalProcessSpawner
+from ..spawner import Spawner
 from ..user import User
 from ..utils import get_accepted_mimetype
 from ..utils import maybe_future
@@ -448,6 +449,16 @@ class BaseHandler(RequestHandler):
         """
         orm_user = orm.User.find(db=self.db, name=name)
         return self._user_from_orm(orm_user)
+
+    def find_spawner_by_id(self, id):
+        """Get a Spawner by ID.
+
+        :param id: The ID of the `spawners` table record.
+        :return: None if no record was found by ID, else a spawn.Spawner object.
+        """
+        orm_spawner = orm.Spawner.find_by_id(self.db, id)
+        if orm_spawner:
+            return self.users[orm_spawner.user_id].spawners[orm_spawner.name]
 
     def user_from_username(self, username):
         """Get User for username, creating if it doesn't exist"""

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -220,6 +220,15 @@ class User(Base):
         """
         return db.query(cls).filter(cls.name == name).first()
 
+    @classmethod
+    def find_by_id(cls, db, id):
+        """Find a user by id.
+
+        :param id: The id of the user record.
+        :return: None if not found.
+        """
+        return db.query(cls).filter(cls.id == id).first()
+
 
 class Spawner(Base):
     """"State about a Spawner"""

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -259,6 +259,15 @@ class Spawner(Base):
     def orm_spawner(self):
         return self
 
+    @classmethod
+    def find_by_id(cls, db, id):
+        """Find a spawner by id.
+
+        :param id: The id of the spawner record.
+        :return: None if not found.
+        """
+        return db.query(cls).filter(cls.id == id).first()
+
 
 class Service(Base):
     """A service run with JupyterHub

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -31,6 +31,7 @@ from traitlets import Instance
 from traitlets import Integer
 from traitlets import List
 from traitlets import observe
+from traitlets import TraitError
 from traitlets import Unicode
 from traitlets import Union
 from traitlets import validate
@@ -211,6 +212,19 @@ class Spawner(LoggingConfigurable):
         if self.orm_spawner:
             return self.orm_spawner.name
         return ''
+
+    # pass getattr to ORM spawner
+    def __getattr__(self, attr):
+        # orm_spawner is by default an Any traitlet and might not have a
+        # default value for the attribute requested so handle TraitError
+        # as a normal AttributeError.
+        try:
+            if hasattr(self.orm_spawner, attr):
+                return getattr(self.orm_spawner, attr)
+            else:
+                raise AttributeError(attr)
+        except TraitError:
+            raise AttributeError(attr)
 
     internal_ssl = Bool(False)
     internal_trust_bundles = Dict()

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -114,6 +114,23 @@ async def test_referer_check(app):
 # ----------------
 
 
+def fill_server(model):
+    """Fill a default server model
+
+    Any unspecified fields will be filled with the defaults
+    """
+    model.setdefault('name', '')
+    model.setdefault('ready', False)
+    model.setdefault('pending', None)
+    model.setdefault('url', None)
+    model.setdefault('progress_url', None)
+    model.setdefault('started', None)
+    model.setdefault('last_activity', None)
+    model.setdefault('state', None)
+    model.setdefault('user_options', None)
+    return model
+
+
 @mark.server
 async def test_get_servers(app):
     """
@@ -125,20 +142,10 @@ async def test_get_servers(app):
 
     servers = sorted(r.json(), key=lambda d: d['name'])
     servers = [normalize_server(server) for server in servers]
+    # Note that there are two servers to start because the `app` fixture
+    # creates a user named "user" and test_referer_check creates an admin user.
     # TODO(mriedem): Use something like a fill_server here.
-    assert servers == [
-        {
-            'name': '',
-            'last_activity': None,
-            'started': None,
-            'pending': None,
-            'ready': False,
-            'state': None,
-            'url': None,
-            'user_options': None,
-            'progress_url': None,
-        }
-    ]
+    assert servers == [fill_server({})] * 2
 
     r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
     assert r.status_code == 403
@@ -224,7 +231,7 @@ async def test_get_users(app):
     users = [normalize_user(u) for u in users]
     assert users == [
         fill_user({'name': 'admin', 'admin': True}),
-        fill_user({'name': 'user', 'admin': False, 'last_activity': None}),
+        fill_user({'name': 'user', 'admin': False}),
     ]
 
     r = await api_request(app, 'users', headers=auth_header(db, 'user'))

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -124,6 +124,27 @@ def normalize_timestamp(ts):
     return re.sub(r'\d(\.\d+)?', '0', ts)
 
 
+def normalize_server(server):
+    """Normalize a server model for comparison
+
+    smooths out a server model with things like timestamps
+    for easier comparison
+    """
+    for key in ('started', 'last_activity'):
+        server[key] = normalize_timestamp(server[key])
+    # TODO(mriedem): Remove this conditional when GET /servers is always
+    # returning a progress_url.
+    if server['progress_url']:
+        server['progress_url'] = re.sub(
+            r'.*/hub/api', 'PREFIX/hub/api', server['progress_url']
+        )
+    if isinstance(server['state'], dict) and isinstance(
+        server['state'].get('pid', None), int
+    ):
+        server['state']['pid'] = 0
+    return server
+
+
 def normalize_user(user):
     """Normalize a user model for comparison
 
@@ -134,15 +155,7 @@ def normalize_user(user):
         user[key] = normalize_timestamp(user[key])
     if 'servers' in user:
         for server in user['servers'].values():
-            for key in ('started', 'last_activity'):
-                server[key] = normalize_timestamp(server[key])
-            server['progress_url'] = re.sub(
-                r'.*/hub/api', 'PREFIX/hub/api', server['progress_url']
-            )
-            if isinstance(server['state'], dict) and isinstance(
-                server['state'].get('pid', None), int
-            ):
-                server['state']['pid'] = 0
+            normalize_server(server)
     return user
 
 
@@ -1339,6 +1352,41 @@ async def test_token_list(app, as_user, for_user, status):
         r.raise_for_status()
         reply = r.json()
         assert normalize_token(reply) == normalize_token(token)
+
+
+# ----------------
+# Server API tests
+# ----------------
+
+
+@mark.server
+async def test_get_servers(app):
+    """
+    Basic test for GET /servers
+    """
+    db = app.db
+    r = await api_request(app, 'servers')
+    assert r.status_code == 200
+
+    servers = sorted(r.json(), key=lambda d: d['name'])
+    servers = [normalize_server(server) for server in servers]
+    # TODO(mriedem): Use something like a fill_server here.
+    assert servers == [
+        {
+            'name': '',
+            'last_activity': None,
+            'started': None,
+            'pending': None,
+            'ready': False,
+            'state': None,
+            'url': None,
+            'user_options': None,
+            'progress_url': None,
+        }
+    ]
+
+    r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
+    assert r.status_code == 403
 
 
 # ---------------

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -153,6 +153,29 @@ async def test_get_servers(app):
     assert r.status_code == 403
 
 
+@mark.server
+async def test_delete_server_no_auth(app):
+    """
+    Negative test to make sure DELETE /servers/{id} enforces admin auth.
+    """
+    r = await api_request(app, 'servers', '99999', method='delete', noauth=True)
+    assert r.status_code == 404  # FIXME(mriedem): Why isn't this a 403?
+
+
+@mark.server
+async def test_delete_server_not_found(app):
+    """
+    Negative test to delete a server which does not exist results in a 404 response.
+    """
+    r = await api_request(app, 'servers', '99999', method='delete')
+    assert r.status_code == 404
+
+
+# TODO(mriedem): More server delete negative tests for things like:
+# - trying to delete the default server ('')
+# - trying to delete a pending server (stopping and spawning)
+
+
 # --------------
 # User API tests
 # --------------

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -171,10 +171,6 @@ async def test_delete_server_not_found(app):
     assert r.status_code == 404
 
 
-# TODO(mriedem): More server delete negative tests for things like:
-# - trying to delete a pending server (stopping and spawning)
-
-
 @mark.server
 async def test_delete_default_server_fails(app):
     """

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -109,6 +109,41 @@ async def test_referer_check(app):
     assert r.status_code == 200
 
 
+# ----------------
+# Server API tests
+# ----------------
+
+
+@mark.server
+async def test_get_servers(app):
+    """
+    Basic test for GET /servers. Run this early for predictable results.
+    """
+    db = app.db
+    r = await api_request(app, 'servers')
+    assert r.status_code == 200
+
+    servers = sorted(r.json(), key=lambda d: d['name'])
+    servers = [normalize_server(server) for server in servers]
+    # TODO(mriedem): Use something like a fill_server here.
+    assert servers == [
+        {
+            'name': '',
+            'last_activity': None,
+            'started': None,
+            'pending': None,
+            'ready': False,
+            'state': None,
+            'url': None,
+            'user_options': None,
+            'progress_url': None,
+        }
+    ]
+
+    r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
+    assert r.status_code == 403
+
+
 # --------------
 # User API tests
 # --------------
@@ -1352,41 +1387,6 @@ async def test_token_list(app, as_user, for_user, status):
         r.raise_for_status()
         reply = r.json()
         assert normalize_token(reply) == normalize_token(token)
-
-
-# ----------------
-# Server API tests
-# ----------------
-
-
-@mark.server
-async def test_get_servers(app):
-    """
-    Basic test for GET /servers
-    """
-    db = app.db
-    r = await api_request(app, 'servers')
-    assert r.status_code == 200
-
-    servers = sorted(r.json(), key=lambda d: d['name'])
-    servers = [normalize_server(server) for server in servers]
-    # TODO(mriedem): Use something like a fill_server here.
-    assert servers == [
-        {
-            'name': '',
-            'last_activity': None,
-            'started': None,
-            'pending': None,
-            'ready': False,
-            'state': None,
-            'url': None,
-            'user_options': None,
-            'progress_url': None,
-        }
-    ]
-
-    r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
-    assert r.status_code == 403
 
 
 # ---------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ markers =
     services: mark as a services test
     user: mark as a test for a user
     slow: mark a test as slow
+    server: mark as a test for a server


### PR DESCRIPTION
This starts the `DELETE /servers/{id}` API based on the
existing `DELETE /users/{name}/servers/{server_name}` API.
TODOs are inline for testing and DRYing up some of that
code, plus docs are obviously needed.

There is also a question of whether or not we want to do
a separate route to stop a server versus delete it to keep
this code a bit less complicated.

Part of issue #2954
