### PR TITLE
Change cull_idle to use GET /servers if not culling users

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -405,6 +405,16 @@ paths:
           description: The authenticated user's model is returned.
           schema:
             $ref: '#/definitions/User'
+  /servers:
+    get:
+      summary: List servers
+      responses:
+        '200':
+          description: The Hub's server list
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Server'
   /groups:
     get:
       summary: List groups
@@ -768,6 +778,9 @@ definitions:
   Server:
     type: object
     properties:
+      id:
+        type: integer
+        description: The unique internal ID of the server.
       name:
         type: string
         description: The server's name. The user's default server has an empty name ('')
@@ -787,6 +800,14 @@ definitions:
         description: |
           The URL where the server can be accessed
           (typically /user/:name/:server.name/).
+      user:
+        type: object
+        description: |
+          Contains information about the user that owns the server.
+          Only available on ``GET /servers``.
+          Includes fields:
+
+          - ``name``: The name of the user that owns the server.
       progress_url:
         type: string
         description: |

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -780,7 +780,7 @@ definitions:
     properties:
       id:
         type: integer
-        description: The unique internal ID of the server.
+        description: The unique internal ID of the server. Only available on ``GET /servers``.
       name:
         type: string
         description: The server's name. The user's default server has an empty name ('')

--- a/jupyterhub/apihandlers/__init__.py
+++ b/jupyterhub/apihandlers/__init__.py
@@ -2,10 +2,11 @@ from . import auth
 from . import groups
 from . import hub
 from . import proxy
+from . import servers
 from . import services
 from . import users
 from .base import *
 
 default_handlers = []
-for mod in (auth, hub, proxy, users, groups, services):
+for mod in (auth, hub, proxy, users, groups, services, servers):
     default_handlers.extend(mod.default_handlers)

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -133,6 +133,15 @@ class APIHandler(BaseHandler):
 
     def server_model(self, spawner, include_state=False):
         """Get the JSON model for a Spawner"""
+        # TODO(mriedem): Need to convert orm.Spawner to spawner.Spawner
+        # to use the `get_state` method, but how to do that conversion?
+        if hasattr(spawner, 'user') and hasattr(spawner.user, 'url'):
+            url = url_path_join(spawner.user.url, spawner.name, '/')
+        else:
+            url = None
+        progress_url = (
+            spawner._progress_url if hasattr(spawner, '_progress_url') else None
+        )
         return {
             'name': spawner.name,
             'last_activity': isoformat(spawner.orm_spawner.last_activity),
@@ -140,9 +149,9 @@ class APIHandler(BaseHandler):
             'pending': spawner.pending,
             'ready': spawner.ready,
             'state': spawner.get_state() if include_state else None,
-            'url': url_path_join(spawner.user.url, spawner.name, '/'),
+            'url': url,
             'user_options': spawner.user_options,
-            'progress_url': spawner._progress_url,
+            'progress_url': progress_url,
         }
 
     def token_model(self, token):

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -135,16 +135,12 @@ class APIHandler(BaseHandler):
     def server_model(self, spawner, include_state=False, include_user_and_id=False):
         """Get the JSON model for a Spawner"""
         if isinstance(spawner, orm.Spawner):
-            # TODO(mriedem): Would be nice to join the user field from
-            # the Spawner ORM object when we fetch it from the DB so we don't
-            # need the roundtrip.
-            orm_user = orm.User.find_by_id(self.db, spawner.user_id)
-            user = self._user_from_orm(orm_user)
+            user = self._user_from_orm(spawner.user)
             spawner = spawner_obj.Spawner(orm_spawner=spawner, user=user)
         server = {
             'name': spawner.name,
-            'last_activity': isoformat(spawner.orm_spawner.last_activity),
-            'started': isoformat(spawner.orm_spawner.started),
+            'last_activity': isoformat(spawner.last_activity),
+            'started': isoformat(spawner.started),
             'pending': spawner.pending,
             'ready': spawner.ready,
             'state': spawner.get_state() if include_state else None,

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -1,0 +1,27 @@
+"""Server handlers"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import json
+
+from .. import orm
+from ..utils import admin_only
+from .base import APIHandler
+
+
+class ServerListAPIHandler(APIHandler):
+    @admin_only
+    def get(self):
+        # TODO(mriedem): Should include_state be conditional on
+        # `spawner.active` like how `user_model` works for
+        # `GET /users`?
+        include_state = False
+        data = [
+            self.server_model(spawner, include_state=include_state)
+            for spawner in self.db.query(orm.Spawner)
+        ]
+        self.write(json.dumps(data))
+
+
+default_handlers = [
+    (r"/api/servers", ServerListAPIHandler),
+]

--- a/jupyterhub/apihandlers/servers.py
+++ b/jupyterhub/apihandlers/servers.py
@@ -14,9 +14,11 @@ class ServerListAPIHandler(APIHandler):
         # TODO(mriedem): Should include_state be conditional on
         # `spawner.active` like how `user_model` works for
         # `GET /users`?
-        include_state = False
+        include_state = True
         data = [
-            self.server_model(spawner, include_state=include_state)
+            self.server_model(
+                spawner, include_state=include_state, include_user_and_id=True
+            )
             for spawner in self.db.query(orm.Spawner)
         ]
         self.write(json.dumps(data))

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -220,6 +220,15 @@ class User(Base):
         """
         return db.query(cls).filter(cls.name == name).first()
 
+    @classmethod
+    def find_by_id(cls, db, id):
+        """Find a user by id.
+
+        :param id: The id of the user record.
+        :return: None if not found.
+        """
+        return db.query(cls).filter(cls.id == id).first()
+
 
 class Spawner(Base):
     """"State about a Spawner"""

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -220,15 +220,6 @@ class User(Base):
         """
         return db.query(cls).filter(cls.name == name).first()
 
-    @classmethod
-    def find_by_id(cls, db, id):
-        """Find a user by id.
-
-        :param id: The id of the user record.
-        :return: None if not found.
-        """
-        return db.query(cls).filter(cls.id == id).first()
-
 
 class Spawner(Base):
     """"State about a Spawner"""

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -31,6 +31,7 @@ from traitlets import Instance
 from traitlets import Integer
 from traitlets import List
 from traitlets import observe
+from traitlets import TraitError
 from traitlets import Unicode
 from traitlets import Union
 from traitlets import validate
@@ -211,6 +212,19 @@ class Spawner(LoggingConfigurable):
         if self.orm_spawner:
             return self.orm_spawner.name
         return ''
+
+    # pass getattr to ORM spawner
+    def __getattr__(self, attr):
+        # orm_spawner is by default an Any traitlet and might not have a
+        # default value for the attribute requested so handle TraitError
+        # as a normal AttributeError.
+        try:
+            if hasattr(self.orm_spawner, attr):
+                return getattr(self.orm_spawner, attr)
+            else:
+                raise AttributeError(attr)
+        except TraitError:
+            raise AttributeError(attr)
 
     internal_ssl = Bool(False)
     internal_trust_bundles = Dict()

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -114,6 +114,23 @@ async def test_referer_check(app):
 # ----------------
 
 
+def fill_server(model):
+    """Fill a default server model
+
+    Any unspecified fields will be filled with the defaults
+    """
+    model.setdefault('name', '')
+    model.setdefault('ready', False)
+    model.setdefault('pending', None)
+    model.setdefault('url', None)
+    model.setdefault('progress_url', None)
+    model.setdefault('started', None)
+    model.setdefault('last_activity', None)
+    model.setdefault('state', None)
+    model.setdefault('user_options', None)
+    return model
+
+
 @mark.server
 async def test_get_servers(app):
     """
@@ -125,20 +142,10 @@ async def test_get_servers(app):
 
     servers = sorted(r.json(), key=lambda d: d['name'])
     servers = [normalize_server(server) for server in servers]
+    # Note that there are two servers to start because the `app` fixture
+    # creates a user named "user" and test_referer_check creates an admin user.
     # TODO(mriedem): Use something like a fill_server here.
-    assert servers == [
-        {
-            'name': '',
-            'last_activity': None,
-            'started': None,
-            'pending': None,
-            'ready': False,
-            'state': None,
-            'url': None,
-            'user_options': None,
-            'progress_url': None,
-        }
-    ]
+    assert servers == [fill_server({})] * 2
 
     r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
     assert r.status_code == 403
@@ -224,7 +231,7 @@ async def test_get_users(app):
     users = [normalize_user(u) for u in users]
     assert users == [
         fill_user({'name': 'admin', 'admin': True}),
-        fill_user({'name': 'user', 'admin': False, 'last_activity': None}),
+        fill_user({'name': 'user', 'admin': False}),
     ]
 
     r = await api_request(app, 'users', headers=auth_header(db, 'user'))

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -124,6 +124,27 @@ def normalize_timestamp(ts):
     return re.sub(r'\d(\.\d+)?', '0', ts)
 
 
+def normalize_server(server):
+    """Normalize a server model for comparison
+
+    smooths out a server model with things like timestamps
+    for easier comparison
+    """
+    for key in ('started', 'last_activity'):
+        server[key] = normalize_timestamp(server[key])
+    # TODO(mriedem): Remove this conditional when GET /servers is always
+    # returning a progress_url.
+    if server['progress_url']:
+        server['progress_url'] = re.sub(
+            r'.*/hub/api', 'PREFIX/hub/api', server['progress_url']
+        )
+    if isinstance(server['state'], dict) and isinstance(
+        server['state'].get('pid', None), int
+    ):
+        server['state']['pid'] = 0
+    return server
+
+
 def normalize_user(user):
     """Normalize a user model for comparison
 
@@ -134,15 +155,7 @@ def normalize_user(user):
         user[key] = normalize_timestamp(user[key])
     if 'servers' in user:
         for server in user['servers'].values():
-            for key in ('started', 'last_activity'):
-                server[key] = normalize_timestamp(server[key])
-            server['progress_url'] = re.sub(
-                r'.*/hub/api', 'PREFIX/hub/api', server['progress_url']
-            )
-            if isinstance(server['state'], dict) and isinstance(
-                server['state'].get('pid', None), int
-            ):
-                server['state']['pid'] = 0
+            normalize_server(server)
     return user
 
 
@@ -1339,6 +1352,41 @@ async def test_token_list(app, as_user, for_user, status):
         r.raise_for_status()
         reply = r.json()
         assert normalize_token(reply) == normalize_token(token)
+
+
+# ----------------
+# Server API tests
+# ----------------
+
+
+@mark.server
+async def test_get_servers(app):
+    """
+    Basic test for GET /servers
+    """
+    db = app.db
+    r = await api_request(app, 'servers')
+    assert r.status_code == 200
+
+    servers = sorted(r.json(), key=lambda d: d['name'])
+    servers = [normalize_server(server) for server in servers]
+    # TODO(mriedem): Use something like a fill_server here.
+    assert servers == [
+        {
+            'name': '',
+            'last_activity': None,
+            'started': None,
+            'pending': None,
+            'ready': False,
+            'state': None,
+            'url': None,
+            'user_options': None,
+            'progress_url': None,
+        }
+    ]
+
+    r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
+    assert r.status_code == 403
 
 
 # ---------------

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -109,6 +109,41 @@ async def test_referer_check(app):
     assert r.status_code == 200
 
 
+# ----------------
+# Server API tests
+# ----------------
+
+
+@mark.server
+async def test_get_servers(app):
+    """
+    Basic test for GET /servers. Run this early for predictable results.
+    """
+    db = app.db
+    r = await api_request(app, 'servers')
+    assert r.status_code == 200
+
+    servers = sorted(r.json(), key=lambda d: d['name'])
+    servers = [normalize_server(server) for server in servers]
+    # TODO(mriedem): Use something like a fill_server here.
+    assert servers == [
+        {
+            'name': '',
+            'last_activity': None,
+            'started': None,
+            'pending': None,
+            'ready': False,
+            'state': None,
+            'url': None,
+            'user_options': None,
+            'progress_url': None,
+        }
+    ]
+
+    r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
+    assert r.status_code == 403
+
+
 # --------------
 # User API tests
 # --------------
@@ -1352,41 +1387,6 @@ async def test_token_list(app, as_user, for_user, status):
         r.raise_for_status()
         reply = r.json()
         assert normalize_token(reply) == normalize_token(token)
-
-
-# ----------------
-# Server API tests
-# ----------------
-
-
-@mark.server
-async def test_get_servers(app):
-    """
-    Basic test for GET /servers
-    """
-    db = app.db
-    r = await api_request(app, 'servers')
-    assert r.status_code == 200
-
-    servers = sorted(r.json(), key=lambda d: d['name'])
-    servers = [normalize_server(server) for server in servers]
-    # TODO(mriedem): Use something like a fill_server here.
-    assert servers == [
-        {
-            'name': '',
-            'last_activity': None,
-            'started': None,
-            'pending': None,
-            'ready': False,
-            'state': None,
-            'url': None,
-            'user_options': None,
-            'progress_url': None,
-        }
-    ]
-
-    r = await api_request(app, 'servers', headers=auth_header(db, 'user'))
-    assert r.status_code == 403
 
 
 # ---------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ markers =
     services: mark as a services test
     user: mark as a test for a user
     slow: mark a test as slow
+    server: mark as a test for a server


### PR DESCRIPTION
This changes the `cull_idle_servers` script such that if users
are not being culled (the default) and the `GET /servers` API
is available it uses that to get servers directly rather than
go through `GET /users` which could have a lot more records if
servers are being culled but users are not.

In our deployment we have ~50K users but only a couple hundred
servers and since `cull_idle_servers` runs on startup it makes
restarting our single jupyterhub pod instance quite slow:

```
[I 2020-02-27 13:32:07.798 JupyterHub log:174] 200 GET /hub/api/users (cull-idle@127.0.0.1) 1222100.09ms
```

There is a bit of refactoring in this change to have consistent
"log names" and to be graceful about `GET /servers` not being
available.

Closes issue #2954 