### PR TITLE
Merge pull request #2971 from mriedem/issues/2970-singleuser-version-logging

### DIFF
--- a/jupyterhub/tests/test_version.py
+++ b/jupyterhub/tests/test_version.py
@@ -4,6 +4,11 @@ import logging
 import pytest
 
 from .._version import _check_version
+from .._version import reset_globals
+
+
+def setup_function(function):
+    reset_globals()
 
 
 @pytest.mark.parametrize(
@@ -25,3 +30,17 @@ def test_check_version(hub_version, singleuser_version, log_level, msg, caplog):
     record = caplog.records[0]
     assert record.levelno == log_level
     assert msg in record.getMessage()
+
+
+def test_check_version_singleton(caplog):
+    """Tests that minor version difference logging is only logged once."""
+    # Run test_check_version twice which will assert that the warning is only logged
+    # once.
+    for x in range(2):
+        test_check_version(
+            '1.2.0',
+            '1.1.0',
+            logging.WARNING,
+            'This could cause failure to authenticate',
+            caplog,
+        )

--- a/jupyterhub/tests/test_version.py
+++ b/jupyterhub/tests/test_version.py
@@ -44,3 +44,13 @@ def test_check_version_singleton(caplog):
             'This could cause failure to authenticate',
             caplog,
         )
+    # Run it again with a different singleuser_version to make sure that is logged as
+    # a warning.
+    caplog.clear()
+    test_check_version(
+        '1.2.0',
+        '1.1.1',
+        logging.WARNING,
+        'This could cause failure to authenticate',
+        caplog,
+    )


### PR DESCRIPTION
If your jupyterhub and jupyterhub-singleuser instances
are running at different minor or greater versions a
warning gets logged per active server which can be a lot
when you have hundreds of active servers.

This adds a flag to that version mismatch logging logic
such that the warning is only logged once per hub/singleuser
per restart of the hub server.

Closes #2970