### PR TITLE
Support JupyterLab with LocalSpawner

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -38,8 +38,12 @@ from traitlets import (
     TraitError,
 )
 
+try:
+    from jupyterlab.labapp import LabApp as App
+except ImportError:
+    from notebook.notebookapp import NotebookApp as App
+
 from notebook.notebookapp import (
-    NotebookApp,
     aliases as notebook_aliases,
     flags as notebook_flags,
 )
@@ -216,7 +220,7 @@ def _exclude_home(path_list):
             yield p
 
 
-class SingleUserNotebookApp(NotebookApp):
+class SingleUserNotebookApp(App):
     """A Subclass of the regular NotebookApp that is aware of the parent multiuser context."""
 
     description = dedent(
@@ -230,7 +234,7 @@ class SingleUserNotebookApp(NotebookApp):
     examples = ""
     subcommands = {}
     version = __version__
-    classes = NotebookApp.classes + [HubOAuth]
+    classes = App.classes + [HubOAuth]
 
     # disable single-user app's localhost checking
     allow_remote_access = True


### PR DESCRIPTION
Some users want to get jupyterlab by default and the recommended way is [documented here](https://jupyterlab.readthedocs.io/en/stable/user/jupyterhub.html) with `c.Spawner.default_url = '/lab'`.

This works fine for e.g. `DockerSpawner` but I have found it failing for the basic `LocalSpawner`. When I set c.Spawner.default_url = '/lab' with `LocalSpawner`, the notebook process is launched but return a `404` on the `lab` url. Then manually changing to `tree` makes it work and the classic notebook is shown.

Looking at the code, this sound logical as the `singleuser.py` contains `class SingleUserNotebookApp(NotebookApp)` which launches a classic notebook, and not a jupyterlab.

This PR address this with a simple change `class SingleUserNotebookApp(LabApp)` - The rest of the  `singleuser.py` remains unchanged and still uses the NotebookApp nomenclature.

I have found this change to make the jlab/localspawner tandem work.