### PR TITLE
Spawn with options passed in query arguments to /spawn

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -384,6 +384,37 @@ class Spawner(LoggingConfigurable):
         """
         return form_data
 
+    def options_from_query(self, query_data):
+        """Interpret query arguments passed to /spawn
+
+        Query arguments will always arrive as a dict of unicode strings.
+        Override this function to understand single-values, numbers, etc.
+
+        By default, options_from_form is called from this function. You can however override
+        this function if you need to process the query arguments differently.
+
+        This should coerce form data into the structure expected by self.user_options,
+        which must be a dict, and should be JSON-serializeable,
+        though it can contain bytes in addition to standard JSON data types.
+
+        This method should not have any side effects.
+        Any handling of `user_options` should be done in `.start()`
+        to ensure consistent behavior across servers
+        spawned via the API and form submission page.
+
+        Instances will receive this data on self.user_options, after passing through this function,
+        prior to `Spawner.start`.
+
+        .. versionadded:: 1.2
+            user_options are persisted in the JupyterHub database to be reused
+            on subsequent spawns if no options are given.
+            user_options is serialized to JSON as part of this persistence
+            (with additional support for bytes in case of uploaded file data),
+            and any non-bytes non-jsonable values will be replaced with None
+            if the user_options are re-used.
+        """
+        return self.options_from_form(query_data)
+
     user_options = Dict(
         help="""
         Dict of user specified options for the user's spawned instance of a single-user server.

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -173,6 +173,9 @@ class FormSpawner(MockSpawner):
             options['energy'] = form_data['energy'][0]
         if 'hello_file' in form_data:
             options['hello'] = form_data['hello_file'][0]
+
+        if 'illegal_argument' in form_data:
+            raise ValueError("You are not allowed to specify 'illegal_argument'")
         return options
 
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -277,6 +277,25 @@ async def test_spawn_with_query_arguments(app):
         }
 
 
+async def test_spawn_with_query_arguments_error(app):
+    with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
+        base_url = ujoin(public_host(app), app.hub.base_url)
+        cookies = await app.login_user('jones')
+        orm_u = orm.User.find(app.db, 'jones')
+        u = app.users[orm_u]
+        await u.stop()
+        next_url = ujoin(app.base_url, 'user/jones/tree')
+        r = await async_requests.get(
+            url_concat(
+                ujoin(base_url, 'spawn'),
+                {'next': next_url, 'energy': '510keV', 'illegal_argument': '42'},
+            ),
+            cookies=cookies,
+        )
+        r.raise_for_status()
+        assert "You are not allowed to specify " in r.text
+
+
 async def test_spawn_form(app):
     with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
         base_url = ujoin(public_host(app), app.hub.base_url)


### PR DESCRIPTION
Currently it is only possible to pass spawn parameters via a POST-request to `/spawn` . As we want to support nbgitpuller-links, I expanded the support for spawn parameters to the GET-request of /spawn.

I also introduced an extra function `Spawner.options_from_query` to process these query parameters. However, this function is implemented to be optional: if it is not defined, it will fallback to the `Spawner.options_from_form` function.

This pull request makes it possible to create links that spawn Jupyter instances with a certain configuration, and that then use the `/user-redirect/` functionality to do something on the Jupyter notebook instance (for example: execute nbgitpuller)

Example link: https://jupyterhub.example.com/devhub/hub/spawn?project=testproj&docker_image=jupyter%2Ftensorflow-notebook%3Alatest&nprocs=1&ngpus=0&memory=2048&next=%2Fdevhub%2Fhub%2Fuser-redirect%2Fgit-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252FRajawat23%252FRL_Lab