### PR TITLE
Fix user_row endblock in admin template

### DIFF
--- a/share/jupyterhub/templates/admin.html
+++ b/share/jupyterhub/templates/admin.html
@@ -96,8 +96,8 @@
           <a role="button" class="delete-server btn btn-xs btn-warning">delete server</a>
         {%- endif -%}
       </td>
-      </tr>
       {% endblock user_row %}
+      </tr>
       {% endfor %}
       {% endfor %}
   </tbody>


### PR DESCRIPTION
It looks like the `user_row` block was ended right after the `</tr>` element, while it is defined right after the corresponding `<tr>` element above:

https://github.com/jupyterhub/jupyterhub/blob/1f515464fe2edf5d9d8a7617c22ebe67002e0ba0/share/jupyterhub/templates/admin.html#L43-L46

This came up when trying to extend the admin template to add extra information to the user row.