### PR TITLE
Fix docs CI test failure: duplicate object description

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,9 @@
 -r ../requirements.txt
 
 alabaster_jupyterhub
-autodoc-traits
+# Temporary fix of #3021. Revert back to released autodoc-traits when
+# 0.1.0 released.
+https://github.com/jupyterhub/autodoc-traits/archive/75885ee24636efbfebfceed1043459715049cd84.zip
 pydata-sphinx-theme
 recommonmark>=0.6
 sphinx-copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ extensions = [
     'autodoc_traits',
     'sphinx_copybutton',
     'sphinx-jsonschema',
+    'recommonmark',
 ]
 
 templates_path = ['_templates']
@@ -65,8 +66,6 @@ def setup(app):
     app.add_css_file('custom.css')
     app.add_transform(AutoStructify)
 
-
-source_parsers = {'.md': 'recommonmark.parser.CommonMarkParser'}
 
 source_suffix = ['.rst', '.md']
 # source_encoding = 'utf-8-sig'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ from recommonmark.transform import AutoStructify
 
 def setup(app):
     app.add_config_value('recommonmark_config', {'enable_eval_rst': True}, True)
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')
     app.add_transform(AutoStructify)
 
 


### PR DESCRIPTION
We've been seeing this warning in docs build:
```
Warning, treated as error:
/l/data/git/jupyterhub/jupyterhub/auth.py:docstring of jupyterhub.auth.Authenticator.admin_users:1:duplicate object description of jupyterhub.auth.Authenticator.admin_users, other instance in api/auth, use :noindex: for one of
 them
```

Basic discussion is in #2726.  The problem seems to comes from autodocs-traits: https://github.com/jupyterhub/autodoc-traits/pull/1

This patches requiremens.txt to fix it as a demo, then tries to fix some of the actual errors.  But... it quickly turns into what seems to a large game of fixing many different errors, it seems most of them are at the interface of rst/md: some of the worst are caused by code blocks in markdown, some of which evaluate rst.

I'm pushing this now for others to explore, but not everything is fixed yet.  Anyone, feel free to push to this branch (but I might force-push it myself, too, so pull/push often).