### PR TITLE
Fix use of auxiliary verb on index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ It can be used in a class of students, a corporate data science group or scienti
 research group. It is a multi-user **Hub** that spawns, manages, and proxies multiple
 instances of the single-user `Jupyter notebook`_ server.
 
-To make life easier, JupyterHub have distributions. Be sure to
+To make life easier, JupyterHub has distributions. Be sure to
 take a look at them before continuing with the configuration of the broad
 original system of `JupyterHub`_. Today, you can find two main cases:
 


### PR DESCRIPTION
Updating the use of _have_ to _has_ when referring to the distributions that JupyterHub has in the index.rst landing page.