### PR TITLE
Always pass config object to render_template

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1132,6 +1132,7 @@ class BaseHandler(RequestHandler):
             static_url=self.static_url,
             version_hash=self.version_hash,
             services=self.get_accessible_services(user),
+            config=self.config,
         )
         if self.settings['template_vars']:
             ns.update(self.settings['template_vars'])


### PR DESCRIPTION
Adds 'config' as a standard Jinja2 template var for all request handlers. This means that custom configuration can be accessed from inside a custom template html file.

So e.g. if I replace home.html in my own templates folder, I can locate custom config settings, or even vary behavior based on standard config settings.