### PR TITLE
Cross site scripting false positive

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -39,6 +39,7 @@ class APIHandler(BaseHandler):
 
         - allow unspecified host/referer (e.g. scripts)
         """
+        referer = self.request.headers.get("Referer")
         host_header = self.request.headers.get("Host")
         # http spec allows for port at end of host header but this causes
         # cross site scripting check to give false positive

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -42,8 +42,11 @@ class APIHandler(BaseHandler):
         host_header = self.request.headers.get("Host")
         # http spec allows for port at end of host header but this causes
         # cross site scripting check to give false positive
-        host, port = host_header.split(":", maxsplit=1)
-        if not (port=='443' or port=='80'):
+        if ':' in host_header:
+            host, port = host_header.split(":", maxsplit=1)
+            if not (port=='443' or port=='80'):
+                host = host_header
+        else:
             host = host_header
 
         # If no header is provided, assume it comes from a script/curl.

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -42,11 +42,7 @@ class APIHandler(BaseHandler):
         host = self.request.headers.get("Host")
         # http spec allows for port at end of host header but this causes
         # cross site scripting check to give false positive
-        if (host.endswith(':443')):
-            host = host[:-4]
-        elif (host.endswith(':80')):
-            host = host[:-3]
-        referer = self.request.headers.get("Referer")
+        host, port = host.split(":", maxsplit=1)
 
         # If no header is provided, assume it comes from a script/curl.
         # We are only concerned with cross-site browser stuff here.

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -39,10 +39,12 @@ class APIHandler(BaseHandler):
 
         - allow unspecified host/referer (e.g. scripts)
         """
-        host = self.request.headers.get("Host")
+        host_header = self.request.headers.get("Host")
         # http spec allows for port at end of host header but this causes
         # cross site scripting check to give false positive
         host, port = host.split(":", maxsplit=1)
+        if not (port=='443' or port=='80'):
+            host = host_header
 
         # If no header is provided, assume it comes from a script/curl.
         # We are only concerned with cross-site browser stuff here.

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -40,6 +40,12 @@ class APIHandler(BaseHandler):
         - allow unspecified host/referer (e.g. scripts)
         """
         host = self.request.headers.get("Host")
+        # http spec allows for port at end of host header but this causes
+        # cross site scripting check to give false positive
+        if (host.endswith('.443')):
+            host = host[:-4]
+        elif (host.endswith('.80'))::
+            host = host[:-3]
         referer = self.request.headers.get("Referer")
 
         # If no header is provided, assume it comes from a script/curl.

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -42,9 +42,9 @@ class APIHandler(BaseHandler):
         host = self.request.headers.get("Host")
         # http spec allows for port at end of host header but this causes
         # cross site scripting check to give false positive
-        if (host.endswith('.443')):
+        if (host.endswith(':443')):
             host = host[:-4]
-        elif (host.endswith('.80'))::
+        elif (host.endswith(':80')):
             host = host[:-3]
         referer = self.request.headers.get("Referer")
 

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -42,7 +42,7 @@ class APIHandler(BaseHandler):
         host_header = self.request.headers.get("Host")
         # http spec allows for port at end of host header but this causes
         # cross site scripting check to give false positive
-        host, port = host.split(":", maxsplit=1)
+        host, port = host_header.split(":", maxsplit=1)
         if not (port=='443' or port=='80'):
             host = host_header
 


### PR DESCRIPTION
A load balancer in front of my jupyterhub service is adding a :443 into the host header.   This is undesired but valid according to the http spec and causes a false positive when performing the cross site scripting check.  This pull request modifies the value read from the host header to strip the :443 or :80 if a load balancer has added it.   In our case it is an azure load balancer and we cant control it.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23

Host = "Host" ":" host [ ":" **port** ] ; Section 3.2.2

Error seen in logs during false positive:

[W 2020-04-17 11:51:29.470 JupyterHub base:60] Blocking Cross Origin API request.  Referer: https://jupyter.myurl.fi/hub/spawn-pending/user, Host: **jupyter.myurl.fi:443**/hub/
[W 2020-04-17 11:51:29.471 JupyterHub log:174] 403 GET /hub/api/users/xxx/server/progress (@myip) 6.40ms