### PR TITLE
UI Feedback on Submit

### DIFF
--- a/share/jupyterhub/static/less/login.less
+++ b/share/jupyterhub/static/less/login.less
@@ -6,7 +6,7 @@
         .bg-warning();
         padding:10px;
     }
-
+    
     .service-login {
       text-align: center;
       display: table-cell;
@@ -27,9 +27,9 @@
     }
 
     input[type=submit] {
-        margin-top: 16px;
+        margin-top: 0px;
     }
-
+    
     .form-control:focus, input[type=submit]:focus {
         box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px @jupyter-orange;
         border-color: @jupyter-orange;

--- a/share/jupyterhub/static/less/page.less
+++ b/share/jupyterhub/static/less/page.less
@@ -26,3 +26,19 @@
 // .progress-log-event:hover {
 //   background: rgba(66, 165, 245, 0.2);
 // }
+
+
+.feedback {
+    &-container {
+        margin-top: 16px;
+    }
+    
+    &-widget {
+        padding: 5px 0px 0px 6px;
+        i {
+            font-size: 2em;
+            color: lightgrey;
+        }
+    }
+    
+}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -85,10 +85,11 @@ if (window.location.protocol === "http:") {
   warning.className = warning.className.replace(/\bhidden\b/, '');
 }
 // setup onSubmit feedback
-$('form').submit(() => {
-  $('.feedback-container>input').attr('disabled', true);
-  $('.feedback-container>*').toggleClass('hidden');
-  $('.feedback-widget>*').toggleClass('fa-pulse');
+$('form').submit((e) => {
+  var form = $(e.target);
+  form.find('.feedback-container>input').attr('disabled', true);
+  form.find('.feedback-container>*').toggleClass('hidden');
+  form.find('.feedback-widget>*').toggleClass('fa-pulse');
 });
 </script>
 {% endblock %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -56,13 +56,18 @@
       tabindex="2"
     />
 
-    <input
-      type="submit"
-      id="login_submit"
-      class='btn btn-jupyter'
-      value='Sign In'
-      tabindex="3"
-    />
+    <div class="feedback-container">
+      <input
+        id="login_submit"
+        type="submit"
+        class='btn btn-jupyter'
+        value='Sign In'
+        tabindex="3"
+        />
+      <div class="feedback-widget hidden">
+        <i class="fa fa-spinner"></i>
+      </div>
+    </div>
   </div>
 </form>
 {% endif %}
@@ -79,6 +84,11 @@ if (window.location.protocol === "http:") {
   var warning = document.getElementById('insecure-login-warning');
   warning.className = warning.className.replace(/\bhidden\b/, '');
 }
+// setup onSubmit feedback
+$('form').submit(() => {
+  $('.feedback-container>input').attr('disabled', true);
+  $('.feedback-container>*').toggleClass('hidden');
+  $('.feedback-widget>*').toggleClass('fa-pulse');
+});
 </script>
-
 {% endblock %}

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -23,9 +23,26 @@
     <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
       {{spawner_options_form | safe}}
       <br>
-      <input type="submit" value="Start" class="btn btn-jupyter form-control">
+      <div class="feedback-container">
+        <input type="submit" value="Start" class="btn btn-jupyter form-control">
+        <div class="feedback-widget hidden">
+          <i class="fa fa-spinner"></i>
+        </div>
+      </div>
     </form>
   </div>
 </div>
 
+{% endblock %}
+
+{% block script %}
+{{ super() }}
+<script>
+// setup onSubmit feedback
+$('form').submit(() => {
+  $('.feedback-container>input').attr('disabled', true);
+  $('.feedback-container>*').toggleClass('hidden');
+  $('.feedback-widget>*').toggleClass('fa-pulse');
+});
+</script>
 {% endblock %}

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -39,10 +39,11 @@
 {{ super() }}
 <script>
 // setup onSubmit feedback
-$('form').submit(() => {
-  $('.feedback-container>input').attr('disabled', true);
-  $('.feedback-container>*').toggleClass('hidden');
-  $('.feedback-widget>*').toggleClass('fa-pulse');
+$('form').submit((e) => {
+  var form = $(e.target);
+  form.find('.feedback-container>input').attr('disabled', true);
+  form.find('.feedback-container>*').toggleClass('hidden');
+  form.find('.feedback-widget>*').toggleClass('fa-pulse');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
This pull request is meant to add the UI enhancement requested in issue #2834; it adds a simple mechanism enabling the UI to provide feedback to the user when a form is submitted. 

This is accomplished by adding a pair of css classes (named feedback-container & feedback-widget), as well as, a generic 'onsubmit' handler which interacts with these classes. When a form is submitted, the handler toggles the visibility of the children of an element with class "feedback-container", then adds the class "fa-pulse" to all children of elements with class "feedback-widget".

![ui-feedback-onsubmit](https://user-images.githubusercontent.com/58000192/79770960-18f06a80-82fc-11ea-9ac4-33aa589f02cc.gif)
