### PR TITLE
Fix CSS on admin page version listing

### DIFF
--- a/share/jupyterhub/static/less/admin.less
+++ b/share/jupyterhub/static/less/admin.less
@@ -3,7 +3,6 @@ i.sort-icon {
 }
 
 .version_footer {
-  position: fixed;
   bottom: 0;
   width: 100%;
 }


### PR DESCRIPTION
Removes fixed position for `version_footer`. Footer overlaps the last user in the list when sufficiently long, obscuring half of the entry.  My bad :(