### PR TITLE
#1018 PAM added in prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ for administration of the Hub and its users.
     The `nodejs-legacy` package installs the `node` executable and is currently
     required for npm to work on Debian/Ubuntu.
 
+- A [pluggable authentication module (PAM)](https://en.wikipedia.org/wiki/Pluggable_authentication_module) 
+  to use the default Authenticator
 - TLS certificate and key for HTTPS communication
 - Domain name
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ for administration of the Hub and its users.
     The `nodejs-legacy` package installs the `node` executable and is currently
     required for npm to work on Debian/Ubuntu.
 
-- A [pluggable authentication module (PAM)](https://en.wikipedia.org/wiki/Pluggable_authentication_module) 
-  to use the default Authenticator
+- If using the default PAM Authenticator, a [pluggable authentication module (PAM)](https://en.wikipedia.org/wiki/Pluggable_authentication_module).
 - TLS certificate and key for HTTPS communication
 - Domain name
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -26,6 +26,10 @@ Before installing JupyterHub, you will need:
     The `nodejs-legacy` package installs the `node` executable and is currently
     required for npm to work on Debian/Ubuntu.
 
+- A [pluggable authentication module (PAM)](https://en.wikipedia.org/wiki/Pluggable_authentication_module) 
+  to use the [default Authenticator](./getting-started/authenticators-users-basics.md).
+  PAM is often available by default on most distributions, if this is not the case it can be installed by 
+  using the operating system's package manager.
 - TLS certificate and key for HTTPS communication
 - Domain name
 


### PR DESCRIPTION
Hello,

As I had a the problem of a missing PAM on UBI minimal Docker image https://github.com/jupyterhub/jupyterhub/issues/1018#issuecomment-625158497, I propose to add this information in the _Prerequisites_ section of the documentation.

Best.