### PR TITLE
Sudo Environment access to jupyterhub.service

### DIFF
--- a/docs/source/installation-guide-hard.md
+++ b/docs/source/installation-guide-hard.md
@@ -143,7 +143,7 @@ After=syslog.target network.target
 
 [Service]
 User=root
-Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/jupyterhub/bin"
+Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/bin/sudo:/opt/jupyterhub/bin"
 ExecStart=/opt/jupyterhub/bin/jupyterhub -f /opt/jupyterhub/etc/jupyterhub/jupyterhub_config.py
 
 [Install]


### PR DESCRIPTION
Sudo Environment Access to Jupyter Hub as only giving root in user was not working for PAM authentication in ubuntu 18.04