### PR TITLE
Changing start my server button link to spawn url once server is stopped

### DIFF
--- a/share/jupyterhub/static/js/home.js
+++ b/share/jupyterhub/static/js/home.js
@@ -104,6 +104,7 @@ require(["jquery", "moment", "jhapi"], function(
           .text("Start My Server")
           .attr("title", "Start your default server")
           .attr("disabled", false)
+          .attr("href", base_url + "spawn/" + user)
           .off("click");
       },
     });


### PR DESCRIPTION
When single user server is stopped from hub/home, the text for the button "My server" is changed to "Start My server" but it does not change the url link to the button. It remains referenced to "/user/<username". So, on clicking "Start My server", it tries to redirect to the single user server. 
As, server is already stopped, so it redirects user to server not running page. Changing the url to spawn up the single user sever.
#2925 