### PR TITLE
[Docs] Disable proxy_buffering when using nginx reverse proxy

### DIFF
--- a/docs/source/reference/config-proxy.md
+++ b/docs/source/reference/config-proxy.md
@@ -85,6 +85,8 @@ server {
         # websocket headers
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
+
+        proxy_buffering off;
     }
 
     # Managing requests to verify letsencrypt host


### PR DESCRIPTION
When running jupyterhub behind an nginx proxy, the progress bar does not show the spawn progress until it completes,
Setting `proxy_buffering off` solves this issue.