### PR TITLE
Update links to the black GitHub repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v1.9.0
   hooks:
   - id: reorder-python-imports
-- repo: https://github.com/ambv/black
+- repo: https://github.com/psf/black
   rev: 19.10b0
   hooks:
   - id: black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ pre-commit run
 
 which should run any autoformatting on your code
 and tell you about any errors it couldn't fix automatically.
-You may also install [black integration](https://github.com/ambv/black#editor-integration)
+You may also install [black integration](https://github.com/psf/black#editor-integration)
 into your text editor to format code automatically.
 
 If you have already committed files before setting up the pre-commit


### PR DESCRIPTION
Although GitHub handles the redirects, we can update the link to the `black` GitHub repo now that it was moved under the `psf` organization: https://github.com/psf/black