### PR TITLE
Warn if both bind_url and ip/port/base_url are set

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -568,7 +568,16 @@ class JupyterHub(Application):
         urlinfo = urlinfo._replace(netloc=fmt % (self.ip, self.port))
         urlinfo = urlinfo._replace(path=self.base_url)
         bind_url = urlunparse(urlinfo)
+
+        # Warn if both bind_url and ip/port/base_url are set
         if bind_url != self.bind_url:
+            if self.bind_url != "http://:8000" and self.bind_url != "https://:8000":
+                self.log.warning(
+                    "Both bind_url and ip/port/base_url have been configured. "
+                    "JupyterHub.ip, JupyterHub.port, JupyterHub.base_url are"
+                    " deprecated in JupyterHub 0.9,"
+                    " please use JupyterHub.bind_url instead."
+                )
             self.bind_url = bind_url
 
     bind_url = Unicode(

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -571,7 +571,7 @@ class JupyterHub(Application):
 
         # Warn if both bind_url and ip/port/base_url are set
         if bind_url != self.bind_url:
-            if self.bind_url != "http://:8000" and self.bind_url != "https://:8000":
+            if self.bind_url != self._bind_url_default():
                 self.log.warning(
                     "Both bind_url and ip/port/base_url have been configured. "
                     "JupyterHub.ip, JupyterHub.port, JupyterHub.base_url are"


### PR DESCRIPTION
This PR adds a warning if a user sets both `bind_url` and `ip`/`port`/`base_url` (which are deprecated as of JupyterHub 0.9 and replaced by `bind_url` according to the [config definitions](https://github.com/jupyterhub/jupyterhub/blob/81d423d6c674765400a6fe88064c1366b7070f94/jupyterhub/app.py#L516)).

This is a follow up on Min's comment [here](https://github.com/jupyterhub/jupyterhub/pull/2773#issuecomment-543119346) and Erik's [question](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1680) about `JupyterHub.ip` and `.port`.
