### PR TITLE
Add JupyterHub Demo docker image

### DIFF
--- a/demo-image/Dockerfile
+++ b/demo-image/Dockerfile
@@ -1,0 +1,16 @@
+# Demo JupyterHub Docker image
+#
+# This should only be used for demo or testing and not as a base image to build on.
+#
+# It includes the notebook package and it uses the DummyAuthenticator and the SimpleLocalProcessSpawner.
+
+FROM jupyterhub/jupyterhub-onbuild
+
+# Install the notebook package
+RUN python3 -m pip install notebook
+
+# Create a demo user
+RUN useradd --create-home demo
+RUN chown demo .
+
+USER demo

--- a/demo-image/README.md
+++ b/demo-image/README.md
@@ -1,0 +1,25 @@
+## Demo Dockerfile
+
+This is a demo JupyterHub Docker image to help you get a quick overview of what
+JupyterHub is and how it works.
+
+It uses the SimpleLocalProcessSpawner to spawn new user servers and
+DummyAuthenticator for authentication.
+The DummyAuthenticator allows you to log in with any username & password and the
+SimpleLocalProcessSpawner allows starting servers without having to create a
+local user for each JupyterHub user.
+
+### Important!
+
+This should only be used for demo or testing purposes!
+It shouldn't be used as a base image to build on.
+
+### Try it
+1. `cd` to the root of your jupyterhub repo.
+
+2. Build the demo image with `docker build -t jupyterhub-demo demo-image`. 
+
+3. Run the demo image with `docker run -d -p 8000:8000 jupyterhub-demo`.
+
+4. Visit http://localhost:8000 and login with any username and password
+5. Happy demo-ing :tada:!

--- a/demo-image/jupyterhub_config.py
+++ b/demo-image/jupyterhub_config.py
@@ -1,0 +1,7 @@
+# Configuration file for jupyterhub-demo
+
+c = get_config()
+
+# Use DummyAuthenticator and SympleSpawner
+c.JupyterHub.spawner_class = "simple"
+c.JupyterHub.authenticator_class = "dummy"


### PR DESCRIPTION
This adds a docker image example that includes the notebook package and sets up JupyterHub to use the dummy authenticator and the simple spawner. This can be used to quickly test out how JupyterHub works.
 
Closes https://github.com/jupyterhub/jupyterhub/issues/2503
Relevant reference: https://github.com/jupyterhub/jupyterhub/issues/3007#issuecomment-633984779