### PR TITLE
pin jupyter_telemetry dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ async_generator>=1.8
 certipy>=0.1.2
 entrypoints
 jinja2
-jupyter_telemetry
+jupyter_telemetry==0.1.0
 oauthlib>=3.0
 pamela
 prometheus_client>=0.0.21


### PR DESCRIPTION
[Some changes](https://github.com/jupyter/telemetry/pull/46) in jupyter_telemetry are pending that will lead to breaking changes here in jupyterhub. jupyter_telemetry is likely going to require event schemas to explicitly state if+when they are collecting personal data. This is critically important for protecting user's personal data. Once these changes land in jupyter_telemetry, JupyterHub's event schemas will need updating to include the new, required fields. 

In the meantime, I think it's wise for jupyterhub to pin its dependency to the current release of jupyter_telemetry so we don't have to coordinate a release of jupyter_telemetry and jupyterhub w/ new event schemas.

I'll update JupyterHub's event schemas once jupyter/telemetry#46 merges and jupyter_telemetry has a new release. 