### PR TITLE
More consistent behavior for UserDict.get and `key in UserDict`

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -676,9 +676,10 @@ class BaseHandler(RequestHandler):
             raise ValueError("Username doesn't match! %s != %s" % (username, user.name))
 
         if user is None:
-            new_user = username not in self.users
-            user = self.user_from_username(username)
+            user = self.find_user(username)
+            new_user = user is None
             if new_user:
+                user = self.user_from_username(username)
                 await maybe_future(self.authenticator.add_user(user))
         # Only set `admin` if the authenticator returned an explicit value.
         if admin is not None and admin != user.admin:

--- a/jupyterhub/tests/test_user.py
+++ b/jupyterhub/tests/test_user.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ..user import UserDict
+from .utils import add_user
+
+
+@pytest.mark.parametrize("attr", ["self", "id", "name"])
+async def test_userdict_get(db, attr):
+    u = add_user(db, name="rey", app=False)
+    userdict = UserDict(db_factory=lambda: db, settings={})
+
+    if attr == "self":
+        key = u
+    else:
+        key = getattr(u, attr)
+
+    # `in` checks cache only
+    assert key not in userdict
+    assert userdict.get(key)
+    assert userdict.get(key).id == u.id
+    # `in` should find it now
+    assert key in userdict


### PR DESCRIPTION
- `in` supports all key types, checking for presence in cache (O(N) for str since we don't maintain a separate name map)
- `get` behaves the same as attempting to fetch (meaning it supports all key types); the inherited base dict implementation only checked presence in the Dict, not the db, and only worked with integers