### PR TITLE
Allow `python:3.8 + master dependencies` to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,4 +103,5 @@ jobs:
       python: nightly
   allow_failures:
     - name: python:nightly
+    - name: python:3.8 + master dependencies
   fast_finish: true


### PR DESCRIPTION
Follow-up from https://github.com/jupyterhub/jupyterhub/pull/3076

This job failed on https://github.com/jupyterhub/jupyterhub/pull/3078