### PR TITLE
make Spawner.environment config highest priority

### DIFF
--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -404,3 +404,15 @@ async def test_spawner_routing(app, name):
     assert r.url == url
     assert r.text == urlparse(url).path
     await user.stop()
+
+
+async def test_spawner_env(db):
+    env_overrides = {
+        "JUPYTERHUB_API_URL": "https://test.horse/hub/api",
+        "TEST_KEY": "value",
+    }
+    spawner = new_spawner(db, environment=env_overrides)
+    env = spawner.get_env()
+    for key, value in env_overrides.items():
+        assert key in env
+        assert env[key] == value


### PR DESCRIPTION
so that it can override 'default' env variables like JUPYTERHUB_API_URL

use with caution, since this allows setting non-working values for required URLs, but is still a useful escape hatch when e.g. hub_connect_url might want to have different values across spawners


cf https://github.com/jupyterhub/dockerspawner/pull/361