### PR TITLE
Ensure client dependencies build before wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,15 @@ RUN apt-get update \
 # compromise between needing to rebuild and maintaining
 # what needs to be part of the build
 COPY . /src/jupyterhub/
-COPY jupyterhub/ /src/jupyterhub/jupyterhub
-COPY share/ /src/jupyterhub/share
 
 WORKDIR /src/jupyterhub
+
 RUN python3 -m pip install --upgrade setuptools pip wheel
-RUN python3 -m pip wheel -v --wheel-dir wheelhouse .
+
+# Build client component packages (they will be copied into ./share and
+# packaged with the built wheel.)
+RUN npm install
+RUN python3 -m pip wheel --wheel-dir wheelhouse .
 
 
 FROM $BASE_IMAGE
@@ -87,7 +90,6 @@ RUN npm install -g configurable-http-proxy@^4.2.0 \
 
 # install the wheels we built in the first stage
 COPY --from=builder /src/jupyterhub/wheelhouse /tmp/wheelhouse
-COPY --from=builder /src/jupyterhub/share /src/jupyterhub/share
 RUN python3 -m pip install --no-cache /tmp/wheelhouse/*
 
 RUN mkdir -p /srv/jupyterhub/


### PR DESCRIPTION
Bug #2852 describes an issue where templates cannot be found by
JupyterHub when using the Docker images built out of this repo. The
issue turned out to be due to missing node_modules at the time of build.

There is a hook in the `package.json` that causes node_modules to be
copied to the static/components directory post-install. If this is not
run, those components are not in the static directory and thus are not
included in the wheel when it is built.

Fix #2905 fixed one problem--the `bower-lite` hook script wasn't copied
to the Docker image, and so the hook couldn't run, but the other issue
is that the client dependencies are never explicitly built. They must be
built prior to the wheel build, and the hook script must have run so
they are copied to the ./static folder, which is included in the wheel
build thanks to [MANIFEST.in][1]

.. note::

   This removes the verbose flag from the wheel build command. The
   reason is that it generates a lot of writes to stdout. It seems that
   wheel can (or always) is switching to non-blocking mode, which can cause
   EAGAIN to be raised, which leads to fun errors like:

     BlockingIOError(.., 'write could not complete without blocking', ..)

   The wheels fail to build if this error is raised. Removing the verbosity
   flag is a quick solution (it drastically reduces writes to STDOUT), but
   comes at the cost of more trouble debugging a failed wheel build. Adding
   the "-v" back in the Dockerfile when debugging a build failure is still
   possible. [Credit: @vbraun][2]

.. note::

   This commit also removes some extraneous COPY operations during the
   Docker build, in particular the /src/jupyterhub/share directory is
   not used unless users have explicitly override their
   jupyterhub_config.py to include it somehow. If the default
   data_files_path behavior is used, JupyterHub should find the proper
   static directory when the application loads.

Fixes: #2852

[1]: https://packaging.python.org/guides/using-manifest-in/
[2]:
https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959