### PR TITLE
Remove already done named servers from roadmap

### DIFF
--- a/docs/source/contributing/roadmap.md
+++ b/docs/source/contributing/roadmap.md
@@ -83,7 +83,6 @@ these will be moved at a future review of the roadmap.
     - (prometheus?) API for resource monitoring
     - tracking activity on single-user servers instead of the proxy
     - notes and activity tracking per API token
-    - UI for managing named servers
 
 
 ### Later


### PR DESCRIPTION
Remove already done "UI for managing named servers" from the roadmap