### PR TITLE
Make `delete_invalid_users` configurable

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -206,6 +206,7 @@ class Authenticator(LoggingConfigurable):
 
     delete_invalid_users = Bool(
         False,
+        config=True,
         help="""Delete any users from the database that do not pass validation
 
         When JupyterHub starts, `.add_user` will be called


### PR DESCRIPTION
The following warning may happen:

https://github.com/jupyterhub/jupyterhub/blob/b7f277147bad0855104e4b725254cefba784a9ed/jupyterhub/app.py#L1738-L1743

But the corresponding setting is not configurable.