### PR TITLE
Rename Authenticator.white/blacklist to allowed/blocked

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,6 +7,8 @@ command line for details.
 
 ## [Unreleased]
 
+
+
 ## 1.1
 
 ### [1.1.0] 2020-01-17
@@ -116,7 +118,7 @@ Thanks to everyone who has contributed to this release!
 - Log JupyterHub version on startup [#2752](https://github.com/jupyterhub/jupyterhub/pull/2752) ([@consideRatio](https://github.com/consideRatio))
 - Reduce verbosity for "Failing suspected API request to not-running server" (new) [#2751](https://github.com/jupyterhub/jupyterhub/pull/2751) ([@rkdarst](https://github.com/rkdarst))
 - Add missing package for json schema doc build [#2744](https://github.com/jupyterhub/jupyterhub/pull/2744) ([@willingc](https://github.com/willingc))
-- blacklist urllib3 versions with encoding bug [#2743](https://github.com/jupyterhub/jupyterhub/pull/2743) ([@minrk](https://github.com/minrk))
+- block urllib3 versions with encoding bug [#2743](https://github.com/jupyterhub/jupyterhub/pull/2743) ([@minrk](https://github.com/minrk))
 - Remove tornado deprecated/unnecessary AsyncIOMainLoop().install() call [#2740](https://github.com/jupyterhub/jupyterhub/pull/2740) ([@kinow](https://github.com/kinow))
 - Fix deprecated call [#2739](https://github.com/jupyterhub/jupyterhub/pull/2739) ([@kinow](https://github.com/kinow))
 - Remove duplicate hub and authenticator traitlets from Spawner [#2736](https://github.com/jupyterhub/jupyterhub/pull/2736) ([@eslavich](https://github.com/eslavich))
@@ -231,8 +233,8 @@ whether it was through discussion, testing, documentation, or development.
   This hook may transform the return value of `Authenticator.authenticate()`
   and return a new authentication dictionary,
   e.g. specifying admin privileges, group membership,
-  or custom white/blacklisting logic.
-  This hook is called *after* existing normalization and whitelist checking.
+  or custom allowed/blocked logic.
+  This hook is called *after* existing normalization and allowed-username checking.
 - `Spawner.options_from_form` may now be async
 - Added `JupyterHub.shutdown_on_logout` option to trigger shutdown of a user's
   servers when they log out.
@@ -418,7 +420,7 @@ and tornado < 5.0.
   launching an IPython session connected to your JupyterHub database.
 - Include `User.auth_state` in user model on single-user REST endpoints for admins only.
 - Include `Server.state` in server model on REST endpoints for admins only.
-- Add `Authenticator.blacklist` for blacklisting users instead of whitelisting.
+- Add `Authenticator.blacklist` for blocking users instead of allowing.
 - Pass `c.JupyterHub.tornado_settings['cookie_options']` down to Spawners
   so that cookie options (e.g. `expires_days`) can be set globally for the whole application.
 - SIGINFO (`ctrl-t`) handler showing the current status of all running threads,

--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -7,20 +7,20 @@ with an account and password on the system will be allowed to login.
 ## Create a set of allowed users
 
 You can restrict which users are allowed to login with a set,
-`Authenticator.allowed`:
+`Authenticator.allowed_users`:
 
 
 ```python
-c.Authenticator.allowed = {'mal', 'zoe', 'inara', 'kaylee'}
+c.Authenticator.allowed_users = {'mal', 'zoe', 'inara', 'kaylee'}
 ```
 
-Users in the allowed set are added to the Hub database when the Hub is
+Users in the `allowed_users` set are added to the Hub database when the Hub is
 started.
 
 ## Configure admins (`admin_users`)
 
 Admin users of JupyterHub, `admin_users`, can add and remove users from
-the user `allowed` set. `admin_users` can take actions on other users'
+the user `allowed_users` set. `admin_users` can take actions on other users'
 behalf, such as stopping and restarting their servers.
 
 A set of initial admin users, `admin_users` can configured be as follows:
@@ -28,7 +28,7 @@ A set of initial admin users, `admin_users` can configured be as follows:
 ```python
 c.Authenticator.admin_users = {'mal', 'zoe'}
 ```
-Users in the admin set are automatically added to the user `allowed` set,
+Users in the admin set are automatically added to the user `allowed_users` set,
 if they are not already present.
 
 Each authenticator may have different ways of determining whether a user is an
@@ -53,12 +53,12 @@ sure your users know if admin_access is enabled.**
 
 Users can be added to and removed from the Hub via either the admin
 panel or the REST API. When a user is **added**, the user will be
-automatically added to the allowed set and database. Restarting the Hub
-will not require manually updating the allowed set in your config file,
+automatically added to the allowed users set and database. Restarting the Hub
+will not require manually updating the allowed users set in your config file,
 as the users will be loaded from the database.
 
 After starting the Hub once, it is not sufficient to **remove** a user
-from the allowed set in your config file. You must also remove the user
+from the allowed users set in your config file. You must also remove the user
 from the Hub's database, either by deleting the user from JupyterHub's
 admin page, or you can clear the `jupyterhub.sqlite` database and start
 fresh.

--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -4,23 +4,23 @@ The default Authenticator uses [PAM][] to authenticate system users with
 their username and password. With the default Authenticator, any user
 with an account and password on the system will be allowed to login.
 
-## Create a whitelist of users
+## Create a set of allowed users
 
-You can restrict which users are allowed to login with a whitelist,
-`Authenticator.whitelist`:
+You can restrict which users are allowed to login with a set,
+`Authenticator.allowed`:
 
 
 ```python
-c.Authenticator.whitelist = {'mal', 'zoe', 'inara', 'kaylee'}
+c.Authenticator.allowed = {'mal', 'zoe', 'inara', 'kaylee'}
 ```
 
-Users in the whitelist are added to the Hub database when the Hub is
+Users in the allowed set are added to the Hub database when the Hub is
 started.
 
 ## Configure admins (`admin_users`)
 
 Admin users of JupyterHub, `admin_users`, can add and remove users from
-the user `whitelist`. `admin_users` can take actions on other users'
+the user `allowed` set. `admin_users` can take actions on other users'
 behalf, such as stopping and restarting their servers.
 
 A set of initial admin users, `admin_users` can configured be as follows:
@@ -28,7 +28,7 @@ A set of initial admin users, `admin_users` can configured be as follows:
 ```python
 c.Authenticator.admin_users = {'mal', 'zoe'}
 ```
-Users in the admin list are automatically added to the user `whitelist`,
+Users in the admin set are automatically added to the user `allowed` set,
 if they are not already present.
 
 Each authenticator may have different ways of determining whether a user is an
@@ -53,12 +53,12 @@ sure your users know if admin_access is enabled.**
 
 Users can be added to and removed from the Hub via either the admin
 panel or the REST API. When a user is **added**, the user will be
-automatically added to the whitelist and database. Restarting the Hub
-will not require manually updating the whitelist in your config file,
+automatically added to the allowed set and database. Restarting the Hub
+will not require manually updating the allowed set in your config file,
 as the users will be loaded from the database.
 
 After starting the Hub once, it is not sufficient to **remove** a user
-from the whitelist in your config file. You must also remove the user
+from the allowed set in your config file. You must also remove the user
 from the Hub's database, either by deleting the user from JupyterHub's
 admin page, or you can clear the `jupyterhub.sqlite` database and start
 fresh.

--- a/docs/source/reference/config-ghoauth.md
+++ b/docs/source/reference/config-ghoauth.md
@@ -52,7 +52,7 @@ c.GitHubOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
 c.LocalAuthenticator.create_system_users = True
 
 # specify users and admin
-c.Authenticator.whitelist = {'rgbkrk', 'minrk', 'jhamrick'}
+c.Authenticator.allowed = {'rgbkrk', 'minrk', 'jhamrick'}
 c.Authenticator.admin_users = {'jhamrick', 'rgbkrk'}
 
 # uses the default spawner

--- a/docs/source/reference/config-ghoauth.md
+++ b/docs/source/reference/config-ghoauth.md
@@ -52,7 +52,7 @@ c.GitHubOAuthenticator.oauth_callback_url = os.environ['OAUTH_CALLBACK_URL']
 c.LocalAuthenticator.create_system_users = True
 
 # specify users and admin
-c.Authenticator.allowed = {'rgbkrk', 'minrk', 'jhamrick'}
+c.Authenticator.allowed_users = {'rgbkrk', 'minrk', 'jhamrick'}
 c.Authenticator.admin_users = {'jhamrick', 'rgbkrk'}
 
 # uses the default spawner

--- a/docs/source/reference/config-sudo.md
+++ b/docs/source/reference/config-sudo.md
@@ -57,7 +57,7 @@ To do this we add to `/etc/sudoers` (use `visudo` for safe editing of sudoers):
 For example:
 
 ```bash
-# comma-separated whitelist of users that can spawn single-user servers
+# comma-separated list of users that can spawn single-user servers
 # this should include all of your Hub users
 Runas_Alias JUPYTER_USERS = rhea, zoe, wash
 

--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -313,7 +313,7 @@ class MyHandler(HubAuthenticated, web.RequestHandler):
 The HubAuth will automatically load the desired configuration from the Service
 environment variables.
 
-If you want to limit user access, you can whitelist users through either the
+If you want to limit user access, you can specify allowed users through either the
 `.hub_users` attribute or `.hub_groups`. These are sets that check against the
 username and user group list, respectively. If a user matches neither the user
 list nor the group list, they will not be allowed access. If both are left

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -7,8 +7,8 @@ problem and how to resolve it.
 [*Behavior*](#behavior)
 - JupyterHub proxy fails to start
 - sudospawner fails to run
-- What is the default behavior when none of the lists (admin, whitelist,
-  group whitelist) are set?
+- What is the default behavior when none of the lists (admin, allowed,
+  allowed groups) are set?
 - JupyterHub Docker container not accessible at localhost
 
 [*Errors*](#errors)
@@ -55,14 +55,14 @@ or add:
 
 to the config file, `jupyterhub_config.py`.
 
-### What is the default behavior when none of the lists (admin, whitelist, group whitelist) are set?
+### What is the default behavior when none of the lists (admin, allowed, allowed groups) are set?
 
 When nothing is given for these lists, there will be no admins, and all users
 who can authenticate on the system (i.e. all the unix users on the server with
-a password) will be allowed to start a server. The whitelist lets you limit
-this to a particular set of users, and the admin_users lets you specify who
+a password) will be allowed to start a server. The allowed username set lets you limit
+this to a particular set of users, and admin_users lets you specify who
 among them may use the admin interface (not necessary, unless you need to do
-things like inspect other users' servers, or modify the userlist at runtime).
+things like inspect other users' servers, or modify the user list at runtime).
 
 ### JupyterHub Docker container not accessible at localhost
 
@@ -332,8 +332,7 @@ notebook servers to default to JupyterLab:
 ### How do I set up JupyterHub for a workshop (when users are not known ahead of time)?
 
 1. Set up JupyterHub using OAuthenticator for GitHub authentication
-2. Configure whitelist to be an empty list in` jupyterhub_config.py`
-3. Configure admin list to have workshop leaders be listed with administrator privileges.
+2. Configure admin list to have workshop leaders be listed with administrator privileges.
 
 Users will need a GitHub account to login and be authenticated by the Hub.
 

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -201,7 +201,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
     def needs_oauth_confirm(self, user, oauth_client):
         """Return whether the given oauth client needs to prompt for access for the given user
 
-        Checks whitelist for oauth clients
+        Checks list for oauth clients that don't need confirmation
 
         (i.e. the user's own server)
 
@@ -214,9 +214,8 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
         if (
             # it's the user's own server
             oauth_client.identifier in own_oauth_client_ids
-            # or it's in the global whitelist
-            or oauth_client.identifier
-            in self.settings.get('oauth_no_confirm_whitelist', set())
+            # or it's in the global no-confirm list
+            or oauth_client.identifier in self.settings.get('oauth_no_confirm', set())
         ):
             return False
         # default: require confirmation
@@ -229,7 +228,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
         Render oauth confirmation page:
         "Server at ... would like permission to ...".
 
-        Users accessing their own server or a service whitelist
+        Users accessing their own server or a blessed service
         will skip confirmation.
         """
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1689,22 +1689,22 @@ class JupyterHub(Application):
         # the admin_users config variable will never be used after this point.
         # only the database values will be referenced.
 
-        whitelist = [
+        allowed = [
             self.authenticator.normalize_username(name)
-            for name in self.authenticator.whitelist
+            for name in self.authenticator.allowed
         ]
-        self.authenticator.whitelist = set(whitelist)  # force normalization
-        for username in whitelist:
+        self.authenticator.allowed = set(allowed)  # force normalization
+        for username in allowed:
             if not self.authenticator.validate_username(username):
                 raise ValueError("username %r is not valid" % username)
 
-        if not whitelist:
+        if not allowed:
             self.log.info(
-                "Not using whitelist. Any authenticated user will be allowed."
+                "Not using allowed user list. Any authenticated user will be allowed."
             )
 
-        # add whitelisted users to the db
-        for name in whitelist:
+        # add allowed users to the db
+        for name in allowed:
             user = orm.User.find(db, name)
             if user is None:
                 user = orm.User(name=name)
@@ -1714,9 +1714,9 @@ class JupyterHub(Application):
         db.commit()
 
         # Notify authenticator of all users.
-        # This ensures Auth whitelist is up-to-date with the database.
-        # This lets whitelist be used to set up initial list,
-        # but changes to the whitelist can occur in the database,
+        # This ensures Authenticator.allowed is up-to-date with the database.
+        # This lets .allowed be used to set up initial list,
+        # but changes to the allowed list can occur in the database,
         # and persist across sessions.
         total_users = 0
         for user in db.query(orm.User):
@@ -1753,9 +1753,9 @@ class JupyterHub(Application):
                     user.created = user.last_activity or datetime.utcnow()
         db.commit()
 
-        # The whitelist set and the users in the db are now the same.
+        # The allowed set and the users in the db are now the same.
         # From this point on, any user changes should be done simultaneously
-        # to the whitelist set and user db, unless the whitelist is empty (all users allowed).
+        # to the allowed set and user db, unless the allowed set is empty (all users allowed).
 
         TOTAL_USERS.set(total_users)
 
@@ -1770,11 +1770,11 @@ class JupyterHub(Application):
             for username in usernames:
                 username = self.authenticator.normalize_username(username)
                 if not (
-                    await maybe_future(
-                        self.authenticator.check_whitelist(username, None)
-                    )
+                    await maybe_future(self.authenticator.check_allowed(username, None))
                 ):
-                    raise ValueError("Username %r is not in whitelist" % username)
+                    raise ValueError(
+                        "Username %r is not in Authenticator.allowed" % username
+                    )
                 user = orm.User.find(db, name=username)
                 if user is None:
                     if not self.authenticator.validate_username(username):
@@ -1798,11 +1798,13 @@ class JupyterHub(Application):
             if kind == 'user':
                 name = self.authenticator.normalize_username(name)
                 if not (
-                    await maybe_future(self.authenticator.check_whitelist(name, None))
+                    await maybe_future(self.authenticator.check_allowed(name, None))
                 ):
-                    raise ValueError("Token name %r is not in whitelist" % name)
+                    raise ValueError(
+                        "Token user name %r is not in Authenticator.allowed" % name
+                    )
                 if not self.authenticator.validate_username(name):
-                    raise ValueError("Token name %r is not valid" % name)
+                    raise ValueError("Token user name %r is not valid" % name)
             if kind == 'service':
                 if not any(service["name"] == name for service in self.services):
                     self.log.warning(
@@ -2183,14 +2185,14 @@ class JupyterHub(Application):
         else:
             version_hash = datetime.now().strftime("%Y%m%d%H%M%S")
 
-        oauth_no_confirm_whitelist = set()
+        oauth_no_confirm_list = set()
         for service in self._service_map.values():
             if service.oauth_no_confirm:
                 self.log.warning(
                     "Allowing service %s to complete OAuth without confirmation on an authorization web page",
                     service.name,
                 )
-                oauth_no_confirm_whitelist.add(service.oauth_client_id)
+                oauth_no_confirm_list.add(service.oauth_client_id)
 
         settings = dict(
             log_function=log_request,
@@ -2226,7 +2228,7 @@ class JupyterHub(Application):
             default_server_name=self._default_server_name,
             named_server_limit_per_user=self.named_server_limit_per_user,
             oauth_provider=self.oauth_provider,
-            oauth_no_confirm_whitelist=oauth_no_confirm_whitelist,
+            oauth_no_confirm_list=oauth_no_confirm_list,
             concurrent_spawn_limit=self.concurrent_spawn_limit,
             spawn_throttle_retry_range=self.spawn_throttle_retry_range,
             active_server_limit=self.active_server_limit,

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -297,7 +297,7 @@ class Authenticator(LoggingConfigurable):
         self._init_deprecated_methods()
 
     def _init_deprecated_methods(self):
-        # TODO: properly handle deprecated signature *and* name
+        # handles deprecated signature *and* name
         # with correct subclass override priority!
         for old_name, new_name in (
             ('check_whitelist', 'check_allowed'),

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -860,15 +860,15 @@ class HubAuthenticated(object):
         if kind == 'service':
             # it's a service, check hub_services
             if self.hub_services and name in self.hub_services:
-                app_log.debug("Allowing whitelisted Hub service %s", name)
+                app_log.debug("Allowing Hub service %s", name)
                 return model
             else:
                 app_log.warning("Not allowing Hub service %s", name)
                 raise UserNotAllowed(model)
 
         if self.hub_users and name in self.hub_users:
-            # user in whitelist
-            app_log.debug("Allowing whitelisted Hub user %s", name)
+            # user in allowed list
+            app_log.debug("Allowing Hub user %s", name)
             return model
         elif self.hub_groups and set(model['groups']).intersection(self.hub_groups):
             allowed_groups = set(model['groups']).intersection(self.hub_groups)
@@ -877,7 +877,7 @@ class HubAuthenticated(object):
                 name,
                 ','.join(sorted(allowed_groups)),
             )
-            # group in whitelist
+            # group in allowed list
             return model
         else:
             app_log.warning("Not allowing Hub user %s", name)

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -435,9 +435,9 @@ class Spawner(LoggingConfigurable):
             'LC_ALL',
         ],
         help="""
-        Whitelist of environment variables for the single-user server to inherit from the JupyterHub process.
+        List of environment variables for the single-user server to inherit from the JupyterHub process.
 
-        This whitelist is used to ensure that sensitive information in the JupyterHub process's environment
+        This list is used to ensure that sensitive information in the JupyterHub process's environment
         (such as `CONFIGPROXY_AUTH_TOKEN`) is not passed to the single-user server's process.
         """,
     ).tag(config=True)
@@ -456,7 +456,7 @@ class Spawner(LoggingConfigurable):
 
         Environment variables that end up in the single-user server's process come from 3 sources:
           - This `environment` configurable
-          - The JupyterHub process' environment variables that are whitelisted in `env_keep`
+          - The JupyterHub process' environment variables that are listed in `env_keep`
           - Variables to establish contact between the single-user notebook and the hub (such as JUPYTERHUB_API_TOKEN)
 
         The `environment` configurable should be set by JupyterHub administrators to add

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -93,7 +93,7 @@ def test_generate_config():
     os.remove(cfg_file)
     assert cfg_file in out
     assert 'Spawner.cmd' in cfg_text
-    assert 'Authenticator.allowed' in cfg_text
+    assert 'Authenticator.allowed_users' in cfg_text
 
 
 async def test_init_tokens(request):

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -93,7 +93,7 @@ def test_generate_config():
     os.remove(cfg_file)
     assert cfg_file in out
     assert 'Spawner.cmd' in cfg_text
-    assert 'Authenticator.whitelist' in cfg_text
+    assert 'Authenticator.allowed' in cfg_text
 
 
 async def test_init_tokens(request):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -686,7 +686,7 @@ async def test_shutdown_on_logout(app, shutdown_on_logout):
     assert spawner.ready == (not shutdown_on_logout)
 
 
-async def test_login_no_whitelist_adds_user(app):
+async def test_login_no_allowed_adds_user(app):
     auth = app.authenticator
     mock_add_user = mock.Mock()
     with mock.patch.object(auth, 'add_user', mock_add_user):

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -185,7 +185,7 @@ def test_hub_authenticated(request):
 
         m.get(good_url, text=json.dumps(mock_model))
 
-        # no whitelist
+        # no specific allowed user
         r = requests.get(
             'http://127.0.0.1:%i' % port,
             cookies={'jubal': 'early'},
@@ -194,7 +194,7 @@ def test_hub_authenticated(request):
         r.raise_for_status()
         assert r.status_code == 200
 
-        # pass whitelist
+        # pass allowed user
         TestHandler.hub_users = {'jubalearly'}
         r = requests.get(
             'http://127.0.0.1:%i' % port,
@@ -204,7 +204,7 @@ def test_hub_authenticated(request):
         r.raise_for_status()
         assert r.status_code == 200
 
-        # no pass whitelist
+        # no pass allowed ser
         TestHandler.hub_users = {'kaylee'}
         r = requests.get(
             'http://127.0.0.1:%i' % port,
@@ -213,7 +213,7 @@ def test_hub_authenticated(request):
         )
         assert r.status_code == 403
 
-        # pass group whitelist
+        # pass allowed group
         TestHandler.hub_groups = {'lions'}
         r = requests.get(
             'http://127.0.0.1:%i' % port,
@@ -223,7 +223,7 @@ def test_hub_authenticated(request):
         r.raise_for_status()
         assert r.status_code == 200
 
-        # no pass group whitelist
+        # no pass allowed group
         TestHandler.hub_groups = {'tigers'}
         r = requests.get(
             'http://127.0.0.1:%i' % port,


### PR DESCRIPTION
cf https://github.com/jupyterhub/team-compass/issues/299

todo:

- [x] Authenticator.whitelist -> Authenticator.allowed_users
- [x] Authenticator.blacklist -> Authenticator.blocked_users
- [x] group_whitelist -> allowed_groups
- [x] Authenticator.check_whitelist -> Authenticator.check_allowed (this is the top-level method that checks *all* sources of allow—users, groups, etc.)
- [x] LocalAuthenticator.check_group_whitelist -> LocalAuthenticator.check_allowed_groups
- [x] deprecate traits, config
- [x] test deprecated names still work
- [x] test various combinations of deprecated config for proper priority resolution
- [x] subclass resolution in deprecated method names (subclass overriding check_whitelist should take priority over base class check_allowed, but warn about deprecation *unless* check_allowed is also defined on the subclass)
- [x] update docs