### PR TITLE
Remove old context-less print statement

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2360,7 +2360,6 @@ class JupyterHub(Application):
         if init_spawners_timeout < 0:
             # negative timeout means forever (previous, most stable behavior)
             init_spawners_timeout = 86400
-        print(init_spawners_timeout)
 
         init_start_time = time.perf_counter()
         init_spawners_future = asyncio.ensure_future(self.init_spawners())


### PR DESCRIPTION
This was added in PR #2721 and by default results in just printing
out "10" without any context when starting the hub service. This
simply removes the orphan print statement.

I'm open to changing this to a debug log statement with context if
someone finds that useful, e.g.:

`self.log.debug('Effective init_spawners_timeout: %s', init_spawners_timeout)`