### PR TITLE
loosen jupyter-telemetry pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ async_generator>=1.8
 certipy>=0.1.2
 entrypoints
 jinja2
-jupyter_telemetry==0.1.0
+jupyter_telemetry>=0.1.0
 oauthlib>=3.0
 pamela
 prometheus_client>=0.0.21


### PR DESCRIPTION
we don't want strict pinning in package dependencies

that's a job for specific deployments (e.g. z2jh images)