### PR TITLE
Hide hamburger button menu in mobile/responsive mode and fix other minor issues

### DIFF
--- a/share/jupyterhub/static/less/page.less
+++ b/share/jupyterhub/static/less/page.less
@@ -13,6 +13,20 @@
   }
 }
 
+.navbar-right {
+  li {
+    span {
+      // same as .nav > li > a from bootstrap, but applied to the span[id="login_widget"]
+      // or any other span that matches .nav > li > span, but only in responsive mode
+      @media (max-width: @grid-float-breakpoint) {
+        position: relative;
+        display: block;
+        padding: 10px 15px;
+      }
+    }
+  }
+}
+
 #header {
   border-bottom: 1px solid #e7e7e7;
 }

--- a/share/jupyterhub/static/less/page.less
+++ b/share/jupyterhub/static/less/page.less
@@ -1,8 +1,16 @@
+@import "../components/bootstrap/less/variables.less";
+
 @logo-height: 28px;
 
-.jpy-logo {
-  height: @logo-height;
-  margin-top: (@navbar-height - @logo-height) / 2;
+#jupyterhub-logo {
+  @media (max-width: @grid-float-breakpoint) {
+    // same length as the navbar-toggle element, displayed on responsive mode
+    margin-left: 15px;
+  }
+  .jpy-logo {
+    height: @logo-height;
+    margin-top: (@navbar-height - @logo-height) / 2;
+  }
 }
 
 #header {

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -144,7 +144,7 @@
               {% block login_widget %}
                 <span id="login_widget">
                   {% if user %}
-		    <p class="navbar-text">{{user.name}}</p>
+		            <p class="navbar-text">{{user.name}}</p>
                     <a id="logout" role="button" class="navbar-btn btn-sm btn btn-default" href="{{logout_url}}"> <i aria-hidden="true" class="fa fa-sign-out"></i> Logout</a>
                   {% else %}
                     <a id="login" role="button" class="btn-sm btn navbar-btn btn-default" href="{{login_url}}">Login</a>

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -106,12 +106,14 @@
             <a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a>
         </span>
         {% endblock %}
+        {% if user %}
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#thenavbar" aria-expanded="false">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
+        {% endif %}
       </div>
 
       <div class="collapse navbar-collapse" id="thenavbar">


### PR DESCRIPTION
Closes #2182 

I think for #2182 we can simply hide the hamburger menu when there's no `user` variable set? The menu that goes under that hamburger menu [appears to be filled only when there is a `user` set](https://github.com/jupyterhub/jupyterhub/blob/dbc6998375dd8251d196863425b26adc814624cd/share/jupyterhub/templates/page.html#L118), so that would match it I think.

So the login page would look like this on mobile:

![image](https://user-images.githubusercontent.com/304786/85503975-16cdc380-b63f-11ea-95f9-4f2ab5f739c0.png)

---

Another issue that I noticed is that the JupyterHub icon doesn't have a left margin, as the hamburger button menu has on its right hand-side.

![image](https://user-images.githubusercontent.com/304786/85503999-2a792a00-b63f-11ea-8ebd-db8d7326a83b.png)

Added a commit that adds the same margin, using a Bootstrap variable, but only when in mobile mode. That's because the `container-fluid` class appears to be doing the trick when not in mobile, so simply adding it would add the margin twice.

![image](https://user-images.githubusercontent.com/304786/85504087-5694ab00-b63f-11ea-861c-0b7bbb806dd9.png)

![GIFrecord_2020-06-24_155738](https://user-images.githubusercontent.com/304786/85504204-a1aebe00-b63f-11ea-8b61-4e3c7081d783.gif)

---

And clicking on the hamburger menu when logged in, displays the user name and the logout button without left padding/margin.

![image](https://user-images.githubusercontent.com/304786/85504345-f2beb200-b63f-11ea-812b-c39be7289c1a.png)


That's because Bootstrap adds it to `.nav > li > a`, but for the user name and button, we have both under `.nav > li > span`. Added the same values as Bootstrap for `.nav > li > a`, but again only in responsive mode, as in desktop mode it displays everything in horizontal/inline mode.

Final version with the changes in this PR:

![GIFrecord_2020-06-24_171210](https://user-images.githubusercontent.com/304786/85504209-a4a9ae80-b63f-11ea-95a1-492b84dde65a.gif)

To review, it's possible to check out this branch/PR, then run `python setup.py css` to re-compile the less styles, then run `jupyterhub`.

Cheers
Bruno