### PR TITLE
Update version in docs/rest-api.yaml

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
   title: JupyterHub
   description: The REST API for JupyterHub
-  version: 0.9.0dev
+  version: 1.2.0dev
   license:
     name: BSD-3-Clause
 schemes:


### PR DESCRIPTION
The version tag has not been updated since 0.9.0dev.