### PR TITLE
fix for stopping named server deleting default server and tests

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -912,7 +912,7 @@ class BaseHandler(RequestHandler):
                 self.log.error(
                     "Stopping %s to avoid inconsistent state", user_server_name
                 )
-                await user.stop()
+                await user.stop(server_name)
                 PROXY_ADD_DURATION_SECONDS.labels(status='failure').observe(
                     time.perf_counter() - proxy_add_start_time
                 )

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -389,6 +389,7 @@ async def test_named_server_stop_server(app, username, named_servers):
         r.raise_for_status()
         assert r.status_code == 201
         assert r.text == ''
-        assert user.spawners[server_name].server is None
-        assert user.spawners[''].server
-        assert user.running
+
+    assert user.spawners[server_name].server is None
+    assert user.spawners[''].server
+    assert user.running

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -368,3 +368,39 @@ async def test_user_redirect_hook_default_server_name(
     assert redirected_url.path == url_path_join(
         app.base_url, 'user', username, 'terminals/1'
     )
+
+
+async def test_named_server_stop_server(app, username, named_servers):
+    server_name = "myserver"
+    base_url = public_url(app)
+    cookies = await app.login_user(username)
+    user = app.users[username]
+    with mock.patch.dict(app.users.settings, {'spawner_class': FormSpawner}):
+        with mock.patch.object(
+            app.proxy, 'add_user', side_effect=Exception('mock exception')
+        ):
+            await user.spawn()  # spawn default server
+
+            r = await get_page(
+                'spawn/%s/%s' % (username, server_name), app, cookies=cookies
+            )
+            r.raise_for_status()
+            assert r.url.endswith('/spawn/%s/%s' % (username, server_name))
+            assert FormSpawner.options_form in r.text
+
+            # submit the form, should throw Exceotion when add_user is called
+            next_url = url_path_join(
+                app.base_url, 'hub/spawn-pending', username, server_name
+            )
+            r = await async_requests.post(
+                url_concat(
+                    url_path_join(base_url, 'hub/spawn', username, server_name),
+                    {'next': next_url},
+                ),
+                cookies=cookies,
+                data={'bounds': ['-10', '10'], 'energy': '938MeV'},
+            )
+            r.raise_for_status()
+            assert user.spawners[server_name].server is None
+            assert user.running
+            assert user.spawners[''].server


### PR DESCRIPTION
Fix for #3060 
Edited the offending line as suggested by @jeevb and added the corresponding test in `test_named_servers.py`