### PR TITLE
Log slow_stop_timeout when hit like slow_spawn_timeout

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1120,7 +1120,10 @@ class BaseHandler(RequestHandler):
         except gen.TimeoutError:
             # hit timeout, but stop is still pending
             self.log.warning(
-                "User %s:%s server is slow to stop", user.name, server_name
+                "User %s:%s server is slow to stop (timeout=%s)",
+                user.name,
+                server_name,
+                self.slow_stop_timeout,
             )
 
         # return handle on the future for hooking up callbacks


### PR DESCRIPTION
When `slow_spawn_timeout` is hit the configured timeout value
gets logged [1]. This does the same thing when `slow_stop_timeout`
is hit.

[1] https://github.com/jupyterhub/jupyterhub/blob/1.1.0/jupyterhub/handlers/base.py#L947