### PR TITLE
only build tagged versions on docker tags

### DIFF
--- a/singleuser/hooks/build
+++ b/singleuser/hooks/build
@@ -1,11 +1,4 @@
 #!/bin/bash
 set -ex
 
-stable=0.9
-
-for V in master $stable; do
-    docker build --build-arg JUPYTERHUB_VERSION=$V -t $DOCKER_REPO:$V .
-done
-
-echo "tagging $IMAGE_NAME"
-docker tag $DOCKER_REPO:$stable $IMAGE_NAME
+docker build --build-arg JUPYTERHUB_VERSION=$DOCKER_TAG -t $DOCKER_REPO:$DOCKER_TAG .

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -1,15 +1,10 @@
 #!/bin/bash
 set -ex
 
-stable=0.9
-for V in master $stable; do
-  docker push $DOCKER_REPO:$V
-done
-
 function get_hub_version() {
   rm -f hub_version
   V=$1
-  docker run --rm -v $PWD:/version -u $(id -u) -i $DOCKER_REPO:$V sh -c 'jupyterhub --version > /version/hub_version'
+  docker run --rm -v $PWD:/version -u $(id -u) -i $DOCKER_REPO:$DOCKER_TAG sh -c 'jupyterhub --version > /version/hub_version'
   hub_xyz=$(cat hub_version)
   split=( ${hub_xyz//./ } )
   hub_xy="${split[0]}.${split[1]}"
@@ -18,14 +13,9 @@ function get_hub_version() {
     hub_xy="${hub_xy}.${split[3]}"
   fi
 }
-# tag e.g. 0.8.1 with 0.8
-get_hub_version $stable
-docker tag $DOCKER_REPO:$stable $DOCKER_REPO:$hub_xyz
-docker push $DOCKER_REPO:$hub_xyz
-
 # tag e.g. 0.9 with master
-get_hub_version master
-docker tag $DOCKER_REPO:master $DOCKER_REPO:$hub_xy
+get_hub_version
+docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$hub_xy
 docker push $DOCKER_REPO:$hub_xy
-docker tag $DOCKER_REPO:master $DOCKER_REPO:$hub_xyz
+docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$hub_xyz
 docker push $DOCKER_REPO:$hub_xyz


### PR DESCRIPTION
instead of building 'stable' from master

manually tracking what 'stable' is here is resulting in out-of-date docker images. Instead, build pinned versions on tags like we do for the jupyterhub images.

Related to https://github.com/jupyterhub/dockerspawner/pull/379 where the 1.1 image was never uploaded