### PR TITLE
jupyterhub/user: clear spawner state after post_stop_hook

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -795,8 +795,7 @@ class User:
             status = await spawner.poll()
             if status is None:
                 await spawner.stop()
-            spawner.clear_state()
-            spawner.orm_spawner.state = spawner.get_state()
+            spawner.orm_spawner.state = {}
             self.last_activity = spawner.orm_spawner.last_activity = datetime.utcnow()
             # remove server entry from db
             spawner.server = None
@@ -826,7 +825,13 @@ class User:
             spawner.orm_spawner.started = None
             self.db.commit()
             # trigger post-stop hook
-            await maybe_future(spawner.run_post_stop_hook())
+            try:
+                await maybe_future(spawner.run_post_stop_hook())
+            except:
+                spawner.clear_state()
+                raise
+            spawner.clear_state()
+
             # trigger post-spawner hook on authenticator
             auth = spawner.authenticator
             try:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -828,8 +828,12 @@ class User:
                 await maybe_future(spawner.run_post_stop_hook())
             except:
                 spawner.clear_state()
+                spawner.orm_spawner.state = spawner.get_state()
+                self.db.commit()
                 raise
             spawner.clear_state()
+            spawner.orm_spawner.state = spawner.get_state()
+            self.db.commit()
 
             # trigger post-spawner hook on authenticator
             auth = spawner.authenticator

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -795,7 +795,6 @@ class User:
             status = await spawner.poll()
             if status is None:
                 await spawner.stop()
-            spawner.orm_spawner.state = {}
             self.last_activity = spawner.orm_spawner.last_activity = datetime.utcnow()
             # remove server entry from db
             spawner.server = None


### PR DESCRIPTION
I'm submitting this more for discussion than I think it's a good idea, because it's easier to have something concrete to talk about than discussing abstractly.

- Related issue: #3120.  Closes: #3120.

- I realized that spawner.clear_state() is called before
  spawner.post_stop_hook().  This caused was a bit surprising to me,
  and caused some issues.

- I tried the naive strategy of moving clear_state to later and
  setting the orm_state to `{}` at the point where it used to be
  clear.

- This tries to maintain the exception behavior of clear_state and
  post_stop_hook, but is exactly identical.

- To review:

  - Is this even a good idea!

  - Carefully consider the implications of this.  I am not at all sure
    about unintended side-effects or what intended semantics are.
    Should the statements be re-ordered some other way?