### PR TITLE
app.py: Work around incompatibility between Tornado 6 and asyncio proactor event loop in python 3.8 on Windows

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2751,13 +2751,16 @@ class JupyterHub(Application):
             try:
                 from asyncio import (
                     WindowsProactorEventLoopPolicy,
-                    WindowsSelectorEventLoopPolicy
+                    WindowsSelectorEventLoopPolicy,
                 )
             except ImportError:
                 pass
                 # not affected
             else:
-                if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                if (
+                    type(asyncio.get_event_loop_policy())
+                    is WindowsProactorEventLoopPolicy
+                ):
                     # WindowsProactorEventLoopPolicy is not compatible with Tornado 6.
                     # Fallback to the pre-3.8 default of WindowsSelectorEventLoopPolicy.
                     asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2772,6 +2772,7 @@ class JupyterHub(Application):
         if self._atexit_ran:
             return
         self._atexit_ran = True
+        self._init_asyncio_patch()
         # run the cleanup step (in a new loop, because the interrupted one is unclean)
         asyncio.set_event_loop(asyncio.new_event_loop())
         IOLoop.clear_current()

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2731,6 +2731,37 @@ class JupyterHub(Application):
         self.log.critical("Received signalnum %s, , initiating shutdown...", signum)
         raise SystemExit(128 + signum)
 
+    def _init_asyncio_patch(self):
+        """Set default asyncio policy to be compatible with Tornado.
+
+        Tornado 6 (at least) is not compatible with the default
+        asyncio implementation on Windows.
+
+        Pick the older SelectorEventLoopPolicy on Windows
+        if the known-incompatible default policy is in use.
+
+        Do this as early as possible to make it a low priority and overrideable.
+
+        ref: https://github.com/tornadoweb/tornado/issues/2608
+
+        FIXME: If/when tornado supports the defaults in asyncio,
+               remove and bump tornado requirement for py38.
+        """
+        if sys.platform.startswith("win") and sys.version_info >= (3, 8):
+            try:
+                from asyncio import (
+                    WindowsProactorEventLoopPolicy,
+                    WindowsSelectorEventLoopPolicy
+                )
+            except ImportError:
+                pass
+                # not affected
+            else:
+                if type(asyncio.get_event_loop_policy()) is WindowsProactorEventLoopPolicy:
+                    # WindowsProactorEventLoopPolicy is not compatible with Tornado 6.
+                    # Fallback to the pre-3.8 default of WindowsSelectorEventLoopPolicy.
+                    asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
+
     _atexit_ran = False
 
     def atexit(self):
@@ -2787,6 +2818,7 @@ class JupyterHub(Application):
     @classmethod
     def launch_instance(cls, argv=None):
         self = cls.instance()
+        self._init_asyncio_patch()
         loop = IOLoop.current()
         task = asyncio.ensure_future(self.launch_instance_async(argv))
         try:


### PR DESCRIPTION
In py38, asyncio made the `WindowsProactorEventLoopPolicy` the default setting for event loops on Windows. However, this is incompatible with Tornado. The result is that the Hub does not start on Windows on Python 3.8, with a `NotImplementedError`. See tornadoweb/tornado#2608 for additional context. 

The workaround suggested by Tornado is to use the older `WindowsSelectorEventLoopPolicy`, which is the default in py37 and before. This is done via:
```
asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

This workaround has already been applied in the single-user server: jupyter/notebook#5047. The content of this PR is almost identical to the single-user one, save for some formatting differences. We only alter the default setting if we're running in an environment where this issue might occur (Windows, py38, and a sufficiently advanced asyncio API).