### PR TITLE
Don't log a warning when slow_spawn_timeout is disabled

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -977,13 +977,16 @@ class BaseHandler(RequestHandler):
             # waiting_for_response indicates server process has started,
             # but is yet to become responsive.
             if spawner._spawn_pending and not spawner._waiting_for_response:
-                # still in Spawner.start, which is taking a long time
-                # we shouldn't poll while spawn is incomplete.
-                self.log.warning(
-                    "User %s is slow to start (timeout=%s)",
-                    user_server_name,
-                    self.slow_spawn_timeout,
-                )
+                # If slow_spawn_timeout is intentionally disabled then we
+                # don't need to log a warning, just return.
+                if self.slow_spawn_timeout > 0:
+                    # still in Spawner.start, which is taking a long time
+                    # we shouldn't poll while spawn is incomplete.
+                    self.log.warning(
+                        "User %s is slow to start (timeout=%s)",
+                        user_server_name,
+                        self.slow_spawn_timeout,
+                    )
                 return
 
             # start has finished, but the server hasn't come up


### PR DESCRIPTION
When using the `KubeSpawner` it is typical to disable the
`slow_spawn_timeout` by setting it to 0. `zero-to-jupyterhub-k8s`
does this by default [1]. However, this causes an immediate `TimeoutError`
which gets logged as a warning like this:

>User hub-stress-test-123 is slow to start (timeout=0)

This avoids the warning by checking the value and if disabled simply
returns without logging the warning.

[1] https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/b4738edc5

Closes #3126