### PR TITLE
Allow head requests for the health endpoint

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -658,6 +658,9 @@ class HealthCheckHandler(BaseHandler):
     def get(self, *args):
         self.finish()
 
+    def head(self, *args):
+        self.finish()
+
 
 default_handlers = [
     (r'/', RootHandler),


### PR DESCRIPTION
One of the uptime checkers we're using only sends HEAD requests, and tornado doesn't like the HEAD requests and return a 405. We currently have a workaround as follows in the helm chart for Z2JH, but a more permanent solution would be ideal.
```yaml
hub:
  extraConfig:
    enable-head-request-on-health: |
      from jupyterhub.handlers.base import BaseHandler
      class HealthCheckHandler(BaseHandler):
          def get(self, *args):
              self.finish()
          def head(self, *args):
              self.finish()
      c.JupyterHub.extra_handlers.append((r'/health2$', HealthCheckHandler))
```

---

Edit by @consideRatio, related PR in BinderHub: https://github.com/jupyterhub/binderhub/pull/1137