### PR TITLE
Fix the services dropdown on the admin page

### DIFF
--- a/share/jupyterhub/static/js/admin.js
+++ b/share/jupyterhub/static/js/admin.js
@@ -1,9 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function(
+require(["jquery", "moment", "jhapi", "utils"], function(
   $,
-  bs,
   moment,
   JHAPI,
   utils


### PR DESCRIPTION
Fixes #3003 opened by @jtpio 
Remove the unused bootstrap variable which canceled the dropdown events.
I tested the admin actions with different browsers, everything works fine.