### PR TITLE
Allow JupyterHub.default_url to be a callable

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1322,12 +1322,12 @@ class JupyterHub(Application):
 
         By default, redirects users to their own server.
 
-        Can be a Unicode string (e.g. '/hub/home') or a callable based on the user object:
+        Can be a Unicode string (e.g. '/hub/home') or a callable based on the handler object:
 
-            def default_url_fn(user):
-                if user:
-                    if user.admin:
-                        return '/hub/admin'
+            def default_url_fn(handler):
+                user = handler.current_user
+                if user and user.admin:
+                    return '/hub/admin'
                 return '/hub/home'
 
             c.JupyterHub.default_url = default_url_fn

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1324,6 +1324,8 @@ class JupyterHub(Application):
 
         Can be a Unicode string (e.g. '/hub/home') or a callable based on the handler object:
 
+        ::
+        
             def default_url_fn(handler):
                 user = handler.current_user
                 if user and user.admin:

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -55,6 +55,7 @@ from traitlets import (
     Instance,
     Bytes,
     Float,
+    Union,
     observe,
     default,
     validate,
@@ -1314,12 +1315,23 @@ class JupyterHub(Application):
         """
     ).tag(config=True)
 
-    default_url = Unicode(
+    default_url = Union(
+        [Unicode(), Callable()],
         help="""
         The default URL for users when they arrive (e.g. when user directs to "/")
 
         By default, redirects users to their own server.
-        """
+
+        Can be a Unicode string (e.g. '/hub/home') or a callable based on the user object:
+
+            def default_url_fn(user):
+                if user:
+                    if user.admin:
+                        return '/hub/admin'
+                return '/hub/home'
+
+            c.JupyterHub.default_url = default_url_fn
+        """,
     ).tag(config=True)
 
     user_redirect_hook = Callable(

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -638,8 +638,15 @@ class BaseHandler(RequestHandler):
             )
 
         if not next_url:
-            # custom default URL
-            next_url = default or self.default_url
+            # custom default URL, usually passed because user landed on that page but was not logged in
+            if default:
+                next_url = default
+            else:
+                # As set in jupyterhub_config.py
+                if callable(self.default_url):
+                    next_url = self.default_url(user)
+                else:
+                    next_url = self.default_url
 
         if not next_url:
             # default URL after login

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -644,7 +644,7 @@ class BaseHandler(RequestHandler):
             else:
                 # As set in jupyterhub_config.py
                 if callable(self.default_url):
-                    next_url = self.default_url(user)
+                    next_url = self.default_url(self)
                 else:
                     next_url = self.default_url
 


### PR DESCRIPTION
This allows c.JupyterHub.default_url to be a Unicode as before (e.g. '/hub/home') but also allows a callable to be provided instead, calculating the initial URL for a logged-in user based on the user object.

For example in jupyterhub_config.py:

```
def default_url_fn(user):
    if user:
        if user.admin:
            return '/hub/admin'
    return '/hub/home'

c.JupyterHub.default_url = default_url_fn
```

This is useful when the JupyterHub is being used in large part for authentication, but users are often there for other services such as [ContainDS Dashboards](https://cdsdashboards.readthedocs.io/).

Regular users might be redirected to a specific 'intro' dashboard, whereas admin users (or users belonging to a particular group etc) would prefer to go to the main JupyterHub.
