### PR TITLE
admin page sorts on spawner last_activity instead of user last_activity

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -463,7 +463,8 @@ class AdminHandler(BaseHandler):
         mapping = {'running': orm.Spawner.server_id}
         for name in available:
             if name not in mapping:
-                mapping[name] = getattr(orm.User, name)
+                table = orm.User if name != "last_activity" else orm.Spawner
+                mapping[name] = getattr(table, name)
 
         default_order = {
             'name': 'asc',


### PR DESCRIPTION
Currently the admin page last_activity is sorted on User's last activity, which makes it work odd because the column is actually showing the last_activity spawners.   This PR changed the sort column to be spawner's last activity. 
