### PR TITLE
Document external service api_tokens better

### DIFF
--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -151,6 +151,8 @@ c.JupyterHub.services = [
     {
         'name': 'my-web-service',
         'url': 'https://10.0.1.1:1984',
+        # any secret >8 characters, you'll use api_token to
+        # authenticate api requests to the hub from your service
         'api_token': 'super-secret',
     }
 ]
@@ -331,7 +333,9 @@ and taking note of the following process:
 1. retrieve the cookie `jupyterhub-services` from the request.
 2. Make an API request `GET /hub/api/authorizations/cookie/jupyterhub-services/cookie-value`,
     where cookie-value is the url-encoded value of the `jupyterhub-services` cookie.
-    This request must be authenticated with a Hub API token in the `Authorization` header.
+    This request must be authenticated with a Hub API token in the `Authorization` header,
+    for example using the `api_token` from your [external service's configuration](#externally-managed-services).
+
     For example, with [requests][]:
 
     ```python


### PR DESCRIPTION
We're implementing an externally managed service (implemented in javascript/node), following the [implementing your own auth](https://jupyterhub.readthedocs.io/en/stable/reference/services.html#implementing-your-own-authentication-with-jupyterhub) docs.

Getting this to work was difficult (we've spent a couple days debugging, just getting 403 errors, playing guessing games, and reading lots of source code), and two additions to the docs would have saved us a couple days:

- Explicitly mention the min-8-char constraint on (at least `api_token`) secrets, if the api_token is less than 8 characters, which we used in dev to prevent typing mistakes, it will silently not be registered, and trying to use it will always return 403s.
- Connect the api_token in the configuration with the one mentioned in auth requests. This probably wouldn't have been as important, but when debugging "all bets are off", and we started to question which token was which, including confusing this with the proxy API token at one point. I think explicitly mentioning that the tokens mentioned in the two sections are one and the same will help other people.

Co-authored-by: Mike Situ <msitu@ceresimaging.net>