### PR TITLE
Needed NoEsacpe (NE)  option for apache

### DIFF
--- a/docs/source/reference/config-proxy.md
+++ b/docs/source/reference/config-proxy.md
@@ -202,8 +202,8 @@ In case of the need to run the jupyterhub under /jhub/ or other location please 
 
 httpd.conf amendments:
 ```bash
- RewriteRule /jhub/(.*) ws://127.0.0.1:8000/jhub/$1 [P,L]
- RewriteRule /jhub/(.*) http://127.0.0.1:8000/jhub/$1 [P,L]
+ RewriteRule /jhub/(.*) ws://127.0.0.1:8000/jhub/$1 [NE.P,L]
+ RewriteRule /jhub/(.*) http://127.0.0.1:8000/jhub/$1 [NE,P,L]
  
  ProxyPass /jhub/ http://127.0.0.1:8000/jhub/
  ProxyPassReverse /jhub/  http://127.0.0.1:8000/jhub/


### PR DESCRIPTION
Else %20 is esacped to %25%20 and we can not rename "Untitled Folder'
or opening files with spaces or other special chars fails.