### PR TITLE
Get error description from error key vs error_description key

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -371,9 +371,9 @@ class HubAuth(SingletonConfigurable):
             )
             app_log.warning(r.text)
             msg = "Failed to check authorization"
-            # pass on error_description from oauth failure
+            # pass on error from oauth failure
             try:
-                description = r.json().get("error_description")
+                description = r.json().get("error")
             except Exception:
                 pass
             else:

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -373,10 +373,10 @@ class HubAuth(SingletonConfigurable):
             msg = "Failed to check authorization"
             # pass on error from oauth failure
             try:
-                description = (
-                    r.json().get("error")
-                    if r.json().get("error")
-                    else r.json().get("error_description")
+                response = r.json()
+                # prefer more specific 'error_description', fallback to 'error'
+                description = response.get(
+                    "error_description", response.get("error", "Unknown error")
                 )
             except Exception:
                 pass

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -373,7 +373,11 @@ class HubAuth(SingletonConfigurable):
             msg = "Failed to check authorization"
             # pass on error from oauth failure
             try:
-                description = r.json().get("error")
+                description = (
+                    r.json().get("error")
+                    if r.json().get("error")
+                    else r.json().get("error_description")
+                )
             except Exception:
                 pass
             else:


### PR DESCRIPTION
Fetch description from `error` key if available or `error_description` key as a fallback.

Closes #3146 