### PR TITLE
docs: please docs linter (move_cert docstring)

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -943,14 +943,14 @@ class Spawner(LoggingConfigurable):
         """Takes certificate paths and makes them available to the notebook server
 
         Arguments:
-            paths (dict): a list of paths for key, cert, and CA. These paths
-            will be resolvable and readable by the Hub process, but not
-            necessarily by the notebook server.
+            paths (dict): a list of paths for key, cert, and CA.
+                These paths will be resolvable and readable by the Hub process,
+                but not necessarily by the notebook server.
 
         Returns:
             dict: a list (potentially altered) of paths for key, cert, and CA.
-            These paths should be resolvable and readable by the notebook server
-            to be launched.
+                These paths should be resolvable and readable by the notebook
+                server to be launched.
 
 
         `.move_certs` is called after certs for the singleuser notebook have

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -943,15 +943,14 @@ class Spawner(LoggingConfigurable):
         """Takes certificate paths and makes them available to the notebook server
 
         Arguments:
-            paths (dict): a list of paths for key, cert, and CA.
-            These paths will be resolvable and readable by the Hub process,
-            but not necessarily by the notebook server.
+            paths (dict): a list of paths for key, cert, and CA. These paths
+            will be resolvable and readable by the Hub process, but not
+            necessarily by the notebook server.
 
         Returns:
-            dict: a list (potentially altered) of paths for key, cert,
-            and CA.
-            These paths should be resolvable and readable
-            by the notebook server to be launched.
+            dict: a list (potentially altered) of paths for key, cert, and CA.
+            These paths should be resolvable and readable by the notebook server
+            to be launched.
 
 
         `.move_certs` is called after certs for the singleuser notebook have
@@ -1618,5 +1617,5 @@ class SimpleLocalProcessSpawner(LocalProcessSpawner):
         return env
 
     def move_certs(self, paths):
-        """No-op for installing certs"""
+        """No-op for installing certs."""
         return paths


### PR DESCRIPTION
This fixes [a CircleCI build failure](https://app.circleci.com/pipelines/github/jupyterhub/jupyterhub/160/workflows/025ff595-c247-43b8-9492-008e765d2e74/jobs/2390) noticed in another PR failing with the following error.

```
Warning, treated as error:
/home/circleci/project/jupyterhub/spawner.py:docstring of jupyterhub.spawner.Spawner.move_certs:6:Field list ends without a blank line; unexpected unindent.
Makefile:68: recipe for target 'html' failed
make: *** [html] Error 2
```
