### PR TITLE
Update Dockerfile to ubuntu:focal (Python 3.8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,10 @@ jobs:
           name: smoke test jupyterhub
           command: |
             docker run --rm -it jupyterhub/jupyterhub jupyterhub --help
+      - run:
+          name: verify static files
+          command: |
+            docker run --rm -it -v $PWD/dockerfiles:/io jupyterhub/jupyterhub python3 /io/test.py
 
   docs:
     # This is the base environment that Circle will use

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,19 +40,18 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+RUN python3 -m pip install --upgrade setuptools pip wheel
+
 # copy everything except whats in .dockerignore, its a
 # compromise between needing to rebuild and maintaining
 # what needs to be part of the build
 COPY . /src/jupyterhub/
-
 WORKDIR /src/jupyterhub
-
-RUN python3 -m pip install --upgrade setuptools pip wheel
 
 # Build client component packages (they will be copied into ./share and
 # packaged with the built wheel.)
-RUN npm install
-RUN python3 -m pip wheel --wheel-dir wheelhouse .
+RUN python3 setup.py bdist_wheel
+RUN python3 -m pip wheel --wheel-dir wheelhouse dist/*.whl
 
 
 FROM $BASE_IMAGE

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@
 # your jupyterhub_config.py will be added automatically
 # from your docker directory.
 
-# https://github.com/tianon/docker-brew-ubuntu-core/commit/d4313e13366d24a97bd178db4450f63e221803f1
-ARG BASE_IMAGE=ubuntu:bionic-20191029@sha256:6e9f67fa63b0323e9a1e587fd71c561ba48a034504fb804fd26fd8800039835d
+ARG BASE_IMAGE=ubuntu:focal-20200729@sha256:6f2fb2f9fb5582f8b587837afd6ea8f37d8d1d9e41168c90f410a6ef15fa8ce5
 FROM $BASE_IMAGE AS builder
 
 USER root

--- a/dockerfiles/test.py
+++ b/dockerfiles/test.py
@@ -1,0 +1,9 @@
+import os
+
+from jupyterhub._data import DATA_FILES_PATH
+
+print(f"DATA_FILES_PATH={DATA_FILES_PATH}")
+
+for sub_path in ("templates", "static/components", "static/css/style.min.css"):
+    path = os.path.join(DATA_FILES_PATH, sub_path)
+    assert os.path.exists(path), path

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/jupyter/jupyterhub.git"
   },
   "scripts": {
-    "postinstall": "python ./bower-lite",
+    "postinstall": "python3 ./bower-lite",
     "fmt": "prettier --write --trailing-comma es5 share/jupyterhub/static/js/*",
     "lessc": "lessc"
   },


### PR DESCRIPTION
This updates the Docker base image from Ubuntu bionic (18.04) to focal (20.04), which bumps Python3 to 3.8. This might help deal with problems with SameSite cookies:
- https://github.com/jupyterhub/jupyterhub/issues/3117
- https://discourse.jupyter.org/t/issue-with-chrome-80-and-samesite-cookie-changes/3757/7