### PR TITLE
Don't allow 'python:3.8 + master dependencies' to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,5 +103,7 @@ jobs:
       python: nightly
   allow_failures:
     - name: python:nightly
-    - name: python:3.8 + master dependencies
+    # https://github.com/jupyterhub/jupyterhub/issues/3141
+    # The latest traitlets is close to release so it should not fail
+    # - name: python:3.8 + master dependencies
   fast_finish: true


### PR DESCRIPTION
closed #3141
Traitlets 5 is close to release, so it should be safe to require the latest commits to pass.