### PR TITLE
Added extra documentation for endpoint /users/{name}/servers/{server_name}.

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -283,7 +283,10 @@ paths:
           required: true
           type: string
         - name: server_name
-          description: name given to a named-server
+          description: |
+            name given to a named-server. 
+            
+            Note that depending on your JupyterHub infrastructure there are chracterter size limitation to `server_name`. Default spawner with K8s pod will not allow Jupyter Notebooks to be spawned with a name that contains more than 253 characters (keep in mind that the pod will be spawned with extra characters to identify the user and hub).
           in: path
           required: true
           type: string


### PR DESCRIPTION
As mentioned on #3158, there is missing documentation for the endpoint above regarding the character limitation for the `{server_name}` variable. 

This PR is not final. Any input is appreciated on how this should be written.

![Screen Shot 2020-08-26 at 7 04 10 PM](https://user-images.githubusercontent.com/2829082/91365383-f05b0e80-e7ce-11ea-9c8c-adea1b4266cc.png)