### PR TITLE
Control service display

### DIFF
--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -23,6 +23,7 @@ def service_model(service):
         'command': service.command,
         'pid': service.proc.pid if service.proc else 0,
         'info': service.info,
+        'display': service.display,
     }
 
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1188,6 +1188,8 @@ class BaseHandler(RequestHandler):
         for service in self.services.values():
             if not service.url:
                 continue
+            if not service.display:
+                continue
             accessible_services.append(service)
         return accessible_services
 

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -201,6 +201,11 @@ class Service(LoggingConfigurable):
         """
     ).tag(input=True)
 
+    display = Bool(
+        True,
+        help="""Whether to list the service on the JupyterHub UI"""
+    ).tag(input=True)
+
     oauth_no_confirm = Bool(
         False,
         help="""Skip OAuth confirmation when users access this service.

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -202,8 +202,7 @@ class Service(LoggingConfigurable):
     ).tag(input=True)
 
     display = Bool(
-        True,
-        help="""Whether to list the service on the JupyterHub UI"""
+        True, help="""Whether to list the service on the JupyterHub UI"""
     ).tag(input=True)
 
     oauth_no_confirm = Bool(

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1514,6 +1514,7 @@ async def test_get_services(app, mockservice_url):
             'prefix': mockservice.server.base_url,
             'url': mockservice.url,
             'info': {},
+            'display': True,
         }
     }
 
@@ -1538,6 +1539,7 @@ async def test_get_service(app, mockservice_url):
         'prefix': mockservice.server.base_url,
         'url': mockservice.url,
         'info': {},
+        'display': True,
     }
 
     r = await api_request(


### PR DESCRIPTION
The Hub UI now includes a dropdown that lists links to services.  Some services may not have a particularly useful UI that makes sense to expose.  This PR:

-  adds a configurable boolean `display` traitlet to the `Service` class (default `True`),
-  changes the base handler to read the `display` value and omit services we don't want to provide access to, and
-  includes the `display` variable in the API model

The traitlet itself is documented but I haven't updated the `Service` class doc-string itself to include it.  I notice that some other fields (e.g. `info`) are not included in the doc-string either.  I interpret it to mean there are some fields that are much less important to call out, and I could see `display` being one of those (though I find it useful!).