### PR TITLE
[WIP] Remove @ from list of safe chars when escaping username

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -396,7 +396,7 @@ class User:
     @property
     def escaped_name(self):
         """My name, escaped for use in URLs, cookies, etc."""
-        return quote(self.name, safe='@~')
+        return quote(self.name, safe='~')
 
     @property
     def json_escaped_name(self):


### PR DESCRIPTION
Reading up a little bit on URLs I think JupyterHub should not allow @ in the server's URL - it should be URL encoding it I believe. See [here](https://perishablepress.com/stop-using-unsafe-characters-in-urls/).

While @ is technically valid in URLs, it's not really valid in the path and should be URL encoded there.

IMO we shouldn't be seeing URLs like https://myjupyterhub.net/user/dan@test.com/
They should be https://myjupyterhub.net/user/dan%40test.com/
which admittedly doesn't look so nice!

Please note I haven't tested my code change - other aspects might need amending too - but wanted to see if anyone had any important opinions on this first.

This issue has caused confusion [here](https://github.com/ideonate/jhsingle-native-proxy/pull/6). (Although there is also arguably another fix needed in the component in question...)