### PR TITLE
test routing of strictly encoded urls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
             db: mysql
           - python: "3.8"
             db: postgres
+            subdomain: subdomain
           - python: "3.8"
             jupyter_server: jupyter_server
           - python: "3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ alembic
 async_generator>=1.9
 certipy>=0.1.2
 entrypoints
+escapism
 jinja2
 jupyter_telemetry>=0.1.0
 oauthlib>=3.0


### PR DESCRIPTION
tests that usernames with reserved-but-valid characters e.g. `@` and `~` can receive requests from URLs that are strictly encoded (i.e. `@ -> %40`) *and* loosely encoded (preserve `@`).

related to #3164