### PR TITLE
First step for implementing oauth scopes - update to rest-api.yml

### DIFF
--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -737,7 +737,7 @@ paths:
       summary: Identify a user or service from an API token
       security:
         - oauth2:
-          - read:all # minrk: is it really necessary to have a scope for this, or use self handler for token whoami?
+          - read:users:tokens # minrk: is it really necessary to have a scope for this, or use self handler for token whoami?
       parameters:
         - name: token
           in: path

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -16,34 +16,34 @@ securityDefinitions:
   oauth2:
     type: oauth2
     flow: accessCode
-    authorizationUrl: 'https://localhost:8000/hub/api/oauth2/authorize' # what are the absolute URIs here? is oauth2 correct here or shall we use just authorizations?
-    tokenUrl: 'https://localhost:8000/hub/api/oauth2/token'
+    authorizationUrl: '/hub/api/oauth2/authorize' # what are the absolute URIs here? is oauth2 correct here or shall we use just authorizations?
+    tokenUrl: '/hub/api/oauth2/token'
     scopes:
       all: Everything a user can do
       read:all: Read-only access to everything a user can read (also whoami handler)
       users: Grants access to managing users including reading users’ model, posting activity and starting/stoping users servers
       read:users: Read-only access to the above
-      read:users:username: Read-only access to a single user's model
+      read:users!user=username: Read-only access to a single user's model
       read:users:names: Read-only access to users' names
       read:users:groups: Read-only access to users' groups
       read:users:activity: Read-only access to users' activity
-      read:users:activity:groupname: Read-only access to specific group's users' activity
+      read:users:activity!group=groupname: Read-only access to specific group's users' activity
       read:users:servers: Read-only access to users' servers
-      users:activity:username: Update a user's activity
+      users:activity!user=username: Update a user's activity
       users:servers: Grants access to start/stop any server
-      users:servers:servername: Limits the above to a specific server
+      users:servers!server=servername: Limits the above to a specific server
       users:tokens: Grants access to users' token (includes create/revoke a token)
       read:users:tokens: Identify a user from a token
       admin:users: Grants access to creating/removing users
       admin:users:servers: Grants access to create/remove users' servers
       groups: Add/remove users from any group
-      groups:groupname: Add/remove users from a specific group only
+      groups!group=groupname: Add/remove users from a specific group only
       read:groups: Read-only access to groups
       admin:groups: Grants access to create/delete groups
       read:services: Read-only access to services
       proxy: Grants access to proxy's routing table, syncing and notifying about a new proxy
       shutdown: Grants access to shutdown the Hub
-security: # global security, do we want to keep the only the apiKey (token: []), change to only oauth2 (with scope all) or have both as changed here (either can be used)?
+security: # global security, do we want to keep only the apiKey (token: []), change to only oauth2 (with scope all) or have both (either can be used)?
   - token: []
   - oauth2:
     - all
@@ -157,7 +157,7 @@ paths:
         - oauth2:
           - users
           - read:users
-          - read:users:username
+          - read:users!user=username
       parameters:
         - name: name
           description: username
@@ -240,7 +240,7 @@ paths:
       security:
         - oauth2:
           - users
-          - users:activity:username
+          - users:activity!user=username
       parameters:
         - name: name
           description: username
@@ -345,7 +345,7 @@ paths:
         - oauth2:
           - users
           - users:servers
-          - users:servers:servername
+          - users:servers!server=servername
       parameters:
         - name: name
           description: username
@@ -381,7 +381,7 @@ paths:
         - oauth2:
           - users
           - users:servers
-          - users:servers:servername
+          - users:servers!server=servername
       parameters:
         - name: name
           description: username
@@ -519,7 +519,7 @@ paths:
       security:
         - oauth2:
           - groups
-          - groups:groupname
+          - groups!group=groupname
           - read:groups
       parameters:
         - name: name
@@ -568,7 +568,7 @@ paths:
       security:
         - oauth2:
           - groups
-          - groups:groupname
+          - groups!group=groupname
       parameters:
         - name: name
           description: group name
@@ -597,7 +597,7 @@ paths:
       security:
         - oauth2:
           - groups
-          - groups:groupname
+          - groups!group=groupname
       parameters:
         - name: name
           description: group name
@@ -886,6 +886,11 @@ definitions:
       admin:
         type: boolean
         description: Whether the user is an admin
+      roles:
+        type: array
+        description: The names of roles this user has
+        items:
+          type: string
       groups:
         type: array
         description: The names of groups where this user is a member

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -43,8 +43,10 @@ securityDefinitions:
       read:services: Read-only access to services
       proxy: Grants access to proxy's routing table, syncing and notifying about a new proxy
       shutdown: Grants access to shutdown the Hub
-security:
+security: # global security, do we want to keep the only the apiKey (token: []), change to only oauth2 (with scope all) or have both as changed here (either can be used)?
   - token: []
+  - oauth2:
+    - all
 basePath: /hub/api
 produces:
   - application/json
@@ -109,6 +111,10 @@ paths:
   /users:
     get:
       summary: List users
+      security:
+        - oauth2:
+          - users
+          - read:users
       responses:
         '200':
           description: The Hub's user list
@@ -118,6 +124,9 @@ paths:
               $ref: '#/definitions/User'
     post:
       summary: Create multiple users
+      security:
+        - oauth2:
+          - admin:users
       parameters:
         - name: body
           in: body
@@ -144,6 +153,11 @@ paths:
   /users/{name}:
     get:
       summary: Get a user by name
+      security:
+        - oauth2:
+          - users
+          - read:users
+          - read:users:username
       parameters:
         - name: name
           description: username
@@ -157,6 +171,9 @@ paths:
             $ref: '#/definitions/User'
     post:
       summary: Create a single user
+      security:
+        - oauth2:
+          - admin:users
       parameters:
         - name: name
           description: username
@@ -171,6 +188,9 @@ paths:
     patch:
       summary: Modify a user
       description: Change a user's name or admin status
+      security:
+        - oauth2:
+          - users
       parameters:
         - name: name
           description: username
@@ -197,6 +217,9 @@ paths:
             $ref: '#/definitions/User'
     delete:
       summary: Delete a user
+      security:
+        - oauth2:
+          - admin:users
       parameters:
         - name: name
           description: username
@@ -214,6 +237,10 @@ paths:
         Notify the Hub of activity by the user,
         e.g. accessing a service or (more likely)
         actively using a server.
+      security:
+        - oauth2:
+          - users
+          - users:activity:username
       parameters:
         - name: name
           description: username
@@ -266,6 +293,10 @@ paths:
   /users/{name}/server:
     post:
       summary: Start a user's single-user notebook server
+      security:
+        - oauth2:
+          - users
+          - users:servers
       parameters:
         - name: name
           description: username
@@ -292,6 +323,10 @@ paths:
           description: The user's notebook server has not yet started, but has been requested
     delete:
       summary: Stop a user's server
+      security:
+        - oauth2:
+          - users
+          - users:servers
       parameters:
         - name: name
           description: username
@@ -306,6 +341,11 @@ paths:
   /users/{name}/servers/{server_name}:
     post:
       summary: Start a user's single-user named-server notebook server
+      security:
+        - oauth2:
+          - users
+          - users:servers
+          - users:servers:servername
       parameters:
         - name: name
           description: username
@@ -337,6 +377,11 @@ paths:
           description: The user's notebook named-server has not yet started, but has been requested
     delete:
       summary: Stop a user's named-server
+      security:
+        - oauth2:
+          - users
+          - users:servers
+          - users:servers:servername
       parameters:
         - name: name
           description: username
@@ -374,6 +419,9 @@ paths:
         type: string
     get:
       summary: List tokens for the user
+      security:
+        - oauth2:
+          - users:tokens
       responses:
         '200':
           description: The list of tokens
@@ -387,6 +435,9 @@ paths:
           description: No such user
     post:
       summary: Create a new token for the user
+      security:
+        - oauth2:
+          - users:tokens
       parameters:
         - name: token_params
           in: body
@@ -420,6 +471,9 @@ paths:
         type: string
     get:
       summary: Get the model for a token by id
+      security:
+        - oauth2:
+          - users:tokens
       responses:
         '200':
           description: The info for the new token
@@ -427,12 +481,19 @@ paths:
             $ref: '#/definitions/Token'
     delete:
       summary: Delete (revoke) a token by id
+      security:
+        - oauth2:
+          - users:tokens
       responses:
         '204':
           description: The token has been deleted
   /user:
     get:
       summary: Return authenticated user's model
+      security:
+        - oauth2:
+          - all
+          - read:all
       responses:
         '200':
           description: The authenticated user's model is returned.
@@ -441,6 +502,10 @@ paths:
   /groups:
     get:
       summary: List groups
+      security:
+        - oauth2:
+          - groups
+          - read:groups
       responses:
         '200':
           description: The list of groups
@@ -451,6 +516,11 @@ paths:
   /groups/{name}:
     get:
       summary: Get a group by name
+      security:
+        - oauth2:
+          - groups
+          - groups:groupname
+          - read:groups
       parameters:
         - name: name
           description: group name
@@ -464,6 +534,9 @@ paths:
             $ref: '#/definitions/Group'
     post:
       summary: Create a group
+      security:
+        - oauth2:
+          - admin:groups
       parameters:
         - name: name
           description: group name
@@ -477,6 +550,9 @@ paths:
             $ref: '#/definitions/Group'
     delete:
       summary: Delete a group
+      security:
+        - oauth2:
+          - admin:groups
       parameters:
         - name: name
           description: group name
@@ -489,6 +565,10 @@ paths:
   /groups/{name}/users:
     post:
       summary: Add users to a group
+      security:
+        - oauth2:
+          - groups
+          - groups:groupname
       parameters:
         - name: name
           description: group name
@@ -514,6 +594,10 @@ paths:
             $ref: '#/definitions/Group'
     delete:
       summary: Remove users from a group
+      security:
+        - oauth2:
+          - groups
+          - groups:groupname
       parameters:
         - name: name
           description: group name
@@ -538,6 +622,9 @@ paths:
   /services:
     get:
       summary: List services
+      security:
+        - oauth2:
+          - read:services
       responses:
         '200':
           description: The service list
@@ -548,6 +635,9 @@ paths:
   /services/{name}:
     get:
       summary: Get a service by name
+      security:
+        - oauth2:
+          - read:services
       parameters:
         - name: name
           description: service name
@@ -563,6 +653,9 @@ paths:
     get:
       summary: Get the proxy's routing table
       description: A convenience alias for getting the routing table directly from the proxy
+      security:
+        - oauth2:
+          - proxy
       responses:
         '200':
           description: Routing table
@@ -571,12 +664,18 @@ paths:
             description: configurable-http-proxy routing table (see configurable-http-proxy docs for details)
     post:
       summary: Force the Hub to sync with the proxy
+      security:
+        - oauth2:
+          - proxy
       responses:
         '200':
           description: Success
     patch:
       summary: Notify the Hub about a new proxy
       description: Notifies the Hub of a new proxy to use.
+      security:
+        - oauth2:
+          - proxy
       parameters:
         - name: body
           in: body
@@ -609,6 +708,9 @@ paths:
         in the JSON request body.
         Logging in via this method is only available when the active Authenticator
         accepts passwords (e.g. not OAuth).
+      security:
+        - oauth2:
+          - users:tokens # minrk: this is a deprecated alias to POST /users/{name}/tokens, either remove it or use the same scope
       parameters:
         - name: credentials
           in: body
@@ -633,6 +735,7 @@ paths:
   /authorizations/token/{token}:
     get:
       summary: Identify a user or service from an API token
+      # minrk: is it really necessary to have a scope for this, or use self handler for token whoami?
       parameters:
         - name: token
           in: path
@@ -663,6 +766,7 @@ paths:
             $ref: '#/definitions/User'
         '404':
           description: A user is not found.
+      deprecated: true # minrk: let’s not add a scope for this, let’s remove it
   /oauth2/authorize:
     get:
       summary: 'OAuth 2.0 authorize endpoint'
@@ -744,6 +848,9 @@ paths:
   /shutdown:
     post:
       summary: Shutdown the Hub
+      security:
+        - oauth2:
+          - shutdown
       parameters:
         - name: body
           in: body

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -13,6 +13,36 @@ securityDefinitions:
     type: apiKey
     name: Authorization
     in: header
+  oauth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: 'https://localhost:8000/hub/api/oauth2/authorize' # what are the absolute URIs here? is oauth2 correct here or shall we use just authorizations?
+    tokenUrl: 'https://localhost:8000/hub/api/oauth2/token'
+    scopes:
+      all: Everything a user can do
+      read:all: Read-only access to everything a user can read
+      users: Grants access to managing users including reading users’ model, posting activity and starting/stoping users servers
+      read:users: Read-only access to the above
+      read:users:username: Read-only access to a single user's model
+      read:users:names: Read-only access to users' names
+      read:users:groups: Read-only access to users' groups
+      read:users:activity: Read-only access to users' activity
+      read:users:activity:groupname: Read-only access to specific group's users' activity
+      read:users:servers: Read-only access to users' servers
+      users:activity:username: Update a user's activity
+      users:servers: Grants access to start/stop any server
+      users:servers:servername: Limits the above to a specific server
+      users:tokens: Grants access to users' token (includes create/revoke a token)
+      read:users:tokens: Identify a user from a token
+      admin:users: Grants access to creating/removing users
+      admin:users:servers: Grants access to create/remove users' servers
+      groups: Add/remove users from any group
+      groups:groupname: Add/remove users from a specific group only
+      read:groups: Read-only access to groups
+      admin:groups: Grants access to create/delete groups
+      read:services: Read-only access to services
+      proxy: Grants access to proxy's routing table, syncing and notifying about a new proxy
+      shutdown: Grants access to shutdown the Hub
 security:
   - token: []
 basePath: /hub/api

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -451,6 +451,9 @@ paths:
               note:
                 type: string
                 description: A note attached to the token for future bookkeeping
+              roles:
+                type: list
+                description: A list of role names that the token should have
       responses:
         '201':
           description: The newly created token
@@ -458,6 +461,8 @@ paths:
             $ref: '#/definitions/Token'
         '400':
           description: Body must be a JSON dict or empty
+        '403':
+          description: Requested role does not exist
   /users/{name}/tokens/{token_id}:
     parameters:
       - name: name
@@ -972,6 +977,11 @@ definitions:
       admin:
         type: boolean
         description: Whether the service is an admin
+      roles:
+        type: array
+        description: The names of roles this service has
+        items:
+          type: string
       url:
         type: string
         description: The internal url where the service is running
@@ -1006,6 +1016,11 @@ definitions:
       service:
         type: string
         description: The service that owns the token (undefined of owned by a user)
+      roles:
+        type: array
+        description: The names of roles this token has
+        items:
+          type: string
       note:
         type: string
         description: A note about the token, typically describing what it was created for.

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -20,7 +20,7 @@ securityDefinitions:
     tokenUrl: 'https://localhost:8000/hub/api/oauth2/token'
     scopes:
       all: Everything a user can do
-      read:all: Read-only access to everything a user can read
+      read:all: Read-only access to everything a user can read (also whoami handler)
       users: Grants access to managing users including reading users’ model, posting activity and starting/stoping users servers
       read:users: Read-only access to the above
       read:users:username: Read-only access to a single user's model
@@ -735,7 +735,9 @@ paths:
   /authorizations/token/{token}:
     get:
       summary: Identify a user or service from an API token
-      # minrk: is it really necessary to have a scope for this, or use self handler for token whoami?
+      security:
+        - oauth2:
+          - read:all # minrk: is it really necessary to have a scope for this, or use self handler for token whoami?
       parameters:
         - name: token
           in: path


### PR DESCRIPTION
Ref: scopes issue #1057 

The changes to the yml file aim to reflect oauth scopes definition for different permission levels that JupyterHub could use to manage token-based access. The definitions follow [OpenAPI 2.0 Specification ](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).

Scopes will provide more specific access (e.g. read-only, access only users' servers, etc.) instead of "everything as the user/admin can do" (current state). Users, services and tokens will be associated with one or more roles where each role contains a list of permission scopes (ref.: user roles #2245). 

Users/services and tokens will be checked if they carry roles with necessary scopes for the requested action (in rest-api.yml the scopes listed for each API endpoint; if no scope defined, global security applies) through API handlers.

The full list of proposed scopes is available [here](https://hackmd.io/@ZBwjUKuOTz650XPDXRgrjQ/Bycgiah7v).

The Rest API documentation will show the added scopes as:

![image](https://user-images.githubusercontent.com/12073028/92907440-9fc9ef00-f425-11ea-8eb4-e1834a889cf4.png)


Please note comments with few additions:

- authorizationUrl and tokenUrl (line 19 and 20): the security definition requires absolute paths

- global security (lines 46-49): applies to all API endpoints unless overwritten on the operational level for an API endpoint (with a 'security' keyword); for the current state keeping both apiKey and oauth (either one can be used to access API endpoints with no scopes defined)

- scopes for /authorize/... endpoints (lines 713, 740 and 771)