### PR TITLE
Upgraded Jquery dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bootstrap": "^3.4.1",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.3.1",
+    "jquery": "^3.5.1",
     "moment": "^2.24.0",
     "requirejs": "^2.3.6"
   }


### PR DESCRIPTION
Jupyterhub is currently using Jquery 3.3.1, which is open to a [few XSS issues](https://snyk.io/test/npm/jquery/3.3.1). I'm using The Littlest JupyterHub in a setting in which our tech support runs vuln scans on it, and it detected the Jquery version.

If there are any frontend tests to run, I can give them a go, but I didn't see anything. It appears that there aren't any major breaking changes for 3.3 -> 3.4 -> 3.5 that Jupyterhub would run into.

https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/
https://jquery.com/upgrade-guide/3.5/