### PR TITLE
Enable async support in jinja2 templates

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -253,7 +253,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
             # Render oauth 'Authorize application...' page
             auth_state = await self.current_user.get_auth_state()
             self.write(
-                self.render_template(
+                await self.render_template(
                     "oauth.html",
                     auth_state=auth_state,
                     scopes=scopes,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2187,7 +2187,7 @@ class JupyterHub(Application):
     def init_tornado_settings(self):
         """Set up the tornado settings dict."""
         base_url = self.hub.base_url
-        jinja_options = dict(autoescape=True)
+        jinja_options = dict(autoescape=True, enable_async=True)
         jinja_options.update(self.jinja_environment_options)
         base_path = self._template_paths_default()[0]
         if base_path not in self.template_paths:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1264,7 +1264,7 @@ class BaseHandler(RequestHandler):
         # so we run it sync here, instead of making a sync version of render_template
 
         try:
-            html = self.render_template(f'{status_code}.html', sync=True, **ns)
+            html = self.render_template('%.html' % status_code, sync=True, **ns)
             print(html, flush=True)
         except TemplateNotFound:
             self.log.debug("No template for %d", status_code)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1476,14 +1476,10 @@ class UserUrlHandler(BaseHandler):
 
         # if request is expecting JSON, assume it's an API request and fail with 503
         # because it won't like the redirect to the pending page
-        if (
-            get_accepted_mimetype(
-                self.request.headers.get('Accept', ''),
-                choices=['application/json', 'text/html'],
-            )
-            == 'application/json'
-            or 'api' in user_path.split('/')
-        ):
+        if get_accepted_mimetype(
+            self.request.headers.get('Accept', ''),
+            choices=['application/json', 'text/html'],
+        ) == 'application/json' or 'api' in user_path.split('/'):
             self._fail_api_request(user_name, server_name)
             return
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1264,7 +1264,7 @@ class BaseHandler(RequestHandler):
         # so we run it sync here, instead of making a sync version of render_template
 
         try:
-            html = self.render_template('%.html' % status_code, sync=True, **ns)
+            html = self.render_template('%s.html' % status_code, sync=True, **ns)
             print(html, flush=True)
         except TemplateNotFound:
             self.log.debug("No template for %d", status_code)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1265,7 +1265,6 @@ class BaseHandler(RequestHandler):
 
         try:
             html = self.render_template('%s.html' % status_code, sync=True, **ns)
-            print(html, flush=True)
         except TemplateNotFound:
             self.log.debug("No template for %d", status_code)
             try:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1477,10 +1477,14 @@ class UserUrlHandler(BaseHandler):
 
         # if request is expecting JSON, assume it's an API request and fail with 503
         # because it won't like the redirect to the pending page
-        if get_accepted_mimetype(
-            self.request.headers.get('Accept', ''),
-            choices=['application/json', 'text/html'],
-        ) == 'application/json' or 'api' in user_path.split('/'):
+        if (
+            get_accepted_mimetype(
+                self.request.headers.get('Accept', ''),
+                choices=['application/json', 'text/html'],
+            )
+            == 'application/json'
+            or 'api' in user_path.split('/')
+        ):
             self._fail_api_request(user_name, server_name)
             return
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1,7 +1,6 @@
 """HTTP Handlers for the hub server"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import sys
 import asyncio
 import json
 import math
@@ -1183,17 +1182,9 @@ class BaseHandler(RequestHandler):
         template_ns.update(self.template_namespace)
         template_ns.update(ns)
         template = self.get_template(name, sync)
-        # render_async isn't supported until Python 3.6
-        supported_python = sys.version_info > (3, 5)
         if sync:
             return template.render(**template_ns)
         else:
-            if not supported_python:
-                # If we're on Python 3.5, jinja doesn't support `templates.render_async``
-                # So we render our template synchronously, and pretend we did not.
-                future = asyncio.get_running_loop().create_future()
-                future.set_result(template.render(**template_ns))
-                return future
             return template.render_async(**template_ns)
 
     @property

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1160,7 +1160,7 @@ class BaseHandler(RequestHandler):
         """
         Return the jinja template object for a given name
 
-        If sync is True, we return a Template that is compiled without async suppor.
+        If sync is True, we return a Template that is compiled without async support.
         Only those can be used in synchronous code.
 
         If sync is False, we return a Template that is compiled with async support

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -89,8 +89,8 @@ class LogoutHandler(BaseHandler):
 class LoginHandler(BaseHandler):
     """Render the login page."""
 
-    async def _render(self, login_error=None, username=None):
-        return await self.render_template(
+    def _render(self, login_error=None, username=None):
+        return self.render_template(
             'login.html',
             next=url_escape(self.get_argument('next', default='')),
             username=username,

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -79,7 +79,7 @@ class LogoutHandler(BaseHandler):
 
     async def get(self):
         """Log the user out, call the custom action, forward the user
-            to the logout page
+        to the logout page
         """
         await self.default_handle_logout()
         await self.handle_logout()

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -72,7 +72,7 @@ class LogoutHandler(BaseHandler):
         Override this function to set a custom logout page.
         """
         if self.authenticator.auto_login:
-            html = self.render_template('logout.html')
+            html = await self.render_template('logout.html')
             self.finish(html)
         else:
             self.redirect(self.settings['login_url'], permanent=False)
@@ -89,8 +89,8 @@ class LogoutHandler(BaseHandler):
 class LoginHandler(BaseHandler):
     """Render the login page."""
 
-    def _render(self, login_error=None, username=None):
-        return self.render_template(
+    async def _render(self, login_error=None, username=None):
+        return await self.render_template(
             'login.html',
             next=url_escape(self.get_argument('next', default='')),
             username=username,
@@ -132,7 +132,7 @@ class LoginHandler(BaseHandler):
                     self.redirect(auto_login_url)
                 return
             username = self.get_argument('username', default='')
-            self.finish(self._render(username=username))
+            self.finish(await self._render(username=username))
 
     async def post(self):
         # parse the arguments dict
@@ -149,7 +149,7 @@ class LoginHandler(BaseHandler):
             self._jupyterhub_user = user
             self.redirect(self.get_next_url(user))
         else:
-            html = self._render(
+            html = await self._render(
                 login_error='Invalid username or password', username=data['username']
             )
             self.finish(html)

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -67,7 +67,7 @@ class HomeHandler(BaseHandler):
             url = url_path_join(self.hub.base_url, 'spawn', user.escaped_name)
 
         auth_state = await user.get_auth_state()
-        html = self.render_template(
+        html = await self.render_template(
             'home.html',
             auth_state=auth_state,
             user=user,
@@ -94,7 +94,7 @@ class SpawnHandler(BaseHandler):
 
     async def _render_form(self, for_user, spawner_options_form, message=''):
         auth_state = await for_user.get_auth_state()
-        return self.render_template(
+        return await self.render_template(
             'spawn.html',
             for_user=for_user,
             auth_state=auth_state,
@@ -378,7 +378,7 @@ class SpawnPendingHandler(BaseHandler):
                 self.hub.base_url, "spawn", user.escaped_name, server_name
             )
             self.set_status(500)
-            html = self.render_template(
+            html = await self.render_template(
                 "not_running.html",
                 user=user,
                 auth_state=auth_state,
@@ -402,7 +402,7 @@ class SpawnPendingHandler(BaseHandler):
                 page = "stop_pending.html"
             else:
                 page = "spawn_pending.html"
-            html = self.render_template(
+            html = await self.render_template(
                 page,
                 user=user,
                 spawner=spawner,
@@ -429,7 +429,7 @@ class SpawnPendingHandler(BaseHandler):
             spawn_url = url_path_join(
                 self.hub.base_url, "spawn", user.escaped_name, server_name
             )
-            html = self.render_template(
+            html = await self.render_template(
                 "not_running.html",
                 user=user,
                 auth_state=auth_state,
@@ -519,7 +519,7 @@ class AdminHandler(BaseHandler):
         )
 
         auth_state = await self.current_user.get_auth_state()
-        html = self.render_template(
+        html = await self.render_template(
             'admin.html',
             current_user=self.current_user,
             auth_state=auth_state,
@@ -609,7 +609,7 @@ class TokenPageHandler(BaseHandler):
         oauth_clients = sorted(oauth_clients, key=sort_key, reverse=True)
 
         auth_state = await self.current_user.get_auth_state()
-        html = self.render_template(
+        html = await self.render_template(
             'token.html',
             api_tokens=api_tokens,
             oauth_clients=oauth_clients,
@@ -621,7 +621,7 @@ class TokenPageHandler(BaseHandler):
 class ProxyErrorHandler(BaseHandler):
     """Handler for rendering proxy error pages"""
 
-    def get(self, status_code_s):
+    async def get(self, status_code_s):
         status_code = int(status_code_s)
         status_message = responses.get(status_code, 'Unknown HTTP Error')
         # build template namespace
@@ -645,10 +645,10 @@ class ProxyErrorHandler(BaseHandler):
         self.set_header('Content-Type', 'text/html')
         # render the template
         try:
-            html = self.render_template('%s.html' % status_code, **ns)
+            html = await self.render_template('%s.html' % status_code, **ns)
         except TemplateNotFound:
             self.log.debug("No template for %d", status_code)
-            html = self.render_template('error.html', **ns)
+            html = await self.render_template('error.html', **ns)
 
         self.write(html)
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ from setuptools.command.bdist_egg import bdist_egg
 
 
 v = sys.version_info
-if v[:2] < (3, 5):
-    error = "ERROR: JupyterHub requires Python version 3.5 or above."
+if v[:2] < (3, 6):
+    error = "ERROR: JupyterHub requires Python version 3.6 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -94,7 +94,7 @@ setup_args = dict(
     license="BSD",
     platforms="Linux, Mac OS X",
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     entry_points={
         'jupyterhub.authenticators': [
             'default = jupyterhub.auth:PAMAuthenticator',


### PR DESCRIPTION
Follows https://jinja.palletsprojects.com/en/2.11.x/api/#async-support

- This blocks the main thread fewer times
- We can use async methods inside templates too
- Provide sync versions of render_template for `write_error`

   write_error is a synchronous method called by an async
   method from inside the event loop. This means we can't just
   schedule an async render_templates in the same loop and wait
   for it - that would deadlock.

   jinja2 compiled your code differently based on wether you
   enable async support or not. Templates compiled with async
   support can't be used in cases like ours, where we already
   have an event loop running and calling a sync function. So
   we maintain two almost identical jinja2 environments