### PR TITLE
Mention the PAM pitfall on fedora.

### DIFF
--- a/docs/source/reference/config-sudo.md
+++ b/docs/source/reference/config-sudo.md
@@ -120,6 +120,11 @@ the shadow password database.
 
 ### Shadow group (Linux)
 
+**Note:** On Fedora based distributions there is no clear way to configure
+the PAM database to allow sufficient access for autenticating with the target user's password
+from jupyterhub.As a workaround we recommend use an alternative authentication method, e.g.
+[sshauthenticator](https://github.com/andreas-h/sshauthenticator).
+
 ```bash
 $ ls -l /etc/shadow
 -rw-r-----  1 root shadow   2197 Jul 21 13:41 shadow

--- a/docs/source/reference/config-sudo.md
+++ b/docs/source/reference/config-sudo.md
@@ -122,8 +122,8 @@ the shadow password database.
 
 **Note:** On Fedora based distributions there is no clear way to configure
 the PAM database to allow sufficient access for authenticating with the target user's password
-from JupyterHub. As a workaround we recommend use an alternative authentication method, e.g.
-[sshauthenticator](https://github.com/andreas-h/sshauthenticator).
+from JupyterHub. As a workaround we recommend use an
+[alternative authentication method](https://github.com/jupyterhub/jupyterhub/wiki/Authenticators).
 
 ```bash
 $ ls -l /etc/shadow

--- a/docs/source/reference/config-sudo.md
+++ b/docs/source/reference/config-sudo.md
@@ -121,8 +121,8 @@ the shadow password database.
 ### Shadow group (Linux)
 
 **Note:** On Fedora based distributions there is no clear way to configure
-the PAM database to allow sufficient access for autenticating with the target user's password
-from jupyterhub.As a workaround we recommend use an alternative authentication method, e.g.
+the PAM database to allow sufficient access for authenticating with the target user's password
+from JupyterHub. As a workaround we recommend use an alternative authentication method, e.g.
 [sshauthenticator](https://github.com/andreas-h/sshauthenticator).
 
 ```bash


### PR DESCRIPTION
The Linux guide here is only applicable to Debian based systems.
On Fedora the shallow files are supposed to be only read by root, with PAM handling the rest (I am not sure about the magic behind this). 

This is just one of the subtle differences between the distributions, but at least we shouldn't confuse the Fedora users by asking them to change the permissions of shadow files. There isn't even a wheel group on Fedora since probably the Fedora Core days.

I settled using sshauthenticator. There may be a way to properly set up PAM authentication for Fedora, but I wasn't able to find out. I recall the furthest I got was authenticating using rhea's password for any user on the sudoer list, if I remember it accurately.