### PR TITLE
add option to use a different Host header for referer checks

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -58,7 +58,7 @@ class APIHandler(BaseHandler):
 
         - allow unspecified host/referer (e.g. scripts)
         """
-        host = self.request.headers.get("Host")
+        host = self.request.headers.get(self.app.forwarded_host_header or "Host")
         referer = self.request.headers.get("Referer")
 
         # If no header is provided, assume it comes from a script/curl.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -791,6 +791,16 @@ class JupyterHub(Application):
             self.proxy_api_ip or '127.0.0.1', self.proxy_api_port or self.port + 1
         )
 
+    forwarded_host_header = Unicode(
+        '',
+        help="""Alternate header to use as the Host (e.g., X-Forwarded-Host)
+        when determining whether a request is cross-origin
+
+        This may be useful when JupyterHub is running behind a proxy that rewrites
+        the Host header.
+        """,
+    ).tag(config=True)
+
     hub_port = Integer(
         8081,
         help="""The internal port for the Hub process.

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -136,6 +136,32 @@ async def test_cors_checks(app):
     )
     assert r.status_code == 400  # accepted, but invalid
 
+    app.forwarded_host_header = 'X-Forwarded-Host'
+    r = await api_request(
+        app,
+        'users',
+        headers={
+            'Authorization': '',
+            'Referer': url,
+            'Host': host,
+            'X-Forwarded-Host': 'example.com',
+        },
+        cookies=cookies,
+    )
+    assert r.status_code == 403
+
+    r = await api_request(
+        app,
+        'users',
+        headers={
+            'Authorization': '',
+            'Referer': url,
+            'Host': host,
+            'X-Forwarded-Host': host,
+        },
+        cookies=cookies,
+    )
+    assert r.status_code == 200
 
 # --------------
 # User API tests


### PR DESCRIPTION
Hi folks 👋 , 

Here's the problem I'm trying to solve: I'm running JupyterHub on Kubernetes cluster with Istio. Our Istio is configured to internally route requests based on the `Host` header, so I need to actually overwrite the Host header that comes into node-proxy (e.g., `jupyterhub.example.com`) with the internal hostname (e.g., `jupyterhub.production.svc.cluster.local`). Otherwise any requests that the proxy sends just loop back to itself. 

node-proxy's `--change-origin` flag accomplishes this, and stores the original host in the conventional `X-Forwarded-Host` header.

This all works nicely until the check_referer function in JupyterHub tries to confirm the `Referer` and `Host` match. At this point I have headers like 

```
Referer: https://jupyterhub.example.com/hub/etc
Host: jupyterhub.production.svc.cluster.local
X-Forwarded-Host: jupyterhub.example.com
```

Proposed solution: Allow jupyterhub_config to define an alternative host header to use for the check_referer call. I'm not married to this solution, very open to thoughts and suggestions. Thanks!