### PR TITLE
Prevent OverflowErrors in exponential_backoff()

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -171,16 +171,9 @@ async def exponential_backoff(
         # add some random jitter to improve performance
         # this prevents overloading any single tornado loop iteration with
         # too many things
-        # Except Overflow Error. Otherwise start_wait * scale will be too big at some point.
-        try:
-            if scale == 0:
-                dt = min(max_wait, remaining)
-            else:
-                dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
-        except OverflowError:
-            scale = 0
-            dt = min(max_wait, remaining)
-        scale *= scale_factor
+        dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
+        if dt < max_wait:
+            scale *= scale_factor
         await gen.sleep(dt)
     raise TimeoutError(fail_message)
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -171,7 +171,15 @@ async def exponential_backoff(
         # add some random jitter to improve performance
         # this prevents overloading any single tornado loop iteration with
         # too many things
-        dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
+        # Except Overflow Error. Otherwise start_wait * scale will be too big at some point.
+        try:
+            if scale == 0:
+                dt = min(max_wait, remaining))
+            else:
+                dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
+        except OverflowError:
+            scale = 0
+            dt = min(max_wait, remaining)
         scale *= scale_factor
         await gen.sleep(dt)
     raise TimeoutError(fail_message)

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -174,7 +174,7 @@ async def exponential_backoff(
         # Except Overflow Error. Otherwise start_wait * scale will be too big at some point.
         try:
             if scale == 0:
-                dt = min(max_wait, remaining))
+                dt = min(max_wait, remaining)
             else:
                 dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
         except OverflowError:


### PR DESCRIPTION
We start JupyterLabs on a slurm based batch system. Therefore, JupyterLabs may take a while to start. This lead to OverflowErrors in exponential_backoff(). 

This small patch will prevent crashes while waiting for JupyterLabs.