### PR TITLE
Logout on all devices and strict session ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 node_modules
 *.py[co]
 *~

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -88,6 +88,7 @@ class TokenAPIHandler(APIHandler):
             )
         )
 
+
 class SessionIDAPIHandler(APIHandler):
     @token_authenticated
     async def get(self, username, session_id):
@@ -103,6 +104,7 @@ class SessionIDAPIHandler(APIHandler):
             self.write(json.dumps(model))
         else:
             raise web.HTTPError(404)
+
 
 class CookieAPIHandler(APIHandler):
     @token_authenticated

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -98,9 +98,8 @@ class SessionIDAPIHandler(APIHandler):
         if db_user:
             if self.app.strict_session_ids:
                 session_ids = await self.app.load_session_ids(username)
-                _session_id = self.request.query_arguments.get('session_id', [b''])
-                session_id = [v.decode("utf-8") for v in _session_id]
-                if len(session_id) == 0 or session_id[0] not in session_ids:
+                session_id = self.request.headers.get("sessionid", "")
+                if (not session_id) or (session_id not in session_ids):
                     raise web.HTTPError(404)
             model = self.user_model(self.users[db_user])
             self.write(json.dumps(model))

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -91,14 +91,16 @@ class TokenAPIHandler(APIHandler):
 
 class SessionIDAPIHandler(APIHandler):
     @token_authenticated
-    async def get(self, username, session_id):
+    async def get(self, username):
         # Check if session_id is part of user's auth_state session_ids
         db_user = orm.User.find(self.db, username)
         # self.log.info("{} - SessionID Check: {}".format(username, session_id))
         if db_user:
             if self.app.strict_session_ids:
                 session_ids = await self.app.load_session_ids(username)
-                if session_id not in session_ids:
+                _session_id = self.request.query_arguments.get('session_id', [b''])
+                session_id = [v.decode("utf-8") for v in _session_id]
+                if len(session_id) == 0 or session_id[0] not in session_ids:
                     raise web.HTTPError(404)
             model = self.user_model(self.users[db_user])
             self.write(json.dumps(model))
@@ -334,7 +336,7 @@ default_handlers = [
     (r"/api/authorizations/cookie/([^/]+)(?:/([^/]+))?", CookieAPIHandler),
     (r"/api/authorizations/token/([^/]+)", TokenAPIHandler),
     (r"/api/authorizations/token", TokenAPIHandler),
-    (r"/api/authorizations/sessionid/([^/]*)/([^/]*)", SessionIDAPIHandler),
+    (r"/api/authorizations/sessionid/([^/]+)", SessionIDAPIHandler),
     (r"/api/oauth2/authorize", OAuthAuthorizeHandler),
     (r"/api/oauth2/token", OAuthTokenHandler),
 ]

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -93,6 +93,7 @@ class SessionIDAPIHandler(APIHandler):
     async def get(self, username, session_id):
         # Check if session_id is part of user's auth_state session_ids
         db_user = orm.User.find(self.db, username)
+        # self.log.info("{} - SessionID Check: {}".format(username, session_id))
         if db_user:
             if self.app.strict_session_ids:
                 session_ids = await self.app.load_session_ids(username)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -948,6 +948,27 @@ class JupyterHub(Application):
         else:
             return ""
 
+    logout_on_all_devices_argname = Unicode(
+        "onalldevices",
+        config=True,
+        help="""Default argument name for logout on all devices.
+        User can logout on all devices with a GET request to
+        /hub/logout?<logout_on_all_devices_argname>=true
+        Use c.JupyterHub.logout_on_all_devices to define a default
+        value for logout on all devices.
+        """,
+    )
+
+    logout_on_all_devices = Bool(
+        False,
+        config=True,
+        help="""Default value for logout on all devices.
+        This will create a new api_token for a user when he logs out.
+        Therefore all previous generated cookies, based on cookie_id,
+        are invalid.
+        """,
+    )
+
     strict_session_ids = Bool(
         False,
         config=True,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -574,7 +574,10 @@ class BaseHandler(RequestHandler):
         if self.db.query(orm.Service).filter(orm.Service.server != None).first():
             self.set_service_cookie(user)
 
-        session_id = self.set_session_cookie()
+        if not self.get_session_cookie():
+            session_id = self.set_session_cookie()
+        else:
+            session_id = self.get_session_cookie()
 
         # create and set a new cookie token for the hub
         if not self.get_current_user_cookie():

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -702,7 +702,7 @@ class BaseHandler(RequestHandler):
             if auth_state:
                 auth_state['session_ids'] = session_ids
             else:
-                auth_state = { 'session_ids': session_ids }
+                auth_state = {'session_ids': session_ids}
         await user.save_auth_state(auth_state)
         return user
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -696,9 +696,13 @@ class BaseHandler(RequestHandler):
             # ensure that session_ids added previously are not deleted
             prev_auth_state = await user.get_auth_state()
             if prev_auth_state:
-                auth_state['session_ids'] = prev_auth_state.get('session_ids', [])
+                session_ids = prev_auth_state.get('session_ids', [])
             else:
-                auth_state['session_ids'] = []
+                session_ids = []
+            if auth_state:
+                auth_state['session_ids'] = session_ids
+            else:
+                auth_state = { 'session_ids': session_ids }
         await user.save_auth_state(auth_state)
         return user
 
@@ -719,9 +723,10 @@ class BaseHandler(RequestHandler):
                 # append session_id to user's auth_state
                 auth_state = await user.get_auth_state()
                 if auth_state:
-                    if 'session_ids' not in auth_state.keys():
+                    if 'session_ids' not in auth_state:
                         auth_state['session_ids'] = []
                     auth_state['session_ids'].append(session_id)
+                    # self.log.debug("{} - Session_ids: {}".format(user.name, auth_state['session_ids']))
                     await user.save_auth_state(auth_state)
             return user
         else:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -574,12 +574,13 @@ class BaseHandler(RequestHandler):
         if self.db.query(orm.Service).filter(orm.Service.server != None).first():
             self.set_service_cookie(user)
 
-        if not self.get_session_cookie():
-            self.set_session_cookie()
+        session_id = self.set_session_cookie()
 
         # create and set a new cookie token for the hub
         if not self.get_current_user_cookie():
             self.set_hub_cookie(user)
+
+        return session_id
 
     def authenticate(self, data):
         return maybe_future(self.authenticator.get_authenticated_user(self, data))
@@ -690,6 +691,14 @@ class BaseHandler(RequestHandler):
         if not self.authenticator.enable_auth_state:
             # auth_state is not enabled. Force None.
             auth_state = None
+        elif self.app.strict_session_ids:
+            # auth_state is enable and strict_session_ids are required
+            # ensure that session_ids added previously are not deleted
+            prev_auth_state = await user.get_auth_state()
+            if prev_auth_state:
+                auth_state['session_ids'] = prev_auth_state.get('session_ids', [])
+            else:
+                auth_state['session_ids'] = []
         await user.save_auth_state(auth_state)
         return user
 
@@ -701,11 +710,19 @@ class BaseHandler(RequestHandler):
 
         if authenticated:
             user = await self.auth_to_user(authenticated)
-            self.set_login_cookie(user)
+            session_id = self.set_login_cookie(user)
             self.statsd.incr('login.success')
             self.statsd.timing('login.authenticate.success', auth_timer.ms)
             self.log.info("User logged in: %s", user.name)
             user._auth_refreshed = time.monotonic()
+            if self.authenticator.enable_auth_state and self.app.strict_session_ids:
+                # append session_id to user's auth_state
+                auth_state = await user.get_auth_state()
+                if auth_state:
+                    if 'session_ids' not in auth_state.keys():
+                        auth_state['session_ids'] = []
+                    auth_state['session_ids'].append(session_id)
+                    await user.save_auth_state(auth_state)
             return user
         else:
             self.statsd.incr('login.failure')

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -8,9 +8,9 @@ from tornado.escape import url_escape
 from tornado.httputil import url_concat
 
 from ..orm import User
-from ..utils import maybe_future, new_token
+from ..utils import maybe_future
+from ..utils import new_token
 from .base import BaseHandler
-
 
 
 class LogoutHandler(BaseHandler):
@@ -58,9 +58,16 @@ class LogoutHandler(BaseHandler):
             if self.shutdown_on_logout:
                 await self._shutdown_servers(user)
 
-            logout_all_devices = str(self.get_argument(self.app.logout_on_all_devices_argname,
-                                                       self.app.logout_on_all_devices,
-                                                       True)).lower() == "true"
+            logout_all_devices = (
+                str(
+                    self.get_argument(
+                        self.app.logout_on_all_devices_argname,
+                        self.app.logout_on_all_devices,
+                        True,
+                    )
+                ).lower()
+                == "true"
+            )
             # self.log.info("{} - Logout on all devices: {}".format(user.name, logout_all_devices))
 
             if self.app.strict_session_ids and user.authenticator.enable_auth_state:

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -55,7 +55,13 @@ class LogoutHandler(BaseHandler):
         if user:
             if self.shutdown_on_logout:
                 await self._shutdown_servers(user)
-
+            if self.app.strict_session_ids and user.authenticator.enable_auth_state:
+                auth_state = await user.get_auth_state()
+                if auth_state:
+                    current_session_id = self.get_session_cookie()
+                    if current_session_id in auth_state.get('session_ids', []):
+                        auth_state['session_ids'].remove(current_session_id)
+                    await user.save_auth_state(auth_state)
             self._backend_logout_cleanup(user.name)
 
     async def handle_logout(self):

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -61,6 +61,7 @@ class LogoutHandler(BaseHandler):
                     current_session_id = self.get_session_cookie()
                     if current_session_id in auth_state.get('session_ids', []):
                         auth_state['session_ids'].remove(current_session_id)
+                    # self.log.debug("{} - session_ids after logout: {}".format(user.name, auth_state['session_ids']))
                     await user.save_auth_state(auth_state)
             self._backend_logout_cleanup(user.name)
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -28,6 +28,7 @@ from tornado.httputil import url_concat
 from tornado.log import app_log
 from tornado.web import HTTPError
 from tornado.web import RequestHandler
+from traitlets import Bool
 from traitlets import default
 from traitlets import Dict
 from traitlets import Instance
@@ -188,6 +189,20 @@ class HubAuth(SingletonConfigurable):
         help="""API key for accessing Hub API.
 
         Generate with `jupyterhub token [username]` or add to JupyterHub.services config.
+        """,
+    ).tag(config=True)
+
+    session_id_cache_time = Integer(
+        int(os.getenv('JUPYTERHUB_SESSION_ID_CACHE_TIME', 10)),
+        help="""
+        Cache time for session id checks to jupyterhub (in seconds). Default is 10.
+        """,
+    ).tag(config=True)
+
+    session_id_required = Bool(
+        os.getenv('JUPYTERHUB_SESSION_ID_REQUIRED', 'false').lower()=="true",
+        help="""
+        Blocks any requests, if there's no jupyterhub-session-id cookie.
         """,
     ).tag(config=True)
 
@@ -461,6 +476,18 @@ class HubAuth(SingletonConfigurable):
         """
         return handler.get_cookie('jupyterhub-session-id', '')
 
+    last_session_id_validation = 0
+    last_session_id_validation_result = None
+
+    def validate_session_id(self, username, session_id):
+        if time.time() - self.last_session_id_validation > self.session_id_cache_time:
+            self.last_session_id_validation = int(time.time())
+            url=url_path_join(
+                self.api_url, "authorizations/sessionid", quote(username, safe=''), quote(session_id, safe='')
+            )
+            self.last_session_id_validation_result = self._api_request('GET', url, allow_404=True)
+        return self.last_session_id_validation_result
+
     def get_user(self, handler):
         """Get the Hub user for a given tornado handler.
 
@@ -484,16 +511,30 @@ class HubAuth(SingletonConfigurable):
         handler._cached_hub_user = user_model = None
         session_id = self.get_session_id(handler)
 
-        # check token first
-        token = self.get_token(handler)
-        if token:
-            user_model = self.user_for_token(token, session_id=session_id)
+        if self.session_id_required and not session_id:
+            app_log.info("Unauthorized access. Only users with a session id are allowed.")
+            return {'name': '<session_id_required>', 'kind': 'User'}
+        elif self.session_id_required:
+            token = self.get_token(handler)
+            if token:
+                user_model = self.user_for_token(token)
+                if user_model:
+                    handler._token_authenticated = True
+            if user_model is None:
+                user_model = self._get_user_cookie(handler)
             if user_model:
-                handler._token_authenticated = True
+                user_model = self.validate_session_id(user_model.get('name', ''), session_id)
+        else:
+            # check token first
+            token = self.get_token(handler)
+            if token:
+                user_model = self.user_for_token(token, session_id=session_id)
+                if user_model:
+                    handler._token_authenticated = True
 
-        # no token, check cookie
-        if user_model is None:
-            user_model = self._get_user_cookie(handler)
+            # no token, check cookie
+            if user_model is None:
+                user_model = self._get_user_cookie(handler)
 
         # cache result
         handler._cached_hub_user = user_model
@@ -904,10 +945,16 @@ class HubAuthenticated(object):
             # tries to redirect to login URL, 403 will be raised instead.
             # This is not the best, but avoids problems that can be caused
             # when get_current_user is allowed to raise.
-            def raise_on_redirect(*args, **kwargs):
-                raise HTTPError(
-                    403, "{kind} {name} is not allowed.".format(**user_model)
-                )
+            if user_model.get('name', '') == '<session_id_required>':
+                def raise_on_redirect(*args, **kwargs):
+                    raise HTTPError(
+                        401, "Please login to proceed."
+                    )
+            else:
+                def raise_on_redirect(*args, **kwargs):
+                    raise HTTPError(
+                        403, "{kind} {name} is not allowed.".format(**user_model)
+                    )
 
             self.redirect = raise_on_redirect
             return

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -200,7 +200,7 @@ class HubAuth(SingletonConfigurable):
     ).tag(config=True)
 
     session_id_required = Bool(
-        os.getenv('JUPYTERHUB_SESSION_ID_REQUIRED', 'false').lower()=="true",
+        os.getenv('JUPYTERHUB_SESSION_ID_REQUIRED', 'false').lower() == "true",
         help="""
         Blocks any requests, if there's no jupyterhub-session-id cookie.
         """,
@@ -482,10 +482,15 @@ class HubAuth(SingletonConfigurable):
     def validate_session_id(self, username, session_id):
         if time.time() - self.last_session_id_validation > self.session_id_cache_time:
             self.last_session_id_validation = int(time.time())
-            url=url_path_join(
-                self.api_url, "authorizations/sessionid", quote(username, safe=''), quote(session_id, safe='')
+            url = url_path_join(
+                self.api_url,
+                "authorizations/sessionid",
+                quote(username, safe=''),
+                quote(session_id, safe=''),
             )
-            self.last_session_id_validation_result = self._api_request('GET', url, allow_404=True)
+            self.last_session_id_validation_result = self._api_request(
+                'GET', url, allow_404=True
+            )
             # self.log.info("{} - Request to {}. Result: {}".format(username, url, self.last_session_id_validation_result))
         return self.last_session_id_validation_result
 
@@ -513,7 +518,9 @@ class HubAuth(SingletonConfigurable):
         session_id = self.get_session_id(handler)
 
         if self.session_id_required and not session_id:
-            app_log.info("Unauthorized access. Only users with a session id are allowed.")
+            app_log.info(
+                "Unauthorized access. Only users with a session id are allowed."
+            )
             return {'name': '<session_id_required>', 'kind': 'User'}
         elif self.session_id_required:
             token = self.get_token(handler)
@@ -524,7 +531,9 @@ class HubAuth(SingletonConfigurable):
             if user_model is None:
                 user_model = self._get_user_cookie(handler)
             if user_model:
-                user_model = self.validate_session_id(user_model.get('name', ''), session_id)
+                user_model = self.validate_session_id(
+                    user_model.get('name', ''), session_id
+                )
         else:
             # check token first
             token = self.get_token(handler)
@@ -947,11 +956,12 @@ class HubAuthenticated(object):
             # This is not the best, but avoids problems that can be caused
             # when get_current_user is allowed to raise.
             if user_model.get('name', '') == '<session_id_required>':
+
                 def raise_on_redirect(*args, **kwargs):
-                    raise HTTPError(
-                        401, "Please login to proceed."
-                    )
+                    raise HTTPError(401, "Please login to proceed.")
+
             else:
+
                 def raise_on_redirect(*args, **kwargs):
                     raise HTTPError(
                         403, "{kind} {name} is not allowed.".format(**user_model)

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -483,11 +483,9 @@ class HubAuth(SingletonConfigurable):
         if time.time() - self.last_session_id_validation > self.session_id_cache_time:
             self.last_session_id_validation = int(time.time())
             url = url_path_join(
-                self.api_url,
-                "authorizations/sessionid",
-                quote(username, safe=''),
-                quote(session_id, safe=''),
+                self.api_url, "authorizations/sessionid", quote(username, safe=''),
             )
+            url = "{}?session_id={}".format(url, quote(session_id, safe=''))
             self.last_session_id_validation_result = self._api_request(
                 'GET', url, allow_404=True
             )

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -486,6 +486,7 @@ class HubAuth(SingletonConfigurable):
                 self.api_url, "authorizations/sessionid", quote(username, safe=''), quote(session_id, safe='')
             )
             self.last_session_id_validation_result = self._api_request('GET', url, allow_404=True)
+            # self.log.info("{} - Request to {}. Result: {}".format(username, url, self.last_session_id_validation_result))
         return self.last_session_id_validation_result
 
     def get_user(self, handler):
@@ -536,10 +537,10 @@ class HubAuth(SingletonConfigurable):
             if user_model is None:
                 user_model = self._get_user_cookie(handler)
 
-        # cache result
-        handler._cached_hub_user = user_model
-        if not user_model:
-            app_log.debug("No user identified")
+            # cache result
+            handler._cached_hub_user = user_model
+            if not user_model:
+                app_log.debug("No user identified")
         return user_model
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -485,9 +485,9 @@ class HubAuth(SingletonConfigurable):
             url = url_path_join(
                 self.api_url, "authorizations/sessionid", quote(username, safe=''),
             )
-            url = "{}?session_id={}".format(url, quote(session_id, safe=''))
+            headers = {"sessionid": session_id}
             self.last_session_id_validation_result = self._api_request(
-                'GET', url, allow_404=True
+                'GET', url, allow_404=True, headers=headers
             )
             # self.log.info("{} - Request to {}. Result: {}".format(username, url, self.last_session_id_validation_result))
         return self.last_session_id_validation_result

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certipy>=0.1.2
 entrypoints
 jinja2
 jupyter_telemetry
+nest_asyncio==1.4.2
 oauthlib>=3.0
 pamela
 prometheus_client>=0.0.21


### PR DESCRIPTION
Hi everyone,

This patch tries to improve security for JupyterHub, regarding the logout mechanism and running services.

As a User, I have no control over my previously used sessions on different computers or browsers. So I wanted to add a mechanism, which ensures that I'm the only person who is able to browse to my Service ( https://<jupyter_hub>/user/<user_name>/<server_name> ). 

For this, I added a simple "logout_on_all_devices" mechanism. 
You can use `c.JupyterHub.logout_on_all_devices` to set a default behavior and `c.JupyterHub.logout_on_all_devices_argname` to set an argument, which is checked when logging out. So you can send a GET request to `/hub/logout?onalldevices=false` and you will not be logged out from all devices even if `c.JupyterHub.logout_on_all_devices` is `true`.


As a User, I have now at least control if someone else has access to my JupyterHub control panel or other JupyterHub pages. But old browsers are still able to browse directly to my running Services. To avoid this behavior we added the following:

For each login, JupyterHub adds the session_id of the login_cookie to a list in the user's auth_state. If the user logs out, the session_id of the cookie will be removed from this list. 
Services may use the new `SessionIDAPIHandler` to check if the browser, which wants to access this service, has an "active" JupyterHub login cookie. The `session_id_cache_time` parameter will reduce traffic between service and JupyterHub. If I log out from all devices, all session ids are removed.


Test this patch:
```
$ virtualenv -p python3 venv
$ source venv/bin/activate
$ git clone --single-branch --branch strict_session_ids https://github.com/kreuzert/jupyterhub.git strict_session_ids
$ pip3 install -e ./strict_session_ids
$ pip3 install notebook
$ echo -e "c.JupyterHub.logout_on_all_devices = True\nc.JupyterHub.strict_session_ids = True\nc.Spawner.environment = {'JUPYTERHUB_SESSION_ID_REQUIRED': 'true', 'JUPYTERHUB_SESSION_ID_CACHE_TIME': '5'}\nc.Authenticator.enable_auth_state = True" >> jupyterhub_config.py
$ export JUPYTERHUB_CRYPT_KEY="3ded12ca7931404eac114e288cc9b89c"
$ jupyterhub -f jupyterhub_config.py

### Open private window in browser
###### Browse to http://localhost:8000 
###### Log in, start jupyterhub-singleuser
### Open normal window in browser
###### Browse to http://localhost:8000, log in
###### Logout in normal window
### now the user in private window can NOT:
#### 1. Use JupyterHub sites, which require an authentication
#### 2. Open a new browser tab with my running Service ( https://<jupyterhub>/user/<user_name>/<server_name> will lead to an 401 HTTP Error )
#### 3. Open a terminal/notebook/kernel in an active BrowserTab

### Login again in normal browser window
##### Normal browser window can use the Jupyter service
##### the private window cannot use this service
```

----


What are your thoughts about this patch? Is it useful, can it be improved?
Important: If you don't set `c.JupyterHub.strict_session_ids` or `c.JupyterHub.logout_on_all_devices` nothing will change with this patch.


Interesting logging outputs while testing (commented out):
jupyterhub/services/auth.py:494
jupyterhub/apihandlers/auth.py:97
jupyterhub/handlers/login.py:71, 82
