### PR TITLE
Make api_request to CHP's REST API more reliable

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -773,8 +773,8 @@ class ConfigurableHTTPProxy(Proxy):
             request_timeout=5,  # default: 20s
         )
 
+        most_recent_error = None
         async def _wait_for_api_request():
-            most_recent_error = None
             try:
                 async with self.semaphore:
                     return await client.fetch(req)

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -769,8 +769,8 @@ class ConfigurableHTTPProxy(Proxy):
             method=method,
             headers={'Authorization': 'token {}'.format(self.auth_token)},
             body=body,
-            connect_timeout=1,  # default: 20s
-            request_timeout=5,  # default: 20s
+            connect_timeout=3,  # default: 20s
+            request_timeout=10,  # default: 20s
         )
 
         most_recent_error = None

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -773,13 +773,11 @@ class ConfigurableHTTPProxy(Proxy):
             request_timeout=10,  # default: 20s
         )
 
-        most_recent_error = None
         async def _wait_for_api_request():
             try:
                 async with self.semaphore:
                     return await client.fetch(req)
             except HTTPError as e:
-                most_recent_error = e
                 # Retry on potentially transient errors as for example also
                 # suggested for communication witht he k8s api-server
                 #
@@ -804,9 +802,7 @@ class ConfigurableHTTPProxy(Proxy):
 
         result = await exponential_backoff(
             _wait_for_api_request,
-            'Repeated api_request to proxy path "{}" failed, most recently with error "{}".'.format(
-                path, most_recent_error
-            ),
+            'Repeated api_request to proxy path "{}" failed.'.format(path),
             timeout=30,
         )
         return result


### PR DESCRIPTION
This PR addresses instabilities such as HTTP 599: Broken pipe, and general timeout errors trying to connect with the CHP proxy's REST API as done when for example adding a route for a newly spawned user.

This closes #3222.
