### PR TITLE
Allow options_from_form to be configurable

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -354,8 +354,9 @@ class Spawner(LoggingConfigurable):
 
         return options_form
 
-    def options_from_form(self, form_data):
-        """Interpret HTTP form data
+    options_from_form = Callable(
+        help="""
+        Interpret HTTP form data
 
         Form data will always arrive as a dict of lists of strings.
         Override this function to understand single-values, numbers, etc.
@@ -379,7 +380,14 @@ class Spawner(LoggingConfigurable):
             (with additional support for bytes in case of uploaded file data),
             and any non-bytes non-jsonable values will be replaced with None
             if the user_options are re-used.
-        """
+        """,
+    ).tag(config=True)
+
+    @default("options_from_form")
+    def _options_from_form(self):
+        return self._default_options_from_form
+
+    def _default_options_from_form(self, form_data):
         return form_data
 
     def options_from_query(self, query_data):


### PR DESCRIPTION
From the documentation, it is easy to override the options_form to set either a string or a callable to provide a custom options form.  But there doesn't seem to be the same way of configuring the options_from_form, which receives the form data from the options form.

This is a bit tricky, since I want to be able to provide a function to make an options_form that has a few different form elements, and I need to be able to manipulate the output.  But I can't configure the options_from_form callback the same way.  Right now, this all works on subclassing, but you have to derive from the spawner, rather than using traitlets.