### PR TITLE
Make external JupyterHub services' oauth_no_confirm configuration work as intentend

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -215,7 +215,8 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
             # it's the user's own server
             oauth_client.identifier in own_oauth_client_ids
             # or it's in the global no-confirm list
-            or oauth_client.identifier in self.settings.get('oauth_no_confirm', set())
+            or oauth_client.identifier
+            in self.settings.get('oauth_no_confirm_list', set())
         ):
             return False
         # default: require confirmation


### PR DESCRIPTION
fixup for regression introduced in https://github.com/jupyterhub/jupyterhub/pull/3090

This was the typo causing the regression, the equivalent variable for oauth_no_confirm_whitelist was oauth_no_confirm_list rather than oauth_no_confirm which is a boolean.

```diff
-            # or it's in the global whitelist
-            or oauth_client.identifier
-            in self.settings.get('oauth_no_confirm_whitelist', set())
+            # or it's in the global no-confirm list
+            or oauth_client.identifier in self.settings.get('oauth_no_confirm', set())
```