### PR TITLE
[proxy.py] Improve robustness when detecting and closing existing proxy processes

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -492,25 +492,25 @@ class ConfigurableHTTPProxy(Proxy):
     )
 
     def _check_pid(self, pid):
-        import psutil
+        if os.name == 'nt':
+            import psutil
 
-        if not psutil.pid_exists(pid):
-            raise ProcessLookupError
+            if not psutil.pid_exists(pid):
+                raise ProcessLookupError
 
-        try:
-            process = psutil.Process(pid)
-            if self.command and self.command[0]:
-                process_cmd = process.cmdline()
-                if process_cmd and not any(
-                    self.command[0] in clause for clause in process_cmd
-                ):
-                    raise ProcessLookupError
-        except (psutil.AccessDenied, psutil.NoSuchProcess):
-            # If there is a process at the proxy's PID but we don't have permissions to see it,
-            # then it is unlikely to actually be the proxy.
-            raise ProcessLookupError
-
-        if not os.name == 'nt':
+            try:
+                process = psutil.Process(pid)
+                if self.command and self.command[0]:
+                    process_cmd = process.cmdline()
+                    if process_cmd and not any(
+                        self.command[0] in clause for clause in process_cmd
+                    ):
+                        raise ProcessLookupError
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                # If there is a process at the proxy's PID but we don't have permissions to see it,
+                # then it is unlikely to actually be the proxy.
+                raise ProcessLookupError
+        else:
             os.kill(pid, 0)
 
     def __init__(self, **kwargs):

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -500,7 +500,9 @@ class ConfigurableHTTPProxy(Proxy):
         process = psutil.Process(pid)
         if self.command and self.command[0]:
             process_cmd = process.cmdline()
-            if process_cmd and not any(self.command[0] in clause for clause in process_cmd):
+            if process_cmd and not any(
+                self.command[0] in clause for clause in process_cmd
+            ):
                 raise ProcessLookupError
 
         if not os.name == 'nt':


### PR DESCRIPTION
Fixes #2886.

Relying on the pid alone to identify the proxy in between launches of the hub is not robust enough. Another unrelated process may have assumed the proxy's pid, resulting in either a permission error when the hub launches, or in some cases, the hub will kill some unrelated process.

This is especially prevalent on Windows, which seems to reuse pids much more frequently. We launch the hub along with several other processes on Windows, and we had a case where a pid conflict would happen many times, repeatedly. It is less common on Linux, but still an issue that we should guard against.

This PR also improves the proxy termination logic on Windows to match [the psutil docs](https://psutil.readthedocs.io/en/latest/#psutil.wait_procs), in order to ensure that the proxy is shutdown more cleanly. This change is optional, I can remove it if we think it doesn't belong in this PR.

A couple alternate approaches may include:
- Also checking the process's user to see if it matches the hub's user.
- Storing the cmd (plus possibly the user?) in addition to the pid in jupyterhub-proxy.pid to increase robustness if the hub config changes across restarts.

Let me know if we think any of the alternatives listed above would be useful, I'd be happy to extend this accordingly.