### PR TITLE
Assume py36 and remove @gen.coroutine etc.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,8 @@ jobs:
         #       values by instead duplicating the name to signal true.
         include:
           - python: "3.6"
+            oldest_dependencies: oldest_dependencies
+          - python: "3.6"
             subdomain: subdomain
           - python: "3.7"
             db: mysql
@@ -142,6 +144,14 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade . -r dev-requirements.txt
+
+          if [ "${{ matrix.oldest_dependencies }}" != "" ]; then
+            # take any dependencies in requirements.txt such as tornado>=5.0
+            # and transform them to tornado==5.0 so we can run tests with
+            # the earliest-supported versions
+            cat requirements.txt | grep '>=' | sed -e 's@>=@==@g' > oldest-requirements.txt
+            pip install -r oldest-requirements.txt
+          fi
 
           if [ "${{ matrix.main_dependencies }}" != "" ]; then
               pip install git+https://github.com/ipython/traitlets#egg=traitlets --force

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ htmlcov
 .pytest_cache
 pip-wheel-metadata
 docs/source/reference/metrics.rst
+oldest-requirements.txt

--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -235,10 +235,9 @@ to Spawner environment:
 
 ```python
 class MyAuthenticator(Authenticator):
-    @gen.coroutine
-    def authenticate(self, handler, data=None):
-        username = yield identify_user(handler, data)
-        upstream_token = yield token_for_user(username)
+    async def authenticate(self, handler, data=None):
+        username = await identify_user(handler, data)
+        upstream_token = await token_for_user(username)
         return {
             'name': username,
             'auth_state': {
@@ -246,10 +245,9 @@ class MyAuthenticator(Authenticator):
             },
         }
 
-    @gen.coroutine
-    def pre_spawn_start(self, user, spawner):
+    async def pre_spawn_start(self, user, spawner):
         """Pass upstream_token to spawner via environment variable"""
-        auth_state = yield user.get_auth_state()
+        auth_state = await user.get_auth_state()
         if not auth_state:
             # auth_state not enabled
             return

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -930,7 +930,7 @@ class JupyterHub(Application):
 
         with an :meth:`authenticate` method that:
 
-        - is a coroutine (asyncio)
+        - is a coroutine (asyncio or tornado)
         - returns username on success, None on failure
         - takes two arguments: (handler, data),
           where `handler` is the calling web.RequestHandler,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -930,7 +930,7 @@ class JupyterHub(Application):
 
         with an :meth:`authenticate` method that:
 
-        - is a coroutine (asyncio or tornado)
+        - is a coroutine (asyncio)
         - returns username on success, None on failure
         - takes two arguments: (handler, data),
           where `handler` is the calling web.RequestHandler,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2120,7 +2120,7 @@ class JupyterHub(Application):
             self.log.debug(
                 "Awaiting checks for %i possibly-running spawners", len(check_futures)
             )
-            await gen.multi(check_futures)
+            await asyncio.gather(*check_futures)
         db.commit()
 
         # only perform this query if we are going to log it

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1538,7 +1538,7 @@ class UserUrlHandler(BaseHandler):
         if redirects:
             self.log.warning("Redirect loop detected on %s", self.request.uri)
             # add capped exponential backoff where cap is 10s
-            await gen.sleep(min(1 * (2 ** redirects), 10))
+            await asyncio.sleep(min(1 * (2 ** redirects), 10))
             # rewrite target url with new `redirects` query value
             url_parts = urlparse(target)
             query_parts = parse_qs(url_parts.query)

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -25,7 +25,6 @@ from functools import wraps
 from subprocess import Popen
 from urllib.parse import quote
 
-from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPError
 from tornado.httpclient import HTTPRequest
@@ -292,7 +291,7 @@ class Proxy(LoggingConfigurable):
             if service.server:
                 futures.append(self.add_service(service))
         # wait after submitting them all
-        await gen.multi(futures)
+        await asyncio.gather(*futures)
 
     async def add_all_users(self, user_dict):
         """Update the proxy table from the database.
@@ -305,7 +304,7 @@ class Proxy(LoggingConfigurable):
                 if spawner.ready:
                     futures.append(self.add_user(user, name))
         # wait after submitting them all
-        await gen.multi(futures)
+        await asyncio.gather(*futures)
 
     @_one_at_a_time
     async def check_routes(self, user_dict, service_dict, routes=None):
@@ -391,7 +390,7 @@ class Proxy(LoggingConfigurable):
                 self.log.warning("Deleting stale route %s", routespec)
                 futures.append(self.delete_route(routespec))
 
-        await gen.multi(futures)
+        await asyncio.gather(*futures)
         stop = time.perf_counter()  # timer stops here when user is deleted
         CHECK_ROUTES_DURATION_SECONDS.observe(stop - start)  # histogram metric
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -23,7 +23,6 @@ from urllib.parse import quote
 from urllib.parse import urlencode
 
 import requests
-from tornado.gen import coroutine
 from tornado.httputil import url_concat
 from tornado.log import app_log
 from tornado.web import HTTPError
@@ -950,8 +949,7 @@ class HubOAuthCallbackHandler(HubOAuthenticated, RequestHandler):
     .. versionadded: 0.8
     """
 
-    @coroutine
-    def get(self):
+    async def get(self):
         error = self.get_argument("error", False)
         if error:
             msg = self.get_argument("error_description", error)

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -20,7 +20,6 @@ from urllib.parse import urlparse
 
 from jinja2 import ChoiceLoader
 from jinja2 import FunctionLoader
-from tornado import gen
 from tornado import ioloop
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPRequest
@@ -434,7 +433,7 @@ class SingleUserNotebookAppMixin(Configurable):
                     i,
                     RETRIES,
                 )
-                await gen.sleep(min(2 ** i, 16))
+                await asyncio.sleep(min(2 ** i, 16))
             else:
                 break
         else:

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1079,7 +1079,7 @@ class Spawner(LoggingConfigurable):
             Return ip, port instead of setting on self.user.server directly.
         """
         raise NotImplementedError(
-            "Override in subclass. Must be a Tornado gen.coroutine."
+            "Override in subclass. Must be a coroutine."
         )
 
     async def stop(self, now=False):
@@ -1094,7 +1094,7 @@ class Spawner(LoggingConfigurable):
         Must be a coroutine.
         """
         raise NotImplementedError(
-            "Override in subclass. Must be a Tornado gen.coroutine."
+            "Override in subclass. Must be a coroutine."
         )
 
     async def poll(self):
@@ -1122,7 +1122,7 @@ class Spawner(LoggingConfigurable):
 
         """
         raise NotImplementedError(
-            "Override in subclass. Must be a Tornado gen.coroutine."
+            "Override in subclass. Must be a coroutine."
         )
 
     def add_poll_callback(self, callback, *args, **kwargs):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -16,8 +16,7 @@ from tempfile import mkdtemp
 
 if os.name == 'nt':
     import psutil
-from async_generator import async_generator
-from async_generator import yield_
+from async_generator import aclosing
 from sqlalchemy import inspect
 from tornado.ioloop import PeriodicCallback
 from traitlets import Any
@@ -1024,7 +1023,6 @@ class Spawner(LoggingConfigurable):
     def _progress_url(self):
         return self.user.progress_url(self.name)
 
-    @async_generator
     async def _generate_progress(self):
         """Private wrapper of progress generator
 
@@ -1036,20 +1034,16 @@ class Spawner(LoggingConfigurable):
             )
             return
 
-        await yield_({"progress": 0, "message": "Server requested"})
-        from async_generator import aclosing
+        yield {"progress": 0, "message": "Server requested"}
 
         async with aclosing(self.progress()) as progress:
             async for event in progress:
-                await yield_(event)
+                yield event
 
-    @async_generator
     async def progress(self):
         """Async generator for progress events
 
         Must be an async generator
-
-        For Python 3.5-compatibility, use the async_generator package
 
         Should yield messages of the form:
 
@@ -1067,7 +1061,7 @@ class Spawner(LoggingConfigurable):
 
         .. versionadded:: 0.9
         """
-        await yield_({"progress": 50, "message": "Spawning server..."})
+        yield {"progress": 50, "message": "Spawning server..."}
 
     async def start(self):
         """Start the single-user server
@@ -1078,9 +1072,7 @@ class Spawner(LoggingConfigurable):
         .. versionchanged:: 0.7
             Return ip, port instead of setting on self.user.server directly.
         """
-        raise NotImplementedError(
-            "Override in subclass. Must be a coroutine."
-        )
+        raise NotImplementedError("Override in subclass. Must be a coroutine.")
 
     async def stop(self, now=False):
         """Stop the single-user server
@@ -1093,9 +1085,7 @@ class Spawner(LoggingConfigurable):
 
         Must be a coroutine.
         """
-        raise NotImplementedError(
-            "Override in subclass. Must be a coroutine."
-        )
+        raise NotImplementedError("Override in subclass. Must be a coroutine.")
 
     async def poll(self):
         """Check if the single-user process is running
@@ -1121,9 +1111,7 @@ class Spawner(LoggingConfigurable):
           process has not yet completed.
 
         """
-        raise NotImplementedError(
-            "Override in subclass. Must be a coroutine."
-        )
+        raise NotImplementedError("Override in subclass. Must be a coroutine.")
 
     def add_poll_callback(self, callback, *args, **kwargs):
         """Add a callback to fire when the single-user server stops"""

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -54,6 +54,13 @@ from .utils import ssl_setup
 _db = None
 
 
+def pytest_collection_modifyitems(items):
+    """add asyncio marker to all async tests"""
+    for item in items:
+        if inspect.iscoroutinefunction(item.obj):
+            item.add_marker('asyncio')
+
+
 @fixture(scope='module')
 def ssl_tmpdir(tmpdir_factory):
     return tmpdir_factory.mktemp('ssl')

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -36,7 +36,6 @@ from unittest import mock
 
 from pytest import fixture
 from pytest import raises
-from tornado import gen
 from tornado import ioloop
 from tornado.httpclient import HTTPError
 from tornado.platform.asyncio import AsyncIOMainLoop
@@ -53,16 +52,6 @@ from .utils import ssl_setup
 
 # global db session object
 _db = None
-
-
-def pytest_collection_modifyitems(items):
-    """add asyncio marker to all async tests"""
-    for item in items:
-        if inspect.iscoroutinefunction(item.obj):
-            item.add_marker('asyncio')
-        if hasattr(inspect, 'isasyncgenfunction'):
-            # double-check that we aren't mixing yield and async def
-            assert not inspect.isasyncgenfunction(item.obj)
 
 
 @fixture(scope='module')
@@ -244,17 +233,14 @@ def _mockservice(request, app, url=False):
         assert name in app._service_map
         service = app._service_map[name]
 
-        @gen.coroutine
-        def start():
+        async def start():
             # wait for proxy to be updated before starting the service
-            yield app.proxy.add_all_services(app._service_map)
+            await app.proxy.add_all_services(app._service_map)
             service.start()
 
         io_loop.run_sync(start)
 
         def cleanup():
-            import asyncio
-
             asyncio.get_event_loop().run_until_complete(service.stop())
             app.services[:] = []
             app._service_map.clear()

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -55,10 +55,16 @@ _db = None
 
 
 def pytest_collection_modifyitems(items):
-    """add asyncio marker to all async tests"""
+    """This function is automatically run by pytest passing all collected test
+    functions.
+
+    We use it to add asyncio marker to all async tests and assert we don't use
+    test functions that are async generators which wouldn't make sense.
+    """
     for item in items:
         if inspect.iscoroutinefunction(item.obj):
             item.add_marker('asyncio')
+        assert not inspect.isasyncgenfunction(item.obj)
 
 
 @fixture(scope='module')

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -37,7 +37,6 @@ from urllib.parse import urlparse
 
 from pamela import PAMError
 from tornado import gen
-from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 from traitlets import Bool
 from traitlets import default
@@ -110,19 +109,17 @@ class SlowSpawner(MockSpawner):
     delay = 2
     _start_future = None
 
-    @gen.coroutine
-    def start(self):
-        (ip, port) = yield super().start()
+    async def start(self):
+        (ip, port) = await super().start()
         if self._start_future is not None:
-            yield self._start_future
+            await self._start_future
         else:
-            yield gen.sleep(self.delay)
+            await gen.sleep(self.delay)
         return ip, port
 
-    @gen.coroutine
-    def stop(self):
-        yield gen.sleep(self.delay)
-        yield super().stop()
+    async def stop(self):
+        await gen.sleep(self.delay)
+        await super().stop()
 
 
 class NeverSpawner(MockSpawner):
@@ -134,14 +131,12 @@ class NeverSpawner(MockSpawner):
 
     def start(self):
         """Return a Future that will never finish"""
-        return Future()
+        return asyncio.Future()
 
-    @gen.coroutine
-    def stop(self):
+    async def stop(self):
         pass
 
-    @gen.coroutine
-    def poll(self):
+    async def poll(self):
         return 0
 
 
@@ -215,8 +210,7 @@ class MockPAMAuthenticator(PAMAuthenticator):
         # skip the add-system-user bit
         return not user.name.startswith('dne')
 
-    @gen.coroutine
-    def authenticate(self, *args, **kwargs):
+    async def authenticate(self, *args, **kwargs):
         with mock.patch.multiple(
             'pamela',
             authenticate=mock_authenticate,
@@ -224,7 +218,7 @@ class MockPAMAuthenticator(PAMAuthenticator):
             close_session=mock_open_session,
             check_account=mock_check_account,
         ):
-            username = yield super(MockPAMAuthenticator, self).authenticate(
+            username = await super(MockPAMAuthenticator, self).authenticate(
                 *args, **kwargs
             )
         if username is None:
@@ -320,14 +314,13 @@ class MockHub(JupyterHub):
                 self.db.delete(group)
             self.db.commit()
 
-    @gen.coroutine
-    def initialize(self, argv=None):
+    async def initialize(self, argv=None):
         self.pid_file = NamedTemporaryFile(delete=False).name
         self.db_file = NamedTemporaryFile()
         self.db_url = os.getenv('JUPYTERHUB_TEST_DB_URL') or self.db_file.name
         if 'mysql' in self.db_url:
             self.db_kwargs['connect_args'] = {'auth_plugin': 'mysql_native_password'}
-        yield super().initialize([])
+        await super().initialize([])
 
         # add an initial user
         user = self.db.query(orm.User).filter(orm.User.name == 'user').first()
@@ -358,14 +351,13 @@ class MockHub(JupyterHub):
         self.cleanup = lambda: None
         self.db_file.close()
 
-    @gen.coroutine
-    def login_user(self, name):
+    async def login_user(self, name):
         """Login a user by name, returning her cookies."""
         base_url = public_url(self)
         external_ca = None
         if self.internal_ssl:
             external_ca = self.external_certs['files']['ca']
-        r = yield async_requests.post(
+        r = await async_requests.post(
             base_url + 'hub/login',
             data={'username': name, 'password': name},
             allow_redirects=False,
@@ -407,8 +399,7 @@ class StubSingleUserSpawner(MockSpawner):
 
     _thread = None
 
-    @gen.coroutine
-    def start(self):
+    async def start(self):
         ip = self.ip = '127.0.0.1'
         port = self.port = random_port()
         env = self.get_env()
@@ -435,14 +426,12 @@ class StubSingleUserSpawner(MockSpawner):
         assert ready
         return (ip, port)
 
-    @gen.coroutine
-    def stop(self):
+    async def stop(self):
         self._app.stop()
         self._thread.join(timeout=30)
         assert not self._thread.is_alive()
 
-    @gen.coroutine
-    def poll(self):
+    async def poll(self):
         if self._thread is None:
             return 0
         if self._thread.is_alive():

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -36,7 +36,6 @@ from unittest import mock
 from urllib.parse import urlparse
 
 from pamela import PAMError
-from tornado import gen
 from tornado.ioloop import IOLoop
 from traitlets import Bool
 from traitlets import default
@@ -114,11 +113,11 @@ class SlowSpawner(MockSpawner):
         if self._start_future is not None:
             await self._start_future
         else:
-            await gen.sleep(self.delay)
+            await asyncio.sleep(self.delay)
         return ip, port
 
     async def stop(self):
-        await gen.sleep(self.delay)
+        await asyncio.sleep(self.delay)
         await super().stop()
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1,9 +1,9 @@
 """Tests for the REST API."""
+import asyncio
 import json
 import re
 import sys
 import uuid
-from concurrent.futures import Future
 from datetime import datetime
 from datetime import timedelta
 from unittest import mock
@@ -885,8 +885,8 @@ async def test_spawn_limit(app, no_patience, slow_spawn, request):
     # start two pending spawns
     names = ['ykka', 'hjarka']
     users = [add_user(db, app=app, name=name) for name in names]
-    users[0].spawner._start_future = Future()
-    users[1].spawner._start_future = Future()
+    users[0].spawner._start_future = asyncio.Future()
+    users[1].spawner._start_future = asyncio.Future()
     for name in names:
         await api_request(app, 'users', name, 'server', method='post')
     assert app.users.count_active_users()['pending'] == 2
@@ -894,7 +894,7 @@ async def test_spawn_limit(app, no_patience, slow_spawn, request):
     # ykka and hjarka's spawns are both pending. Essun should fail with 429
     name = 'essun'
     user = add_user(db, app=app, name=name)
-    user.spawner._start_future = Future()
+    user.spawner._start_future = asyncio.Future()
     r = await api_request(app, 'users', name, 'server', method='post')
     assert r.status_code == 429
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 from async_generator import async_generator
 from async_generator import yield_
 from pytest import mark
-from tornado import gen
 
 import jupyterhub
 from .. import orm

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -613,7 +613,7 @@ async def test_slow_spawn(app, no_patience, slow_spawn):
 
     async def wait_spawn():
         while not app_user.running:
-            await gen.sleep(0.1)
+            await asyncio.sleep(0.1)
 
     await wait_spawn()
     assert not app_user.spawner._spawn_pending
@@ -622,7 +622,7 @@ async def test_slow_spawn(app, no_patience, slow_spawn):
 
     async def wait_stop():
         while app_user.spawner._stop_pending:
-            await gen.sleep(0.1)
+            await asyncio.sleep(0.1)
 
     r = await api_request(app, 'users', name, 'server', method='delete')
     r.raise_for_status()
@@ -656,7 +656,7 @@ async def test_never_spawn(app, no_patience, never_spawn):
     assert app.users.count_active_users()['pending'] == 1
 
     while app_user.spawner.pending:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         print(app_user.spawner.pending)
 
     assert not app_user.spawner._spawn_pending
@@ -682,7 +682,7 @@ async def test_slow_bad_spawn(app, no_patience, slow_bad_spawn):
     r = await api_request(app, 'users', name, 'server', method='post')
     r.raise_for_status()
     while user.spawner.pending:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
     # spawn failed
     assert not user.running
     assert app.users.count_active_users()['pending'] == 0
@@ -824,7 +824,7 @@ async def progress_forever():
     for i in range(1, 10):
         await yield_({'progress': i, 'message': 'Stage %s' % i})
         # wait a long time before the next event
-        await gen.sleep(10)
+        await asyncio.sleep(10)
 
 
 if sys.version_info >= (3, 6):
@@ -840,7 +840,7 @@ async def progress_forever_native():
             'message': 'Stage %s' % i,
         }
         # wait a long time before the next event
-        await gen.sleep(10)
+        await asyncio.sleep(10)
 """,
         globals(),
     )
@@ -902,7 +902,7 @@ async def test_spawn_limit(app, no_patience, slow_spawn, request):
     users[0].spawner._start_future.set_result(None)
     # wait for ykka to finish
     while not users[0].running:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
     assert app.users.count_active_users()['pending'] == 1
     r = await api_request(app, 'users', name, 'server', method='post')
@@ -913,7 +913,7 @@ async def test_spawn_limit(app, no_patience, slow_spawn, request):
     for user in users[1:]:
         user.spawner._start_future.set_result(None)
     while not all(u.running for u in users):
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
     # everybody's running, pending count should be back to 0
     assert app.users.count_active_users()['pending'] == 0
@@ -922,7 +922,7 @@ async def test_spawn_limit(app, no_patience, slow_spawn, request):
         r = await api_request(app, 'users', u.name, 'server', method='delete')
         r.raise_for_status()
     while any(u.spawner.active for u in users):
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
 
 @mark.slow
@@ -1000,7 +1000,7 @@ async def test_start_stop_race(app, no_patience, slow_spawn):
     r = await api_request(app, 'users', user.name, 'server', method='delete')
     assert r.status_code == 400
     while not spawner.ready:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
     spawner.delay = 3
     # stop the spawner
@@ -1008,7 +1008,7 @@ async def test_start_stop_race(app, no_patience, slow_spawn):
     assert r.status_code == 202
     assert spawner.pending == 'stop'
     # make sure we get past deleting from the proxy
-    await gen.sleep(1)
+    await asyncio.sleep(1)
     # additional stops while stopping shouldn't trigger a new stop
     with mock.patch.object(spawner, 'stop') as m:
         r = await api_request(app, 'users', user.name, 'server', method='delete')
@@ -1020,7 +1020,7 @@ async def test_start_stop_race(app, no_patience, slow_spawn):
     assert r.status_code == 400
 
     while spawner.active:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
     # start after stop is okay
     r = await api_request(app, 'users', user.name, 'server', method='post')
     assert r.status_code == 202

--- a/jupyterhub/tests/test_internal_ssl_connections.py
+++ b/jupyterhub/tests/test_internal_ssl_connections.py
@@ -20,8 +20,7 @@ ssl_enabled = True
 SSL_ERROR = (SSLError, ConnectionError)
 
 
-@gen.coroutine
-def wait_for_spawner(spawner, timeout=10):
+async def wait_for_spawner(spawner, timeout=10):
     """Wait for an http server to show up
 
     polling at shorter intervals for early termination
@@ -32,15 +31,15 @@ def wait_for_spawner(spawner, timeout=10):
         return spawner.server.wait_up(timeout=1, http=True)
 
     while time.monotonic() < deadline:
-        status = yield spawner.poll()
+        status = await spawner.poll()
         assert status is None
         try:
-            yield wait()
+            await wait()
         except TimeoutError:
             continue
         else:
             break
-    yield wait()
+    await wait()
 
 
 async def test_connection_hub_wrong_certs(app):

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -222,8 +222,7 @@ async def test_spawn_fails(db):
     db.commit()
 
     class BadSpawner(MockSpawner):
-        @gen.coroutine
-        def start(self):
+        async def start(self):
             raise RuntimeError("Split the party")
 
     user = User(

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -8,7 +8,6 @@ from urllib.parse import urlparse
 
 import pytest
 from bs4 import BeautifulSoup
-from tornado import gen
 from tornado.escape import url_escape
 from tornado.httputil import url_concat
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -586,8 +586,7 @@ async def test_login_strip(app):
     base_url = public_url(app)
     called_with = []
 
-    @gen.coroutine
-    def mock_authenticate(handler, data):
+    async def mock_authenticate(handler, data):
         called_with.append(data)
 
     with mock.patch.object(app.authenticator, 'authenticate', mock_authenticate):
@@ -943,8 +942,7 @@ async def test_pre_spawn_start_exc_no_form(app):
     exc = "pre_spawn_start error"
 
     # throw exception from pre_spawn_start
-    @gen.coroutine
-    def mock_pre_spawn_start(user, spawner):
+    async def mock_pre_spawn_start(user, spawner):
         raise Exception(exc)
 
     with mock.patch.object(app.authenticator, 'pre_spawn_start', mock_pre_spawn_start):
@@ -959,8 +957,7 @@ async def test_pre_spawn_start_exc_options_form(app):
     exc = "pre_spawn_start error"
 
     # throw exception from pre_spawn_start
-    @gen.coroutine
-    def mock_pre_spawn_start(user, spawner):
+    async def mock_pre_spawn_start(user, spawner):
         raise Exception(exc)
 
     with mock.patch.dict(

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -6,9 +6,7 @@ from binascii import hexlify
 from contextlib import contextmanager
 from subprocess import Popen
 
-from async_generator import async_generator
 from async_generator import asynccontextmanager
-from async_generator import yield_
 from tornado.ioloop import IOLoop
 
 from ..utils import maybe_future
@@ -24,7 +22,6 @@ mockservice_cmd = [sys.executable, mockservice_py]
 
 
 @asynccontextmanager
-@async_generator
 async def external_service(app, name='mockservice'):
     env = {
         'JUPYTERHUB_API_TOKEN': hexlify(os.urandom(5)),
@@ -35,7 +32,7 @@ async def external_service(app, name='mockservice'):
     proc = Popen(mockservice_cmd, env=env)
     try:
         await wait_for_http_server(env['JUPYTERHUB_SERVICE_URL'])
-        await yield_(env)
+        yield env
     finally:
         proc.terminate()
 

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -1,6 +1,7 @@
 """Tests for process spawning"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import asyncio
 import logging
 import os
 import signal
@@ -12,7 +13,6 @@ from unittest import mock
 from urllib.parse import urlparse
 
 import pytest
-from tornado import gen
 
 from .. import orm
 from .. import spawner as spawnermod
@@ -123,7 +123,7 @@ async def test_stop_spawner_sigint_fails(db):
     await spawner.start()
 
     # wait for the process to get to the while True: loop
-    await gen.sleep(1)
+    await asyncio.sleep(1)
 
     status = await spawner.poll()
     assert status is None
@@ -138,7 +138,7 @@ async def test_stop_spawner_stop_now(db):
     await spawner.start()
 
     # wait for the process to get to the while True: loop
-    await gen.sleep(1)
+    await asyncio.sleep(1)
 
     status = await spawner.poll()
     assert status is None
@@ -165,7 +165,7 @@ async def test_spawner_poll(db):
     spawner.start_polling()
 
     # wait for the process to get to the while True: loop
-    await gen.sleep(1)
+    await asyncio.sleep(1)
     status = await spawner.poll()
     assert status is None
 
@@ -173,12 +173,12 @@ async def test_spawner_poll(db):
     proc.terminate()
     for i in range(10):
         if proc.poll() is None:
-            await gen.sleep(1)
+            await asyncio.sleep(1)
         else:
             break
     assert proc.poll() is not None
 
-    await gen.sleep(2)
+    await asyncio.sleep(2)
     status = await spawner.poll()
     assert status is not None
 

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -3,19 +3,16 @@ import asyncio
 
 import pytest
 from async_generator import aclosing
-from async_generator import async_generator
-from async_generator import yield_
 
 from ..utils import iterate_until
 
 
-@async_generator
 async def yield_n(n, delay=0.01):
     """Yield n items with a delay between each"""
     for i in range(n):
         if delay:
             await asyncio.sleep(delay)
-        await yield_(i)
+        yield i
 
 
 def schedule_future(io_loop, *, delay, result=None):
@@ -50,10 +47,9 @@ async def test_iterate_until(io_loop, deadline, n, delay, expected):
 async def test_iterate_until_ready_after_deadline(io_loop):
     f = schedule_future(io_loop, delay=0)
 
-    @async_generator
     async def gen():
         for i in range(5):
-            await yield_(i)
+            yield i
 
     yielded = []
     async with aclosing(iterate_until(f, gen())) as items:

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -503,7 +503,7 @@ def maybe_future(obj):
         return asyncio.wrap_future(obj)
     else:
         # could also check for tornado.concurrent.Future
-        # but with tornado >= 5 tornado.Future is asyncio.Future
+        # but with tornado >= 5.1 tornado.Future is asyncio.Future
         f = asyncio.Future()
         f.set_result(obj)
         return f

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -21,9 +21,6 @@ from hmac import compare_digest
 from operator import itemgetter
 
 from async_generator import aclosing
-from async_generator import async_generator
-from async_generator import asynccontextmanager
-from async_generator import yield_
 from tornado import ioloop
 from tornado import web
 from tornado.httpclient import AsyncHTTPClient
@@ -512,22 +509,6 @@ def maybe_future(obj):
         return f
 
 
-@asynccontextmanager
-@async_generator
-async def not_aclosing(coro):
-    """An empty context manager for Python < 3.5.2
-    which lacks the `aclose` method on async iterators
-    """
-    await yield_(await coro)
-
-
-if sys.version_info < (3, 5, 2):
-    # Python 3.5.1 is missing the aclose method on async iterators,
-    # so we can't close them
-    aclosing = not_aclosing
-
-
-@async_generator
 async def iterate_until(deadline_future, generator):
     """An async generator that yields items from a generator
     until a deadline future resolves
@@ -552,7 +533,7 @@ async def iterate_until(deadline_future, generator):
             )
             if item_future.done():
                 try:
-                    await yield_(item_future.result())
+                    yield item_future.result()
                 except (StopAsyncIteration, asyncio.CancelledError):
                     break
             elif deadline_future.done():

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -24,7 +24,6 @@ from async_generator import aclosing
 from async_generator import async_generator
 from async_generator import asynccontextmanager
 from async_generator import yield_
-from tornado import gen
 from tornado import ioloop
 from tornado import web
 from tornado.httpclient import AsyncHTTPClient
@@ -175,7 +174,7 @@ async def exponential_backoff(
         dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
         if dt < max_wait:
             scale *= scale_factor
-        await gen.sleep(dt)
+        await asyncio.sleep(dt)
     raise TimeoutError(fail_message)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic
-async_generator>=1.8
+async_generator>=1.9
 certipy>=0.1.2
 entrypoints
 jinja2
@@ -11,5 +11,5 @@ psutil>=5.6.5; sys_platform == 'win32'
 python-dateutil
 requests
 SQLAlchemy>=1.1
-tornado>=5.0
+tornado>=5.1
 traitlets>=4.3.2


### PR DESCRIPTION
This PR is meant to close #3241 by removing patches for py34 / py35 which are now both at their end of life. This PR removes py35 support. We will still need the [async_generator](https://pypi.org/project/async_generator/) until python 3.7 for the @asynccontextmanager decorator that is useful to wrap async generator functions that is to be used in a `with` statement.

## Things done
- [x] Replace @gen.coroutine/yield with async/await
- [x] Replace gen.sleep with asyncio.sleep
- [x] (REVERTED) Replace gen.with_timeout with async_timeout.timeout & asyncio.shield
  Initially I tried what was described in https://github.com/dask/distributed/pull/3372, but as it failed I tried with advice in https://hynek.me/articles/waiting-in-asyncio/ and in https://pypi.org/project/async-timeout/ which made it work.
- [x] Replace gen.multi(futures) with asyncio.gather(*futures)
- [x] Replace @async_generator/yeild_ with async/yeild

## Review checks
- [x] (REVERTED) In the commit about replacing gen.with_timeout with async_timeout.timeout & asyncio.shield, I wrap the future in a "shield" that will absorb a CancelledError that comes from async_timeout.timeout that doesn't come from gen.with_timeout. Does this make sense? It is my understanding that we may end up with stranded execution threads that may continue forever if we are not careful. I do think this is something we did in the past though, so I believe what I've done only mirrored current behavior.

## Related
- I learned a lot from this blog post: https://hynek.me/articles/waiting-in-asyncio/
- I made us depend on the async-timeout package: https://pypi.org/project/async-timeout/
- I learned about asyncio.shield from here: https://stackoverflow.com/a/52511210
- I may have learned about the distinction between a future and a coroutine, this is my current understanding that I'd love to get corrected if it seems off.
   ```python
   async def my_async_func():
       asyncio.sleep(1)
       return "slow response"
   
   # Example 1 - what is a coroutine?
   my_coroutine = my_async_func()  # the function isn't scheduled for execution here
   my_return_value = await my_coroutine  # this is where it is scheduled!
   
   # My understanding:
   # a coroutine is an async function + arguments for it not yet running
   
   # Example 2 - what is a future?
   import asyncio
   my_future = asyncio.ensure_future(my_async_func())  # ensure_future took a coroutine and started it!
   asyncio.sleep(1)
   my_return_value = await my_future  # this line completes instantly!
   
   # My understanding:
   # a future is a placeholder for the return value of a coroutine that has started running
   ```