### PR TITLE
remove push-branch conditions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ name: Run tests
 on:
   pull_request:
   push:
-    branches: [main, master, pr/migrate-to-gh-actions-from-travis]
-    tags:
 
 defaults:
   run:


### PR DESCRIPTION
testing branches by default is useful, and there's little cost to removing the conditions:

- we don't issue PRs from our repo, so test runs aren't duplicated on this repo for PRs
- testing on a fork without opening a PR is still useful (I use this often)
- if we push a branch, it should probably be tested (e.g. a backport branch), and filters make this extra work
- the cost of running a few extra tests is low, especially given actions' current quotas and parallelism. If this changes (like Travis!) we can reconsider. Very slow repos like z2jh might want to choose differently.

For instance, I've just started an `rbac` branch so we can start landing PRs related to RBAC without going all the way to master. I don't think we should need to modify our workflow configuration to enable tests for this.