### PR TITLE
Standardize "Sign in" capitalization on the login page

### DIFF
--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -61,7 +61,7 @@
         id="login_submit"
         type="submit"
         class='btn btn-jupyter'
-        value='Sign In'
+        value='Sign in'
         tabindex="3"
         />
       <div class="feedback-widget hidden">


### PR DESCRIPTION
In the login page form header, the `in` of `Sign in` is not capitalized, while the `In` of the `Sign In` button is capitalized. I would suggest we choose one form or another, but not both in the same contex. This PR implements the non-capitalized `in` version.

Sorry for making a PR for such a small change, but I just saw it and now I cannot unsee it.