### PR TITLE
Exclude "code" and "state" query params from next_url

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -659,7 +659,9 @@ class BaseHandler(RequestHandler):
             else:
                 next_url = url_path_join(self.hub.base_url, 'home')
 
-        next_url = self.append_query_parameters(next_url, exclude=['next'])
+        next_url = self.append_query_parameters(
+            next_url, exclude=['next', 'code', 'state']
+        )
         return next_url
 
     def append_query_parameters(self, url, exclude=None):


### PR DESCRIPTION
This fixes our issue with JH skipping spawner UI after authentization although no query parameters were provided - `code` and `state` stay in query after auth and cause Spawner to kick off. All the details are in the issue #3247.

Fixes #3247 

cc @kinow - since the `append_query_parameters` is your contribution, can you take a look?

