### PR TITLE
Fix curl in jupyter announcements

### DIFF
--- a/examples/service-announcement/README.md
+++ b/examples/service-announcement/README.md
@@ -27,7 +27,7 @@ that environment variable is set or `/` if it is not.
 Admin users can set the announcement text with an API token:
 
     $ curl -X POST -H "Authorization: token <token>"                        \
-        -d "{'announcement':'JupyterHub will be upgraded on August 14!'}"   \
+        -d '{"announcement":"JupyterHub will be upgraded on August 14!"}'   \
         https://.../services/announcement
 
 Anyone can read the announcement:


### PR DESCRIPTION
Running curl returns a 500 with the error 
`json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
`
Converting the payload to a proper JSON