### PR TITLE
add Authenticator.strict_config

### DIFF
--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -60,8 +60,15 @@ as the users will be loaded from the database.
 After starting the Hub once, it is not sufficient to **remove** a user
 from the allowed users set in your config file. You must also remove the user
 from the Hub's database, either by deleting the user from JupyterHub's
-admin page, or you can clear the `jupyterhub.sqlite` database and start
-fresh.
+admin page, or you can clear the `jupyterhub.sqlite` database and start fresh.
+The same is true of `Authenticator.admin_users`.
+
+JupyterHub 1.3 adds `c.Authenticator.strict_config` which, if True,
+makes the `allowed_users` and `admin_users` configuration the *only* way to add/remove users and admin permissions.
+If enabled, users removed from `allowed_users` and `admin_users` sets will have their permissions revoked,
+however this also means that users cannot be created or modified via the admin panel or API
+because users created in this way would necessarily be deleted upon every Hub restart.
+
 
 ## Use LocalAuthenticator to create system users
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -100,6 +100,9 @@ class UserListAPIHandler(APIHandler):
 
     @admin_only
     async def post(self):
+        if self.authenticator.strict_config:
+            raise web.HTTPError(403, "User creation via API is not allowed.")
+
         data = self.get_json_body()
         if not data or not isinstance(data, dict) or not data.get('usernames'):
             raise web.HTTPError(400, "Must specify at least one user to create")
@@ -190,6 +193,8 @@ class UserAPIHandler(APIHandler):
 
     @admin_only
     async def post(self, name):
+        if self.authenticator.strict_config:
+            raise web.HTTPError(403, "User modification via API is not allowed.")
         data = self.get_json_body()
         user = self.find_user(name)
         if user is not None:
@@ -215,6 +220,8 @@ class UserAPIHandler(APIHandler):
 
     @admin_only
     async def delete(self, name):
+        if self.authenticator.strict_config:
+            raise web.HTTPError(403, "User modification via API is not allowed.")
         user = self.find_user(name)
         if user is None:
             raise web.HTTPError(404)
@@ -240,6 +247,9 @@ class UserAPIHandler(APIHandler):
 
     @admin_only
     async def patch(self, name):
+        if self.authenticator.strict_config:
+            raise web.HTTPError(403, "User modification via API is not allowed.")
+
         user = self.find_user(name)
         if user is None:
             raise web.HTTPError(404)


### PR DESCRIPTION
and better document the relationship of Authenticator user sets and db 

Some folks may expect/want config modification to be able to *remove* access, which is not currently

this is a draft because it's incompatible with secondary allowed-users implementations like group_whitelist, etc. I'm not certain that's a bad thing (it doesn't make much sense to use both), but at the very least the conflict should be clearer before merge.

I'm going to open a separate PR to allow better init logging for Authenticators to declare their configuration, which ought to allow better debugging.