### PR TITLE
bump oldest-required prometheus-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jinja2
 jupyter_telemetry>=0.1.0
 oauthlib>=3.0
 pamela; sys_platform != 'win32'
-prometheus_client>=0.0.21
+prometheus_client>=0.4.0
 psutil>=5.6.5; sys_platform == 'win32'
 python-dateutil
 requests


### PR DESCRIPTION
oldest-dependency tests caught an error with our base required version

should fix ci failure in the oldest-dependency entry