### PR TITLE
fix increasing pagination limits

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -457,7 +457,8 @@ class AdminHandler(BaseHandler):
     @web.authenticated
     @admin_only
     async def get(self):
-        page, per_page, offset = Pagination(config=self.config).get_page_args(self)
+        pagination = Pagination(url=self.request.uri, config=self.config)
+        page, per_page, offset = pagination.get_page_args(self)
 
         available = {'name', 'admin', 'running', 'last_activity'}
         default_sort = ['admin', 'name']
@@ -513,14 +514,7 @@ class AdminHandler(BaseHandler):
         for u in users:
             running.extend(s for s in u.spawners.values() if s.active)
 
-        total = self.db.query(orm.User.id).count()
-        pagination = Pagination(
-            url=self.request.uri,
-            total=total,
-            page=page,
-            per_page=per_page,
-            config=self.config,
-        )
+        pagination.total = self.db.query(orm.User.id).count()
 
         auth_state = await self.current_user.get_auth_state()
         html = await self.render_template(

--- a/jupyterhub/pagination.py
+++ b/jupyterhub/pagination.py
@@ -1,7 +1,6 @@
 """Basic class to manage pagination utils."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-from traitlets import Bool
 from traitlets import default
 from traitlets import Integer
 from traitlets import observe
@@ -81,13 +80,13 @@ class Pagination(Configurable):
         try:
             self.per_page = int(per_page)
         except Exception:
-            self.per_page = self._default_per_page
+            self.per_page = self.default_per_page
 
         try:
             self.page = int(page)
             if self.page < 1:
                 self.page = 1
-        except:
+        except Exception:
             self.page = 1
 
         return self.page, self.per_page, self.per_page * (self.page - 1)

--- a/jupyterhub/tests/test_pagination.py
+++ b/jupyterhub/tests/test_pagination.py
@@ -6,11 +6,20 @@ from traitlets.config import Config
 from jupyterhub.pagination import Pagination
 
 
-def test_per_page_bounds():
+@mark.parametrize(
+    "per_page, max_per_page, expected",
+    [
+        (20, 10, 10),
+        (1000, 1000, 1000),
+    ],
+)
+def test_per_page_bounds(per_page, max_per_page, expected):
     cfg = Config()
-    cfg.Pagination.max_per_page = 10
-    p = Pagination(config=cfg, per_page=20, total=100)
-    assert p.per_page == 10
+    cfg.Pagination.max_per_page = max_per_page
+    p = Pagination(config=cfg)
+    p.per_page = per_page
+    p.total = 99999
+    assert p.per_page == expected
     with raises(Exception):
         p.per_page = 0
 
@@ -39,7 +48,5 @@ def test_per_page_bounds():
     ],
 )
 def test_window(page, per_page, total, expected):
-    cfg = Config()
-    cfg.Pagination
     pagination = Pagination(page=page, per_page=per_page, total=total)
     assert pagination.calculate_pages_window() == expected


### PR DESCRIPTION
setting per_page in constructor resolves before max_per_page limit is updated from config, preventing max_per_page from being increased beyond the default limit.

we already loaded these values anyway in the first Pagination instance, so remove the redundant Pagination object and the values work out.

closes #3229