### PR TITLE
fixed default roles for mocked services

### DIFF
--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -259,3 +259,16 @@ def update_roles(db, obj, kind, roles=None):
         # users and services can have 'user' or 'admin' roles as default
         else:
             switch_default_role(db, obj, kind, obj.admin)
+
+
+def mock_roles(app, name, kind):
+
+    """Loads and assigns default roles for mocked objects"""
+
+    Class = get_orm_class(kind)
+
+    obj = Class.find(app.db, name=name)
+    default_roles = get_default_roles()
+    for role in default_roles:
+        add_role(app.db, role)
+    update_roles(db=app.db, obj=obj, kind=kind)

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -44,6 +44,7 @@ import jupyterhub.services.service
 from . import mocking
 from .. import crypto
 from .. import orm
+from ..roles import mock_roles
 from ..utils import random_port
 from .mocking import MockHub
 from .test_services import mockservice_cmd
@@ -245,6 +246,7 @@ def _mockservice(request, app, url=False):
     ):
         app.services = [spec]
         app.init_services()
+        mock_roles(app, name, 'services')
         assert name in app._service_map
         service = app._service_map[name]
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1594,7 +1594,7 @@ async def test_get_services(app, mockservice_url):
         mockservice.name: {
             'name': mockservice.name,
             'admin': True,
-            'roles': [],
+            'roles': ['admin'],
             'command': mockservice.command,
             'pid': mockservice.proc.pid,
             'prefix': mockservice.server.base_url,
@@ -1620,7 +1620,7 @@ async def test_get_service(app, mockservice_url):
     assert service == {
         'name': mockservice.name,
         'admin': True,
-        'roles': [],
+        'roles': ['admin'],
         'command': mockservice.command,
         'pid': mockservice.proc.pid,
         'prefix': mockservice.server.base_url,


### PR DESCRIPTION
Ref.: User roles (RBAC) #2245 

Fixes default role assignment for mocked services used in tests.

As @0mar pointed out (thank you!), the mocked services in API tests were not being assigned default roles. 

This is now fixed with calling `mock_roles` function (added to roles.py) in conftest.py, which assigns a default role to the mocked service.