### PR TITLE
Separate metrics port

### DIFF
--- a/jupyterhub/metricshandler.py
+++ b/jupyterhub/metricshandler.py
@@ -1,0 +1,17 @@
+from prometheus_client import CONTENT_TYPE_LATEST
+from prometheus_client import generate_latest
+from prometheus_client import REGISTRY
+
+from .handlers.base import BaseHandler
+
+
+class MetricsHandler(BaseHandler):
+    """
+    Handler to serve Prometheus metrics
+    """
+
+    async def get(self):
+        self.set_header('Content-Type', CONTENT_TYPE_LATEST)
+        self.write(generate_latest(REGISTRY))
+
+default_handlers = [(r'/metrics$', MetricsHandler)]


### PR DESCRIPTION
I'd like to get the JupyterHub metrics from Prometheus which is not mapped as any user in the system. However, the metrics handler is protected by user authentication. As I can protect the metrics port w/o authentication by Kubernetes NetworkPolicy if it's separated.

This implementation may not be enough. Please tell me what else I need to change.