### PR TITLE
docs: fix simple typo, funciton -> function

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -318,7 +318,7 @@ class Expiring:
     which should be unix timestamp or datetime object
     """
 
-    now = utcnow  # funciton, must return float timestamp or datetime
+    now = utcnow  # function, must return float timestamp or datetime
     expires_at = None  # must be defined
 
     @property


### PR DESCRIPTION
There is a small typo in jupyterhub/orm.py.

Should read `function` rather than `funciton`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md