### PR TITLE
Make Authenticator Custom HTML Flexible

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1102,6 +1102,7 @@ class PAMAuthenticator(LocalAuthenticator):
             return super().normalize_username(username)
 
     def get_custom_html(self, base_url):
+        """Get custom HTML for the authenticator."""
         return self.custom_html
 
 

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1101,6 +1101,9 @@ class PAMAuthenticator(LocalAuthenticator):
         else:
             return super().normalize_username(username)
 
+    def get_custom_html(self, base_url):
+        return self.custom_html
+
 
 for _old_name, _new_name, _version in [
     ("check_group_whitelist", "check_group_allowed", "1.2"),

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1102,7 +1102,10 @@ class PAMAuthenticator(LocalAuthenticator):
             return super().normalize_username(username)
 
     def get_custom_html(self, base_url):
-        """Get custom HTML for the authenticator."""
+        """Get custom HTML for the authenticator.
+
+        .. versionadded: 1.4
+        """
         return self.custom_html
 
 

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -92,16 +92,18 @@ class LoginHandler(BaseHandler):
 
     def _render(self, login_error=None, username=None):
         context = {
-                "next": url_escape(self.get_argument('next', default='')),
-                "username": username,
-                "login_error": login_error,
-                "login_url": self.settings['login_url'],
-                "authenticator_login_url": url_concat(
-                    self.authenticator.login_url(self.hub.base_url),
-                    {'next': self.get_argument('next', '')},
-                ),
+            "next": url_escape(self.get_argument('next', default='')),
+            "username": username,
+            "login_error": login_error,
+            "login_url": self.settings['login_url'],
+            "authenticator_login_url": url_concat(
+                self.authenticator.login_url(self.hub.base_url),
+                {'next': self.get_argument('next', '')},
+            ),
         }
-        custom_html = Template(self.authenticator.get_custom_html(self.hub.base_url)).render(**context)
+        custom_html = Template(
+            self.authenticator.get_custom_html(self.hub.base_url)
+        ).render(**context)
         return self.render_template(
             'login.html',
             **context,

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -101,7 +101,7 @@ class LoginHandler(BaseHandler):
                     {'next': self.get_argument('next', '')},
                 ),
         }
-        custom_html = Template(self.authenticator.custom_html).render(**context)
+        custom_html = Template(self.authenticator.get_custom_html(self.hub.base_url)).render(**context)
         return self.render_template(
             'login.html',
             **context,

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import asyncio
 
+from jinja2 import Template
 from tornado import web
 from tornado.escape import url_escape
 from tornado.httputil import url_concat
@@ -90,17 +91,21 @@ class LoginHandler(BaseHandler):
     """Render the login page."""
 
     def _render(self, login_error=None, username=None):
+        context = {
+                "next": url_escape(self.get_argument('next', default='')),
+                "username": username,
+                "login_error": login_error,
+                "login_url": self.settings['login_url'],
+                "authenticator_login_url": url_concat(
+                    self.authenticator.login_url(self.hub.base_url),
+                    {'next': self.get_argument('next', '')},
+                ),
+        }
+        custom_html = Template(self.authenticator.custom_html).render(**context)
         return self.render_template(
             'login.html',
-            next=url_escape(self.get_argument('next', default='')),
-            username=username,
-            login_error=login_error,
-            custom_html=self.authenticator.custom_html,
-            login_url=self.settings['login_url'],
-            authenticator_login_url=url_concat(
-                self.authenticator.login_url(self.hub.base_url),
-                {'next': self.get_argument('next', '')},
-            ),
+            **context,
+            custom_html=custom_html,
         )
 
     async def get(self):


### PR DESCRIPTION
I modified `_render` method of the login handler so I can make the following custom HTML work. The class is based on the idea of https://github.com/jupyterhub/oauthenticator/issues/136#issuecomment-568950338.

```python
class MultiOAuthenticator(Authenticator):
    ...

    def get_custom_html(self, base_url):
        html = []
        for authenticator in self._authenticators:
            login_service = authenticator["instance"].login_service

            url = url_path_join(base_url, authenticator["url_scope"], "oauth_login")

            html.append(
                f"""
                <div class="service-login">
                  <a role="button" class='btn btn-jupyter btn-lg' href='{url}'>
                    Sign in with {login_service}
                  </a>
                </div>
                """
            )
        return "\n".join(html)
```