### PR TITLE
Reconciliating API with scopes from database

### DIFF
--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -40,7 +40,7 @@ class GroupListAPIHandler(_GroupAPIHandler):
         """List groups"""
         groups = self.db.query(orm.Group)
         if scope_filter is not None:
-            groups.filter(orm.Group.name._in(scope_filter))
+            groups = groups.filter(orm.Group.name.in_(scope_filter))
         data = [self.group_model(g) for g in groups]
         self.write(json.dumps(data))
 

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -35,10 +35,12 @@ class _GroupAPIHandler(APIHandler):
 
 
 class GroupListAPIHandler(_GroupAPIHandler):
-    @needs_scope('read:groups')  # Todo: Apply filter on results
-    def get(self):
+    @needs_scope('read:groups')
+    def get(self, scope_filter=None):
         """List groups"""
         groups = self.db.query(orm.Group)
+        if scope_filter is not None:
+            groups.filter(orm.Group.name._in(scope_filter))
         data = [self.group_model(g) for g in groups]
         self.write(json.dumps(data))
 

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -6,8 +6,7 @@ import json
 from tornado import web
 
 from .. import orm
-from ..utils import admin_only
-from ..utils import needs_scope
+from ..scopes import needs_scope
 from .base import APIHandler
 
 

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -35,7 +35,7 @@ class _GroupAPIHandler(APIHandler):
 
 
 class GroupListAPIHandler(_GroupAPIHandler):
-    @needs_scope('read:groups')  # Todo: Filter allowed here?
+    @needs_scope('read:groups')  # Todo: Apply filter on results
     def get(self):
         """List groups"""
         groups = self.db.query(orm.Group)

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -56,6 +56,7 @@ class RootAPIHandler(APIHandler):
     def get(self):
         """GET /api/ returns info about the Hub and its API.
 
+        It is not an authenticated endpoint
         For now, it just returns the version of JupyterHub itself.
         """
         data = {'version': __version__}
@@ -67,7 +68,8 @@ class InfoAPIHandler(APIHandler):
     def get(self):
         """GET /api/info returns detailed info about the Hub and its API.
 
-        Currently, it returns information on the python version, spawner and authenticator
+        Currently, it returns information on the python version, spawner and authenticator.
+        Since this information might be sensitive, it is an authenticated endpoint
         """
 
         def _class_info(typ):

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -57,8 +57,6 @@ class RootAPIHandler(APIHandler):
     def get(self):
         """GET /api/ returns info about the Hub and its API.
 
-        It is not an authenticated endpoint.
-
         For now, it just returns the version of JupyterHub itself.
         """
         data = {'version': __version__}
@@ -66,12 +64,11 @@ class RootAPIHandler(APIHandler):
 
 
 class InfoAPIHandler(APIHandler):
+    @needs_scope('read:hub')
     def get(self):
         """GET /api/info returns detailed info about the Hub and its API.
 
-        It is not an authenticated endpoint.
-
-        For now, it just returns the version of JupyterHub itself.
+        Currently, it returns information on the python version, spawner and authenticator
         """
 
         def _class_info(typ):

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -8,8 +8,7 @@ from tornado import web
 from tornado.ioloop import IOLoop
 
 from .._version import __version__
-from ..utils import admin_only
-from ..utils import needs_scope
+from ..scopes import needs_scope
 from .base import APIHandler
 
 

--- a/jupyterhub/apihandlers/proxy.py
+++ b/jupyterhub/apihandlers/proxy.py
@@ -5,8 +5,7 @@ import json
 
 from tornado import web
 
-from ..utils import admin_only
-from ..utils import needs_scope
+from ..scopes import needs_scope
 from .base import APIHandler
 
 

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -39,6 +39,7 @@ class ServiceListAPIHandler(APIHandler):
 
 def admin_or_self(method):
     """Decorator for restricting access to either the target service or admin"""
+    """***Deprecated in favor of RBAC, use scope-based decorator***"""
 
     def decorated_method(self, name):
         current = self.current_user

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -9,8 +9,7 @@ import json
 from tornado import web
 
 from .. import orm
-from ..utils import admin_only
-from ..utils import needs_scope
+from ..scopes import needs_scope
 from .base import APIHandler
 
 

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -31,8 +31,10 @@ def service_model(service):
 
 class ServiceListAPIHandler(APIHandler):
     @needs_scope('read:services')
-    def get(self):
+    def get(self, scope_filter=None):
         data = {name: service_model(service) for name, service in self.services.items()}
+        if scope_filter is not None:
+            data = dict(filter(lambda tup: tup[0] in scope_filter))
         self.write(json.dumps(data))
 
 

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -33,7 +33,7 @@ class ServiceListAPIHandler(APIHandler):
     def get(self, scope_filter=None):
         data = {name: service_model(service) for name, service in self.services.items()}
         if scope_filter is not None:
-            data = dict(filter(lambda tup: tup[0] in scope_filter))
+            data = dict(filter(lambda tup: tup[0] in scope_filter, data.items()))
         self.write(json.dumps(data))
 
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -38,8 +38,6 @@ class SelfAPIHandler(APIHandler):
             user = self.get_current_user_oauth_token()
         if user is None:
             raise web.HTTPError(403)
-        # Later: filter based on scopes.
-        # Perhaps user
         self.write(json.dumps(self.user_model(user)))
 
 
@@ -53,7 +51,7 @@ class UserListAPIHandler(APIHandler):
         return any(spawner.ready for spawner in user.spawners.values())
 
     @needs_scope('read:users')
-    def get(self):
+    def get(self, scope_filter=None):
         state_filter = self.get_argument("state", None)
 
         # post_filter
@@ -94,6 +92,8 @@ class UserListAPIHandler(APIHandler):
         else:
             # no filter, return all users
             query = self.db.query(orm.User)
+        if scope_filter is not None:
+            query.filter(orm.User.name.in_(scope_filter))
 
         data = [
             self.user_model(u, include_servers=True, include_state=True)

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -93,7 +93,7 @@ class UserListAPIHandler(APIHandler):
             # no filter, return all users
             query = self.db.query(orm.User)
         if scope_filter is not None:
-            query.filter(orm.User.name.in_(scope_filter))
+            query = query.filter(orm.User.name.in_(scope_filter))
 
         data = [
             self.user_model(u, include_servers=True, include_state=True)

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -14,13 +14,12 @@ from tornado import web
 from tornado.iostream import StreamClosedError
 
 from .. import orm
-from .. import roles
 from ..roles import update_roles
+from ..scopes import needs_scope
 from ..user import User
 from ..utils import isoformat
 from ..utils import iterate_until
 from ..utils import maybe_future
-from ..utils import needs_scope
 from ..utils import url_path_join
 from .base import APIHandler
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1858,7 +1858,7 @@ class JupyterHub(Application):
 
         # make sure all users, services and tokens have at least one role (update with default)
         for bearer in role_bearers:
-            Class = roles.get_orm_class(bearer)
+            Class = orm.get_class(bearer)
             for obj in db.query(Class):
                 if len(obj.roles) < 1:
                     roles.update_roles(db, obj=obj, kind=bearer)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -430,7 +430,7 @@ class BaseHandler(RequestHandler):
                 self._jupyterhub_user = None
                 self.log.exception("Error getting current user")
         if self._jupyterhub_user is not None or self.get_current_user_oauth_token():
-            self.scopes = self.settings.get("mock_scopes", [])
+            self.scopes = roles.get_subscopes(*self._jupyterhub_user.roles)
         return self._jupyterhub_user
 
     @property

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -80,7 +80,7 @@ class BaseHandler(RequestHandler):
         The current user (None if not logged in) may be accessed
         via the `self.current_user` property during the handling of any request.
         """
-        self.scopes = []
+        self.scopes = set()
         try:
             await self.get_current_user()
         except Exception:

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -17,7 +17,7 @@ from .. import orm
 from ..metrics import SERVER_POLL_DURATION_SECONDS
 from ..metrics import ServerPollStatus
 from ..pagination import Pagination
-from ..utils import admin_only
+from ..scopes import needs_scope
 from ..utils import maybe_future
 from ..utils import url_path_join
 from .base import BaseHandler
@@ -455,7 +455,7 @@ class AdminHandler(BaseHandler):
     """Render the admin page."""
 
     @web.authenticated
-    @admin_only
+    @needs_scope('admin:users')
     async def get(self):
         page, per_page, offset = Pagination(config=self.config).get_page_args(self)
 

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -455,7 +455,9 @@ class AdminHandler(BaseHandler):
     """Render the admin page."""
 
     @web.authenticated
+    @needs_scope('users')
     @needs_scope('admin:users')
+    @needs_scope('admin:users:servers')
     async def get(self):
         page, per_page, offset = Pagination(config=self.config).get_page_args(self)
 

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -978,3 +978,18 @@ def new_session_factory(
     # this off gives us a major performance boost
     session_factory = sessionmaker(bind=engine, expire_on_commit=expire_on_commit)
     return session_factory
+
+
+def get_class(resource_name):
+    """Translates resource string names to ORM classes"""
+    class_dict = {
+        'users': User,
+        'services': Service,
+        'tokens': APIToken,
+        'groups': Group,
+    }
+    if resource_name not in class_dict:
+        raise ValueError(
+            "Kind must be one of %s, not %s" % (", ".join(class_dict), resource_name)
+        )
+    return class_dict[resource_name]

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -135,7 +135,7 @@ def add_role(db, role_dict):
     db.commit()
 
 
-def get_orm_class(kind):
+def get_orm_class(kind):  # Todo: merge and move to orm.py
     if kind == 'users':
         Class = orm.User
     elif kind == 'services':

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -7,7 +7,6 @@ from . import orm
 
 
 def get_default_roles():
-
     """Returns a list of default role dictionaries"""
 
     default_roles = [
@@ -43,7 +42,6 @@ def get_default_roles():
 
 
 def get_scopes():
-
     """
     Returns a dictionary of scopes:
     scopes.keys() = scopes of highest level and scopes that have their own subscopes
@@ -74,7 +72,6 @@ def get_scopes():
 
 
 def expand_scope(scopename):
-
     """Returns a set of all subscopes"""
 
     scopes = get_scopes()
@@ -103,7 +100,6 @@ def expand_scope(scopename):
 
 
 def get_subscopes(*args):
-
     """Returns a set of all available subscopes for a specified role or list of roles"""
 
     scope_list = []
@@ -117,7 +113,6 @@ def get_subscopes(*args):
 
 
 def add_role(db, role_dict):
-
     """Adds a new role to database or modifies an existing one"""
 
     if 'name' not in role_dict.keys():
@@ -154,7 +149,6 @@ def get_orm_class(kind):
 
 
 def existing_only(func):
-
     """Decorator for checking if objects and roles exist"""
 
     def check_existence(db, objname, kind, rolename):
@@ -175,7 +169,6 @@ def existing_only(func):
 
 @existing_only
 def add_obj(db, objname, kind, rolename):
-
     """Adds a role for users, services or tokens"""
 
     if rolename not in objname.roles:
@@ -185,7 +178,6 @@ def add_obj(db, objname, kind, rolename):
 
 @existing_only
 def remove_obj(db, objname, kind, rolename):
-
     """Removes a role for users, services or tokens"""
 
     if rolename in objname.roles:
@@ -194,7 +186,6 @@ def remove_obj(db, objname, kind, rolename):
 
 
 def switch_default_role(db, obj, kind, admin):
-
     """Switch between default user and admin roles for users/services"""
 
     user_role = orm.Role.find(db, 'user')
@@ -215,7 +206,6 @@ def switch_default_role(db, obj, kind, admin):
 
 
 def update_roles(db, obj, kind, roles=None):
-
     """Updates object's roles if specified,
     assigns default if no roles specified"""
 

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -135,25 +135,12 @@ def add_role(db, role_dict):
     db.commit()
 
 
-def get_orm_class(kind):  # Todo: merge and move to orm.py
-    if kind == 'users':
-        Class = orm.User
-    elif kind == 'services':
-        Class = orm.Service
-    elif kind == 'tokens':
-        Class = orm.APIToken
-    else:
-        raise ValueError("kind must be users, services or tokens, not %r" % kind)
-
-    return Class
-
-
 def existing_only(func):
     """Decorator for checking if objects and roles exist"""
 
     def check_existence(db, objname, kind, rolename):
 
-        Class = get_orm_class(kind)
+        Class = orm.get_class(kind)
         obj = Class.find(db, objname)
         role = orm.Role.find(db, rolename)
 
@@ -209,7 +196,7 @@ def update_roles(db, obj, kind, roles=None):
     """Updates object's roles if specified,
     assigns default if no roles specified"""
 
-    Class = get_orm_class(kind)
+    Class = orm.get_class(kind)
     user_role = orm.Role.find(db, 'user')
 
     if roles:
@@ -252,11 +239,8 @@ def update_roles(db, obj, kind, roles=None):
 
 
 def mock_roles(app, name, kind):
-
     """Loads and assigns default roles for mocked objects"""
-
-    Class = get_orm_class(kind)
-
+    Class = orm.get_class(kind)
     obj = Class.find(app.db, name=name)
     default_roles = get_default_roles()
     for role in default_roles:

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -1,0 +1,216 @@
+import functools
+import inspect
+from enum import Enum
+
+from tornado import web
+from tornado.log import app_log
+
+from . import orm
+
+
+class Scope(Enum):
+    ALL = True
+
+
+def get_user_scopes(name):
+    """
+    Scopes have a metascope 'all' that should be expanded to everything a user can do.
+    At the moment that is a user-filtered version (optional read) access to
+    users
+    users:name
+    users:groups
+    users:activity
+    users:servers
+    users:tokens
+
+    """
+    scope_list = [
+        'users',
+        'users:name',
+        'users:groups',
+        'users:activity',
+        'users:servers',
+        'users:tokens',
+    ]
+    scope_list.extend(['read:' + scope for scope in scope_list])
+    return {"{}!user={}".format(scope, name) for scope in scope_list}
+
+
+def _needs_scope_expansion(filter_, filter_value, sub_scope):
+    """
+    Check if there is a requirements to expand the `group` scope to individual `user` scopes.
+    Assumptions:
+    filter_ != Scope.ALL
+    """
+    if not (filter_ == 'user' and 'group' in sub_scope):
+        return False
+    if 'user' in sub_scope:
+        return filter_value not in sub_scope['user']
+    else:
+        return True
+
+
+def _check_user_in_expanded_scope(handler, user_name, scope_group_names):
+    user = handler.find_user(user_name)
+    if user is None:
+        raise web.HTTPError(404, 'No such user found')
+    group_names = {group.name for group in user.groups}
+    return bool(set(scope_group_names) & group_names)
+
+
+def _flatten_groups(groups):
+    user_set = set()
+    for group in groups:
+        user_set |= {
+            user.name for user in group.users
+        }  # todo: I think this could be one query, no for loop
+    return user_set
+
+
+def get_orm_class(kind):
+    class_dict = {
+        'users': orm.User,
+        'services': orm.Service,
+        'tokens': orm.APIToken,
+        'groups': orm.Group,
+    }
+    if kind not in class_dict:
+        raise ValueError(
+            "Kind must be one of %s, not %s" % (", ".join(class_dict), kind)
+        )
+    return class_dict[kind]
+
+
+def _get_scope_filter(db, req_scope, sub_scope):
+    # Rough draft
+    scope_translator = {
+        'read:users': 'users',
+        'read:services': 'services',
+        'read:groups': 'groups',
+    }
+    if req_scope not in scope_translator:
+        raise AttributeError("Scope not found; scope filter not constructed")
+    kind = scope_translator[req_scope]
+    Class = get_orm_class(kind)
+    sub_scope_values = next(iter(sub_scope.values()))
+    query = db.query(Class).filter(Class.name.in_(sub_scope_values))
+    scope_filter = [entry.name for entry in query.all()]
+    if 'group' in sub_scope and kind == 'users':
+        groups = db.query(orm.Group).filter(orm.Group.name.in_(sub_scope['group']))
+        scope_filter += _flatten_groups(groups)
+    return set(scope_filter)
+
+
+def _check_scope(api_handler, req_scope, scopes, **kwargs):
+    # Parse user name and server name together
+    if 'user' in kwargs and 'server' in kwargs:
+        kwargs['server'] = "{}/{}".format(kwargs['user'], kwargs['server'])
+    if req_scope not in scopes:
+        return False
+    if scopes[req_scope] == Scope.ALL:
+        return True
+    # Apply filters
+    sub_scope = scopes[req_scope]
+    if 'scope_filter' in kwargs:
+        scope_filter = _get_scope_filter(api_handler.db, req_scope, sub_scope)
+        return scope_filter
+    else:
+        # Interface change: Now can have multiple filters
+        for (filter_, filter_value) in kwargs.items():
+            if filter_ in sub_scope and filter_value in sub_scope[filter_]:
+                return True
+            if _needs_scope_expansion(filter_, filter_value, sub_scope):
+                group_names = sub_scope['group']
+                if _check_user_in_expanded_scope(
+                    api_handler, filter_value, group_names
+                ):
+                    return True
+        return False
+
+
+def _parse_scopes(scope_list):
+    """
+    Parses scopes and filters in something akin to JSON style
+
+    For instance, scope list ["users", "groups!group=foo", "users:servers!server=bar", "users:servers!server=baz"]
+    would lead to scope model
+    {
+       "users":scope.ALL,
+       "users:admin":{
+          "user":[
+             "alice"
+          ]
+       },
+       "users:servers":{
+          "server":[
+             "bar",
+             "baz"
+          ]
+       }
+    }
+    """
+    parsed_scopes = {}
+    for scope in scope_list:
+        base_scope, _, filter_ = scope.partition('!')
+        if not filter_:
+            parsed_scopes[base_scope] = Scope.ALL
+        elif base_scope not in parsed_scopes:
+            parsed_scopes[base_scope] = {}
+        if parsed_scopes[base_scope] != Scope.ALL:
+            key, _, val = filter_.partition('=')
+            if key not in parsed_scopes[base_scope]:
+                parsed_scopes[base_scope][key] = []
+            parsed_scopes[base_scope][key].append(val)
+    return parsed_scopes
+
+
+def needs_scope(scope):
+    """Decorator to restrict access to users or services with the required scope"""
+
+    def scope_decorator(func):
+        @functools.wraps(func)
+        def _auth_func(self, *args, **kwargs):
+            sig = inspect.signature(func)
+            bound_sig = sig.bind(self, *args, **kwargs)
+            bound_sig.apply_defaults()
+            s_kwargs = {}
+            for resource in {'user', 'server', 'group', 'service'}:
+                resource_name = resource + '_name'
+                if resource_name in bound_sig.arguments:
+                    resource_value = bound_sig.arguments[resource_name]
+                    s_kwargs[resource] = resource_value
+            if 'scope_filter' in bound_sig.arguments:
+                s_kwargs['scope_filter'] = None
+            if 'all' in self.scopes and self.current_user:
+                # todo: What if no user is found? See test_api/test_referer_check
+                self.scopes |= get_user_scopes(self.current_user.name)
+            parsed_scopes = _parse_scopes(self.scopes)
+            scope_filter = _check_scope(self, scope, parsed_scopes, **s_kwargs)
+            if (
+                scope_filter
+            ):  # Todo: This checks if True or set of resource names. Not very nice yet
+                if isinstance(scope_filter, set):
+                    kwargs['scope_filter'] = scope_filter
+                return func(self, *args, **kwargs)
+            else:
+                # catching attr error occurring for older_requirements test
+                # could be done more ellegantly?
+                try:
+                    request_path = self.request.path
+                except AttributeError:
+                    request_path = 'the requested API'
+                app_log.warning(
+                    "Not authorizing access to {}. Requires scope {}, not derived from scopes {}".format(
+                        request_path, scope, ", ".join(self.scopes)
+                    )
+                )
+                raise web.HTTPError(
+                    403,
+                    "Action is not authorized with current scopes; requires {}".format(
+                        scope
+                    ),
+                )
+
+        return _auth_func
+
+    return scope_decorator

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -68,9 +68,9 @@ def _get_scope_filter(db, req_scope, sub_scope):
     if req_scope not in scope_translator:
         raise AttributeError("Scope not found; scope filter not constructed")
     kind = scope_translator[req_scope]
-    Class = orm.get_class(kind)
+    Resource = orm.get_class(kind)
     sub_scope_values = next(iter(sub_scope.values()))
-    query = db.query(Class).filter(Class.name.in_(sub_scope_values))
+    query = db.query(Resource).filter(Resource.name.in_(sub_scope_values))
     scope_filter = {entry.name for entry in query.all()}
     if 'group' in sub_scope and kind == 'users':
         groups = orm.Group.name.in_(sub_scope['group'])
@@ -164,7 +164,6 @@ def needs_scope(scope):
             if 'scope_filter' in bound_sig.arguments:
                 s_kwargs['scope_filter'] = None
             if 'all' in self.scopes and self.current_user:
-                # todo: What if no user is found? See test_api/test_referer_check
                 self.scopes |= get_user_scopes(self.current_user.name)
             parsed_scopes = _parse_scopes(self.scopes)
             scope_filter = _check_scope(self, scope, parsed_scopes, **s_kwargs)

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -78,13 +78,6 @@ def mock_open_session(username, service, encoding):
     pass
 
 
-def mock_role(app, role='admin', name=None):
-    scopes = get_scopes(role)
-    if name is not None:
-        scopes = [scope.format(username=name) for scope in scopes]
-    return mock.patch.dict(app.tornado_settings, {'mock_scopes': scopes})
-
-
 class MockSpawner(SimpleLocalProcessSpawner):
     """Base mock spawner
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1618,14 +1618,16 @@ async def test_root_api(app):
     if app.internal_ssl:
         kwargs['cert'] = (app.internal_ssl_cert, app.internal_ssl_key)
         kwargs["verify"] = app.internal_ssl_ca
-    r = await async_requests.get(url, **kwargs)
+    with mock_role(app):
+        r = await api_request(app, bypass_proxy=True)
     r.raise_for_status()
     expected = {'version': jupyterhub.__version__}
     assert r.json() == expected
 
 
 async def test_info(app):
-    r = await api_request(app, 'info')
+    with mock_role(app):
+        r = await api_request(app, 'info')
     r.raise_for_status()
     data = r.json()
     assert data['version'] == jupyterhub.__version__

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -25,6 +25,7 @@ from .utils import async_requests
 from .utils import auth_header
 from .utils import find_user
 
+
 # --------------------
 # Authentication tests
 # --------------------
@@ -166,7 +167,7 @@ TIMESTAMP = normalize_timestamp(datetime.now().isoformat() + 'Z')
 
 @mark.user
 @mark.role
-async def test_get_users(app):  # todo: Sync with scope tests
+async def test_get_users(app):
     db = app.db
     r = await api_request(app, 'users', headers=auth_header(db, 'admin'))
     assert r.status_code == 200
@@ -185,7 +186,7 @@ async def test_get_users(app):  # todo: Sync with scope tests
     ]
     r = await api_request(app, 'users', headers=auth_header(db, 'user'))
     assert r.status_code == 200
-    r_user_model = json.loads(r.text)[0]
+    r_user_model = r.json()[0]
     assert r_user_model['name'] == user_model['name']
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1628,17 +1628,15 @@ async def test_get_service(app, mockservice_url):
         'info': {},
         'display': True,
     }
-    with mock_role(app, 'service'):
-        r = await api_request(
-            app,
-            'services/%s' % mockservice.name,
-            headers={'Authorization': 'token %s' % mockservice.api_token},
-        )
-        r.raise_for_status()
-    with mock_role(app, 'user'):
-        r = await api_request(
-            app, 'services/%s' % mockservice.name, headers=auth_header(db, 'user')
-        )
+    r = await api_request(
+        app,
+        'services/%s' % mockservice.name,
+        headers={'Authorization': 'token %s' % mockservice.api_token},
+    )
+    r.raise_for_status()
+    r = await api_request(
+        app, 'services/%s' % mockservice.name, headers=auth_header(db, 'user')
+    )
     assert r.status_code == 403
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1395,7 +1395,7 @@ async def test_token_authenticator_dict_noauth(app):
     [
         ('admin', 'other', 200),
         ('admin', 'missing', 404),
-        ('user', 'other', 403),
+        ('user', 'other', 404),
         ('user', 'user', 200),
     ],
 )
@@ -1687,7 +1687,7 @@ async def test_update_activity_403(app, user, admin_user):
         data="{}",
         method="post",
     )
-    assert r.status_code == 403
+    assert r.status_code == 404
 
 
 async def test_update_activity_admin(app, user, admin_user):

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -217,7 +217,7 @@ async def test_expand_groups(app, user_name, in_group, status_code):
 
 
 async def test_user_filter(app):
-    user_name = 'rollerblade'
+    user_name = 'rita'
     test_role = {
         'name': 'test',
         'description': '',
@@ -247,8 +247,7 @@ async def test_user_filter(app):
     app.db.commit()
     r = await api_request(app, 'users', headers=auth_header(app.db, user_name))
     assert r.status_code == 200
-    data = json.loads(r.content)
-    result_names = {user['name'] for user in data}
+    result_names = {user['name'] for user in r.json()}
     assert result_names == name_in_scope
 
 
@@ -278,8 +277,7 @@ async def test_user_filter_with_group(app):  # todo: Move role setup to setup me
     app.db.commit()
     r = await api_request(app, 'users', headers=auth_header(app.db, user_name))
     assert r.status_code == 200
-    data = json.loads(r.content)
-    result_names = {user['name'] for user in data}
+    result_names = {user['name'] for user in r.json()}
     assert result_names == name_set
 
 
@@ -308,6 +306,5 @@ async def test_group_scope_filter(app):
     app.db.commit()
     r = await api_request(app, 'groups', headers=auth_header(app.db, user_name))
     assert r.status_code == 200
-    data = json.loads(r.content)
-    result_names = {user['name'] for user in data}
+    result_names = {user['name'] for user in r.json()}
     assert result_names == {'sitwell', 'bluths'}

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -97,7 +97,7 @@ class MockAPIHandler:
     def group_thing(self, group_name):
         return True
 
-    @needs_scope('services')
+    @needs_scope('read:services')
     def service_thing(self, service_name):
         return True
 
@@ -133,7 +133,7 @@ class MockAPIHandler:
             ('maybe', 'bluth2'),
             False,
         ),
-        (['services'], 'service_thing', ('service1',), True),
+        (['read:services'], 'service_thing', ('service1',), True),
         (
             ['users!user=george', 'read:groups!group=bluths'],
             'group_thing',

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -88,6 +88,7 @@ async def test_external_service(app):
             }
         ]
         await maybe_future(app.init_services())
+        await maybe_future(app.init_roles())
         await app.init_api_tokens()
         await app.proxy.add_all_services(app._service_map)
 

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -223,6 +223,7 @@ def get_scopes(role='admin'):
             'services',
             'proxy',
             'shutdown',
+            'read:hub',
         ],
         'user': [
             'all',

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -304,8 +304,6 @@ def needs_scope_expansion(filter_, filter_value, sub_scope):
     Check if there is a requirements to expand the `group` scope to individual `user` scopes.
     Assumptions:
     filter_ != Scope.ALL
-
-    This can be made arbitrarily intelligent but that would make it more complex
     """
     if not (filter_ == 'user' and 'group' in sub_scope):
         return False

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -4,7 +4,6 @@
 import asyncio
 import concurrent.futures
 import errno
-import functools
 import hashlib
 import inspect
 import os
@@ -18,7 +17,6 @@ import warnings
 from binascii import b2a_hex
 from datetime import datetime
 from datetime import timezone
-from enum import Enum
 from hmac import compare_digest
 from operator import itemgetter
 
@@ -29,8 +27,6 @@ from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPError
 from tornado.log import app_log
 from tornado.platform.asyncio import to_asyncio_future
-
-from . import orm  # todo: only necessary for scopes, move later
 
 
 def random_port():
@@ -283,8 +279,13 @@ def authenticated_403(self):
 
 @auth_decorator
 def admin_only(self):
-    """Decorator for restricting access to admin users"""
+    """Decorator for restricting access to admin users
+    Deprecated in favor of scopes.need_scope()
+    """
     user = self.current_user
+    app_log.warning(
+        "Admin decorator is deprecated and will be removed soon. Use scope-based decorator instead"
+    )
     if user is None or not user.admin:
         raise web.HTTPError(403)
 
@@ -295,214 +296,6 @@ def metrics_authentication(self):
     user = self.current_user
     if user is None and self.authenticate_prometheus:
         raise web.HTTPError(403)
-
-
-# Todo: Move all scope-related methods to scope module
-class Scope(Enum):
-    ALL = True
-
-
-def get_user_scopes(name):
-    """
-    Scopes have a metascope 'all' that should be expanded to everything a user can do.
-    At the moment that is a user-filtered version (optional read) access to
-    users
-    users:name
-    users:groups
-    users:activity
-    users:servers
-    users:tokens
-
-    """
-    scope_list = [
-        'users',
-        'users:name',
-        'users:groups',
-        'users:activity',
-        'users:servers',
-        'users:tokens',
-    ]
-    scope_list.extend(['read:' + scope for scope in scope_list])
-    return {"{}!user={}".format(scope, name) for scope in scope_list}
-
-
-def needs_scope_expansion(filter_, filter_value, sub_scope):
-    """
-    Check if there is a requirements to expand the `group` scope to individual `user` scopes.
-    Assumptions:
-    filter_ != Scope.ALL
-    """
-    if not (filter_ == 'user' and 'group' in sub_scope):
-        return False
-    if 'user' in sub_scope:
-        return filter_value not in sub_scope['user']
-    else:
-        return True
-
-
-def check_user_in_expanded_scope(handler, user_name, scope_group_names):
-    user = handler.find_user(user_name)
-    if user is None:
-        raise web.HTTPError(404, 'No such user found')
-    group_names = {group.name for group in user.groups}
-    return bool(set(scope_group_names) & group_names)
-
-
-def _flatten_groups(groups):
-    user_set = set()
-    for group in groups:
-        user_set |= {
-            user.name for user in group.users
-        }  # todo: I think this could be one query, no for loop
-    return user_set
-
-
-def get_orm_class(kind):
-    class_dict = {
-        'users': orm.User,
-        'services': orm.Service,
-        'tokens': orm.APIToken,
-        'groups': orm.Group,
-    }
-    if kind not in class_dict:
-        raise ValueError(
-            "Kind must be one of %s, not %s" % (", ".join(class_dict), kind)
-        )
-    return class_dict[kind]
-
-
-def _get_scope_filter(db, req_scope, sub_scope):
-    # Rough draft
-    scope_translator = {
-        'read:users': 'users',
-        'read:services': 'services',
-        'read:groups': 'groups',
-    }
-    if req_scope not in scope_translator:
-        raise AttributeError("Scope not found; scope filter not constructed")
-    kind = scope_translator[req_scope]
-    Class = get_orm_class(kind)
-    sub_scope_values = next(iter(sub_scope.values()))
-    query = db.query(Class).filter(Class.name.in_(sub_scope_values))
-    scope_filter = [entry.name for entry in query.all()]
-    if 'group' in sub_scope and kind == 'users':
-        groups = db.query(orm.Group).filter(orm.Group.name.in_(sub_scope['group']))
-        scope_filter += _flatten_groups(groups)
-    return set(scope_filter)
-
-
-def check_scope(api_handler, req_scope, scopes, **kwargs):
-    # Parse user name and server name together
-    if 'user' in kwargs and 'server' in kwargs:
-        kwargs['server'] = "{}/{}".format(kwargs['user'], kwargs['server'])
-    if req_scope not in scopes:
-        return False
-    if scopes[req_scope] == Scope.ALL:
-        return True
-    # Apply filters
-    sub_scope = scopes[req_scope]
-    if 'scope_filter' in kwargs:
-        scope_filter = _get_scope_filter(api_handler.db, req_scope, sub_scope)
-        return scope_filter
-    else:
-        # Interface change: Now can have multiple filters
-        for (filter_, filter_value) in kwargs.items():
-            if filter_ in sub_scope and filter_value in sub_scope[filter_]:
-                return True
-            if needs_scope_expansion(filter_, filter_value, sub_scope):
-                group_names = sub_scope['group']
-                if check_user_in_expanded_scope(api_handler, filter_value, group_names):
-                    return True
-        return False
-
-
-# Todo: make some methods private
-
-
-def parse_scopes(scope_list):
-    """
-    Parses scopes and filters in something akin to JSON style
-
-    For instance, scope list ["users", "groups!group=foo", "users:servers!server=bar", "users:servers!server=baz"]
-    would lead to scope model
-    {
-       "users":scope.ALL,
-       "users:admin":{
-          "user":[
-             "alice"
-          ]
-       },
-       "users:servers":{
-          "server":[
-             "bar",
-             "baz"
-          ]
-       }
-    }
-    """
-    parsed_scopes = {}
-    for scope in scope_list:
-        base_scope, _, filter_ = scope.partition('!')
-        if not filter_:
-            parsed_scopes[base_scope] = Scope.ALL
-        elif base_scope not in parsed_scopes:
-            parsed_scopes[base_scope] = {}
-        if parsed_scopes[base_scope] != Scope.ALL:
-            key, _, val = filter_.partition('=')
-            if key not in parsed_scopes[base_scope]:
-                parsed_scopes[base_scope][key] = []
-            parsed_scopes[base_scope][key].append(val)
-    return parsed_scopes
-
-
-def needs_scope(scope):
-    """Decorator to restrict access to users or services with the required scope"""
-
-    def scope_decorator(func):
-        @functools.wraps(func)
-        def _auth_func(self, *args, **kwargs):
-            sig = inspect.signature(func)
-            bound_sig = sig.bind(self, *args, **kwargs)
-            bound_sig.apply_defaults()
-            s_kwargs = {}
-            for resource in {'user', 'server', 'group', 'service'}:
-                resource_name = resource + '_name'
-                if resource_name in bound_sig.arguments:
-                    resource_value = bound_sig.arguments[resource_name]
-                    s_kwargs[resource] = resource_value
-            if 'scope_filter' in bound_sig.arguments:
-                s_kwargs['scope_filter'] = None
-            if 'all' in self.scopes and self.current_user:
-                # todo: What if no user is found? See test_api/test_referer_check
-                self.scopes |= get_user_scopes(self.current_user.name)
-            parsed_scopes = parse_scopes(self.scopes)
-            scope_filter = check_scope(self, scope, parsed_scopes, **s_kwargs)
-            if scope_filter:
-                if isinstance(scope_filter, set):
-                    kwargs['scope_filter'] = scope_filter
-                return func(self, *args, **kwargs)
-            else:
-                # catching attr error occurring for older_requirements test
-                # could be done more ellegantly?
-                try:
-                    request_path = self.request.path
-                except AttributeError:
-                    request_path = 'the requested API'
-                app_log.warning(
-                    "Not authorizing access to {}. Requires scope {}, not derived from scopes {}".format(
-                        request_path, scope, ", ".join(self.scopes)
-                    )
-                )
-                raise web.HTTPError(
-                    403,
-                    "Action is not authorized with current scopes; requires {}".format(
-                        scope
-                    ),
-                )
-
-        return _auth_func
-
-    return scope_decorator
 
 
 # Token utilities


### PR DESCRIPTION
Progress on #2245, ready for review

# List of major changes
 - APIHandlers now allow/refuse request based on scopes from database roles.
 - Refactored `scope` module
    - Made some methods private
    - Moved all scope-related methods from `utils.py` to `scopes.py`
 - Implemented scope-based filter for `*ListApiHandler`
    - Modified `test_api` unit tests to conform with new behaviour
    - Added new unit tests
 - Scope decorators can now be stacked
 - Error messages for users/groups/services requested that do not exist or that do exist but are not accessible for requester now return the same error code (404) and error message (`No access to resources or resources not found`).
## Scope-based filter

In API classes `UserListAPIHandler`, `GroupAPIListHandler` and `ServiceListAPIHandler` a `scope_filter` parameter is added to the `get` methods. Empty by default, this parameter is used by the scope authentication decorator.
When the requester only has access to a subset of the requested resources, the `scope_filter` provides a list of allowed names of resources. The inner body of the methods either adapt their query based on this set or filter the query results.

In case of `UserListAPIHandler`, the decorator also expands groups of users to include in the filter.

# Issues/questions

 - Resource filter implementation is still a bit shoddy
 - Is `self.current_user` always available in an API call? (resolved)
 - Admin scope on `pages.py` is currently set to `admin:users`, does that suffice? (resolved)
 - Setup and teardown of test roles in `test_scopes.py` is a bit inconvenient at the moment. suggestions?
 - External services don't read roles yet, so a test in `test_services` fails. (resolved)

@IvanaH8, do you have any suggestions for the last two points?