### PR TITLE
Allow to set spawner-specific hub connect URL

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -699,8 +699,8 @@ class Spawner(LoggingConfigurable):
         If the Hub URL set in your JupyterHub config is not reachable
         from spawned notebooks, you can set differnt URL by this config.
 
-        Is None if you want to use the same API URL.
-        """
+        Is None if you don't need to change the URL.
+        """,
     ).tag(config=True)
 
     def load_state(self, state):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -783,7 +783,9 @@ class Spawner(LoggingConfigurable):
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_SERVER_NAME'] = self.name
         if self.hub_connect_url is not None:
-            hub_api_url = url_path_join(self.hub_connect_url, urlparse(self.hub.api_url).path)
+            hub_api_url = url_path_join(
+                self.hub_connect_url, urlparse(self.hub.api_url).path
+            )
         else:
             hub_api_url = self.hub.api_url
         env['JUPYTERHUB_API_URL'] = hub_api_url

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -13,6 +13,7 @@ import sys
 import warnings
 from subprocess import Popen
 from tempfile import mkdtemp
+from urllib.parse import urlparse
 
 if os.name == 'nt':
     import psutil
@@ -782,7 +783,8 @@ class Spawner(LoggingConfigurable):
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_SERVER_NAME'] = self.name
         if self.hub_connect_url is not None:
-            hub_api_url = url_path_join(self.hub_connect_url, 'hub', 'api')
+            hub_api_url = urlparse(self.hub.api_url)
+            hub_api_url = url_path_join(self.hub_connect_url, hub_api_url.path)
         else:
             hub_api_url = self.hub.api_url
         env['JUPYTERHUB_API_URL'] = hub_api_url

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -783,8 +783,7 @@ class Spawner(LoggingConfigurable):
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_SERVER_NAME'] = self.name
         if self.hub_connect_url is not None:
-            hub_api_url = urlparse(self.hub.api_url)
-            hub_api_url = url_path_join(self.hub_connect_url, hub_api_url.path)
+            hub_api_url = url_path_join(self.hub_connect_url, urlparse(self.hub.api_url).path)
         else:
             hub_api_url = self.hub.api_url
         env['JUPYTERHUB_API_URL'] = hub_api_url

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -691,19 +691,17 @@ class Spawner(LoggingConfigurable):
     ).tag(config=True)
 
     hub_connect_url = Unicode(
+        None,
+        allow_none=True,
         help="""
         The URL the single-user server should connect to the Hub.
 
         If the Hub URL set in your JupyterHub config is not reachable
         from spawned notebooks, you can set differnt URL by this config.
 
-        - The default value is the hub_connect_url of JupyterHub config.
+        Is None if you want to use the same API URL.
         """
     ).tag(config=True)
-
-    @default("hub_connect_url")
-    def _hub_connect_url(self):
-        return self.hub.connect_url
 
     def load_state(self, state):
         """Restore state of spawner from database.
@@ -783,7 +781,10 @@ class Spawner(LoggingConfigurable):
         # Info previously passed on args
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_SERVER_NAME'] = self.name
-        hub_api_url = url_path_join(self.hub_connect_url, 'hub', 'api')
+        if self.hub_connect_url is not None:
+            hub_api_url = url_path_join(self.hub_connect_url, 'hub', 'api')
+        else:
+            hub_api_url = self.hub.api_url
         env['JUPYTERHUB_API_URL'] = hub_api_url
         env['JUPYTERHUB_ACTIVITY_URL'] = url_path_join(
             hub_api_url,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -690,6 +690,18 @@ class Spawner(LoggingConfigurable):
         """
     ).tag(config=True)
 
+    hub_connect_url = Unicode(
+        help="""
+        The URL the single-user server should connect to the Hub.
+
+        - The default value is the hub_connect_url of JupyterHub config.
+        """
+    ).tag(config=True)
+
+    @default("hub_connect_url")
+    def _hub_connect_url(self):
+        return self.hub.api_url
+
     def load_state(self, state):
         """Restore state of spawner from database.
 
@@ -768,9 +780,9 @@ class Spawner(LoggingConfigurable):
         # Info previously passed on args
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_SERVER_NAME'] = self.name
-        env['JUPYTERHUB_API_URL'] = self.hub.api_url
+        env['JUPYTERHUB_API_URL'] = self.hub_connect_url
         env['JUPYTERHUB_ACTIVITY_URL'] = url_path_join(
-            self.hub.api_url,
+            self.hub_connect_url,
             'users',
             # tolerate mocks defining only user.name
             getattr(self.user, 'escaped_name', self.user.name),

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -694,6 +694,9 @@ class Spawner(LoggingConfigurable):
         help="""
         The URL the single-user server should connect to the Hub.
 
+        If the Hub URL set in your JupyterHub config is not reachable
+        from spawned notebooks, you can set differnt URL by this config.
+
         - The default value is the hub_connect_url of JupyterHub config.
         """
     ).tag(config=True)

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -703,7 +703,7 @@ class Spawner(LoggingConfigurable):
 
     @default("hub_connect_url")
     def _hub_connect_url(self):
-        return self.hub.api_url
+        return self.hub.connect_url
 
     def load_state(self, state):
         """Restore state of spawner from database.
@@ -783,9 +783,10 @@ class Spawner(LoggingConfigurable):
         # Info previously passed on args
         env['JUPYTERHUB_USER'] = self.user.name
         env['JUPYTERHUB_SERVER_NAME'] = self.name
-        env['JUPYTERHUB_API_URL'] = self.hub_connect_url
+        hub_api_url = url_path_join(self.hub_connect_url, 'hub', 'api')
+        env['JUPYTERHUB_API_URL'] = hub_api_url
         env['JUPYTERHUB_ACTIVITY_URL'] = url_path_join(
-            self.hub_connect_url,
+            hub_api_url,
             'users',
             # tolerate mocks defining only user.name
             getattr(self.user, 'escaped_name', self.user.name),

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -415,3 +415,9 @@ async def test_spawner_env(db):
     for key, value in env_overrides.items():
         assert key in env
         assert env[key] == value
+
+
+async def test_hub_connect_url(db):
+    spawner = new_spawner(db, hub_connect_url="example.com")
+    env = spawner.get_env()
+    env["JUPYTERHUB_API_URL"] = "https://example.com/hub/api"

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -418,7 +418,7 @@ async def test_spawner_env(db):
 
 
 async def test_hub_connect_url(db):
-    spawner = new_spawner(db, hub_connect_url="https://example.com/hub/api")
+    spawner = new_spawner(db, hub_connect_url="https://example.com/")
     name = spawner.user.name
     env = spawner.get_env()
     assert env["JUPYTERHUB_API_URL"] == "https://example.com/hub/api"

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -418,6 +418,8 @@ async def test_spawner_env(db):
 
 
 async def test_hub_connect_url(db):
-    spawner = new_spawner(db, hub_connect_url="example.com")
+    spawner = new_spawner(db, hub_connect_url="https://example.com/hub/api")
+    name = spawner.user.name
     env = spawner.get_env()
-    env["JUPYTERHUB_API_URL"] = "https://example.com/hub/api"
+    assert env["JUPYTERHUB_API_URL"] == "https://example.com/hub/api"
+    assert env["JUPYTERHUB_ACTIVITY_URL"] == "https://example.com/hub/api/users/%s/activity" % name

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -422,4 +422,7 @@ async def test_hub_connect_url(db):
     name = spawner.user.name
     env = spawner.get_env()
     assert env["JUPYTERHUB_API_URL"] == "https://example.com/hub/api"
-    assert env["JUPYTERHUB_ACTIVITY_URL"] == "https://example.com/hub/api/users/%s/activity" % name
+    assert (
+        env["JUPYTERHUB_ACTIVITY_URL"]
+        == "https://example.com/hub/api/users/%s/activity" % name
+    )

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -421,8 +421,8 @@ async def test_hub_connect_url(db):
     spawner = new_spawner(db, hub_connect_url="https://example.com/")
     name = spawner.user.name
     env = spawner.get_env()
-    assert env["JUPYTERHUB_API_URL"] == "https://example.com/hub/api"
+    assert env["JUPYTERHUB_API_URL"] == "https://example.com/api"
     assert (
         env["JUPYTERHUB_ACTIVITY_URL"]
-        == "https://example.com/hub/api/users/%s/activity" % name
+        == "https://example.com/api/users/%s/activity" % name
     )


### PR DESCRIPTION
I'd like to use JupyterHub w/ `DockerSpawner` but don't want to set up any domain which points to the host IP. Docker for Mac supports `host.docker.internal` which indicates the host IP in Docker containers, so I can use it as hub connect URL. However, the hub config of hub_connect_url is also for chp. This fix allow seperately set the URL.

Currently, I created a custom spawner inheriting DockerSpawner and replace the hostname as below.

```python
import re
from urllib.parse import urlsplit, urlunsplit

import dockerspawner

_docker_hostname = "host.docker.internal"


def _replace_hostname(url: str, hostname: str) -> str:
    p = list(urlsplit(url))
    p[1] = re.sub("^[^:]*", hostname, p[1])
    return urlunsplit(p)


class CustomDockerSpawner(dockerspawner.DockerSpawner):
    def get_env(self):
        env = super(CustomDockerSpawner, self).get_env()
        for target in ("JUPYTERHUB_API_URL", "JUPYTERHUB_ACTIVITY_URL"):
            env[target] = _replace_hostname(env[target], _docker_hostname)
        return env
```

After this fix, it will be,

```python
c.DockerSpawner.hub_connect_url = "host.docker.internal"
```