### PR TITLE
Fix the help related to the proxy check

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -374,7 +374,8 @@ class JupyterHub(Application):
         300, help="Interval (in seconds) at which to update last-activity timestamps."
     ).tag(config=True)
     proxy_check_interval = Integer(
-        5, help="DEPRECATED since version 0.8: Use ConfigurableHTTPProxy.check_running_interval"
+        5,
+        help="DEPRECATED since version 0.8: Use ConfigurableHTTPProxy.check_running_interval",
     ).tag(config=True)
     service_check_interval = Integer(
         60,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -374,7 +374,7 @@ class JupyterHub(Application):
         300, help="Interval (in seconds) at which to update last-activity timestamps."
     ).tag(config=True)
     proxy_check_interval = Integer(
-        30, help="Interval (in seconds) at which to check if the proxy is running."
+        5, help="DEPRECATED since version 0.8: Use ConfigurableHTTPProxy.check_running_interval"
     ).tag(config=True)
     service_check_interval = Integer(
         60,
@@ -688,6 +688,7 @@ class JupyterHub(Application):
     ).tag(config=True)
 
     _proxy_config_map = {
+        'proxy_check_interval': 'check_running_interval',
         'proxy_cmd': 'command',
         'debug_proxy': 'debug',
         'proxy_auth_token': 'auth_token',

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -453,7 +453,7 @@ class ConfigurableHTTPProxy(Proxy):
     check_running_interval = Integer(
         5,
         help="Interval (in seconds) at which to check if the proxy is running.",
-        config=True
+        config=True,
     )
 
     @default('auth_token')

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -450,7 +450,11 @@ class ConfigurableHTTPProxy(Proxy):
         Loaded from the CONFIGPROXY_AUTH_TOKEN env variable by default.
         """
     ).tag(config=True)
-    check_running_interval = Integer(5, config=True)
+    check_running_interval = Integer(
+        5,
+        help="Interval (in seconds) at which to check if the proxy is running.",
+        config=True
+    )
 
     @default('auth_token')
     def _auth_token_default(self):


### PR DESCRIPTION
JupyterHub.proxy_check_interval has been replaced by ConfigurableHTTPProxy.check_running_interval. Fix the help related to the proxy check.