### PR TITLE
Fix pagination with named servers

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -502,8 +502,15 @@ class AdminHandler(BaseHandler):
         ordered = [getattr(c, o)() for c, o in zip(cols, orders)]
 
         query = self.db.query(orm.User).outerjoin(orm.Spawner).distinct(orm.User.id)
+        subquery = query.subquery("users")
+        users = (
+            self.db.query(orm.User)
+            .select_entity_from(subquery)
+            .order_by(*ordered)
+            .limit(per_page)
+            .offset(offset)
+        )
 
-        users = query.order_by(*ordered).limit(per_page).offset(offset)
         users = [self._user_from_orm(u) for u in users]
 
         running = []

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -506,6 +506,7 @@ class AdminHandler(BaseHandler):
         users = (
             self.db.query(orm.User)
             .select_entity_from(subquery)
+            .outerjoin(orm.Spawner)
             .order_by(*ordered)
             .limit(per_page)
             .offset(offset)


### PR DESCRIPTION
Just need to consider distinct users for pagination to work right with named servers.  I am not a sqlalchemy expert (sqlalchemist?) so I am not sure if the "optimization" I did actually does what I think it should or if it actually makes 3 queries happen under the hood.

* Add distinct user id clause
* Separate join and distinct into one query
* Apply limit and offset to the result
* Apply count to the result for pagination total