### PR TITLE
specify minimum alembic 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic
+alembic>=1.4
 async_generator>=1.9
 certipy>=0.1.2
 entrypoints


### PR DESCRIPTION
this gets us *older* alembic in the old-dependencies test

since alembic 1.5 requires sqlalchemy 1.3 and pip doesn't have a real dependency resolver