### PR TITLE
Clear tornado xsrf cookie on logout

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -493,6 +493,11 @@ class BaseHandler(RequestHandler):
             path=url_path_join(self.base_url, 'services'),
             **kwargs,
         )
+        # clear tornado cookie
+        self.clear_cookie(
+            '_xsrf',
+            **self.settings.get('xsrf_cookie_kwargs', {}),
+        )
         # Reset _jupyterhub_user
         self._jupyterhub_user = None
 


### PR DESCRIPTION
We should remove `_xsrf` cookie [set by tornado](https://github.com/tornadoweb/tornado/blob/cef029abd244cd796ea36487050f722a57bfab60/tornado/web.py#L1399-L1420) just in case for security.