### PR TITLE
Clear cookie ID on logout

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -483,7 +483,11 @@ class BaseHandler(RequestHandler):
                     count += 1
                 if count:
                     self.log.debug("Deleted %s access tokens for %s", count, user.name)
-                    self.db.commit()
+
+                # clear cookie from DB
+                user.set_new_cookie_id()
+                self.db.add(user)
+                self.db.commit()
 
         # clear hub cookie
         self.clear_cookie(self.hub.cookie_name, path=self.hub.base_url, **kwargs)

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -221,6 +221,9 @@ class User(Base):
         """
         return db.query(cls).filter(cls.name == name).first()
 
+    def set_new_cookie_id(self):
+        self.cookie_id = new_token()
+
 
 class Spawner(Base):
     """"State about a Spawner"""


### PR DESCRIPTION
Your cookie ID doesn't get cleared when you logout from JupyterHub. Therefore, when your cookie ID is stolen in some way, you cannot immediately expire the cookie ID even if you logout from JupyterHub.