### PR TITLE
Allow cookie_secret to be set to a hexadecimal string

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -848,14 +848,29 @@ class JupyterHub(Application):
         to reduce the cost of checking authentication tokens.
         """,
     ).tag(config=True)
-    cookie_secret = Bytes(
+    cookie_secret = Union(
+        [Bytes(), Unicode()],
         help="""The cookie secret to use to encrypt cookies.
 
         Loaded from the JPY_COOKIE_SECRET env variable by default.
 
         Should be exactly 256 bits (32 bytes).
-        """
+        """,
     ).tag(config=True, env='JPY_COOKIE_SECRET')
+
+    @validate('cookie_secret')
+    def _validate_secret_key(self, proposal):
+        """Coerces strings with even number of hexadecimal characters to bytes."""
+        r = proposal['value']
+        if type(r) == str:
+            try:
+                return bytes.fromhex(r)
+            except ValueError:
+                raise ValueError(
+                    "cookie_secret set as a string must contain an even amount of hexadecimal characters."
+                )
+        else:
+            return r
 
     @observe('cookie_secret')
     def _cookie_secret_check(self, change):

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -862,7 +862,7 @@ class JupyterHub(Application):
     def _validate_secret_key(self, proposal):
         """Coerces strings with even number of hexadecimal characters to bytes."""
         r = proposal['value']
-        if type(r) == str:
+        if isinstance(r, str):
             try:
                 return bytes.fromhex(r)
             except ValueError:

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -199,6 +199,18 @@ def test_cookie_secret_env(tmpdir, request):
     assert not os.path.exists(hub.cookie_secret_file)
 
 
+def test_cookie_secret_string_():
+    cfg = Config()
+
+    cfg.JupyterHub.cookie_secret = "not hex"
+    with pytest.raises(ValueError):
+        JupyterHub(config=cfg)
+
+    cfg.JupyterHub.cookie_secret = "abc123"
+    app = JupyterHub(config=cfg)
+    assert app.cookie_secret == binascii.a2b_hex('abc123')
+
+
 async def test_load_groups(tmpdir, request):
     to_load = {
         'blue': ['cyclops', 'rogue', 'wolverine'],


### PR DESCRIPTION
As YAML/JSON configuration cannot represent bytes directly, it is helpful to support a string representation alongside a Bytes representation.
