### PR TITLE
make_singleuser_app: patch-in HubAuthenticatedHandler at lower priority

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -833,7 +833,7 @@ class HubAuthenticated(object):
             # add state argument to OAuth url
             state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
             login_url = url_concat(login_url, {'state': state})
-        # override at setting level,
+        # temporary override at setting level,
         # to allow any subclass overrides of get_login_url to preserve their effect
         # for example, APIHandler raises 403 to prevent redirects
         with mock.patch.dict(self.application.settings, {"login_url": login_url}):

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -19,6 +19,7 @@ import string
 import time
 import uuid
 import warnings
+from unittest import mock
 from urllib.parse import quote
 from urllib.parse import urlencode
 
@@ -832,8 +833,12 @@ class HubAuthenticated(object):
             # add state argument to OAuth url
             state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
             login_url = url_concat(login_url, {'state': state})
-        app_log.debug("Redirecting to login url: %s", login_url)
-        return login_url
+        # override at setting level,
+        # to allow any subclass overrides of get_login_url to preserve their effect
+        # for example, APIHandler raises 403 to prevent redirects
+        with mock.patch.dict(self.application.settings, {"login_url": login_url}):
+            app_log.debug("Redirecting to login url: %s", login_url)
+            return super().get_login_url()
 
     def check_hub_user(self, model):
         """Check whether Hub-authenticated user or service should be allowed.

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -404,9 +404,10 @@ class StubSingleUserSpawner(MockSpawner):
         Should be:
 
         - authenticated, so we are testing auth
-        - always available (i.e. in base ServerApp and NotebookApp
+        - always available (i.e. in mocked ServerApp and NotebookApp)
+        - *not* an API handler that raises 403 instead of redirecting
         """
-        return "/api/status"
+        return "/tree"
 
     _thread = None
 

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -21,12 +21,18 @@ async def test_singleuser_auth(app):
     user = app.users['nandy']
     if not user.running:
         await user.spawn()
+        await app.proxy.add_user(user)
     url = public_url(app, user)
 
     # no cookies, redirects to login page
     r = await async_requests.get(url)
     r.raise_for_status()
     assert '/hub/login' in r.url
+
+    # unauthenticated /api/ should 403, not redirect
+    api_url = url_path_join(url, "api/status")
+    r = await async_requests.get(api_url, allow_redirects=False)
+    assert r.status_code == 403
 
     # with cookies, login successful
     r = await async_requests.get(url, cookies=cookies)


### PR DESCRIPTION
apply patch directly to BaseHandler instead of each handler instance so that overrides can still take effect (i.e. APIHandler raising 403 instead of redirecting)

closes #3328