### PR TITLE
publish release outputs as artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           print("OK")
           EOF
 
+      # ref: https://github.com/actions/upload-artifact#readme
       - uses: actions/upload-artifact@v2
         with:
           name: jupyterhub-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,12 @@ jobs:
           print("OK")
           EOF
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jupyterhub-${{ github.sha }}
+          path: "dist/*"
+          if-no-files-found: error
+
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
makes local testing of a PR even easier since we build an sdist and wheel for every PR and push. We are already building this, this change only makes them available via the `artifacts` link of a workflow run.

since artifacts are double-archived, it's not quite as simple as giving a URL to install from, but this at least makes it available. To use:

- download and unpack zip
- `pip install path/to/whl`

I've been using this extensively to test recent issues in pyzmq releases, and it's awesome.

Artifacts expire by default after 30 days, I believe.