### PR TITLE
Do not pass self twice to a options_form callable

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -347,7 +347,7 @@ class Spawner(LoggingConfigurable):
         .. versionadded:: 0.9
         """
         if callable(self.options_form):
-            options_form = await maybe_future(self.options_form(self))
+            options_form = await maybe_future(self.options_form())
         else:
             options_form = self.options_form
 

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -184,10 +184,36 @@ class FormSpawner(MockSpawner):
         return options
 
 
+class CallableFormSpawner(FormSpawner):
+    """A spawner that has an options form defined and it is callable"""
+
+    options_form = lambda self: "IMAFORM"
+
+
+class AsyncCallableFormSpawner(FormSpawner):
+    """A spawner that has an options form defined and it is async callable"""
+
+    async def options_form(self):
+        return "IMAFORM"
+
+
+class FalsyFormSpawner(FormSpawner):
+    """A spawner that has an options form property defined returning a falsy value"""
+
+    options_form = ""
+
+
 class FalsyCallableFormSpawner(FormSpawner):
     """A spawner that has a callable options form defined returning a falsy value"""
 
-    options_form = lambda a, b: ""
+    options_form = lambda self: ""
+
+
+class FalsyAsyncCallableFormSpawner(FormSpawner):
+    """A spawner that has a callable options form defined returning a falsy value asynchronously"""
+
+    async def options_form(self):
+        return ""
 
 
 class MockStructGroup:


### PR DESCRIPTION
If someone wants to create custom Spawner class with `options_form` as a function, it should accept 2 arguments:
```python
def options_form(self, _self):
  ...
```
This second argument is just the same as `self`, and there is no reason to use it.

Another way to define this method to avoid adding the second argument is:
```python
@staticmethod
def options_form(self)
```
Which smells really awful.

Here I've removed this unnecessary argument and also added few more tests for different cases.