### PR TITLE
Update pre-commit hooks versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,14 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: "3.8.4"
+    hooks:
+      - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
       - id: end-of-file-fixer
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: requirements-txt-fixer
-      - id: flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,9 +10,9 @@ html5lib  # needed for beautifulsoup
 mock
 notebook
 pre-commit
+pytest>=3.3
 pytest-asyncio
 pytest-cov
-pytest>=3.3
 requests-mock
 # blacklist urllib3 releases affected by https://github.com/urllib3/urllib3/issues/1683
 # I *think* this should only affect testing, not production

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,6 @@ https://github.com/jupyterhub/autodoc-traits/archive/75885ee24636efbfebfceed1043
 pydata-sphinx-theme
 pytablewriter>=0.56
 recommonmark>=0.6
+sphinx>=1.7
 sphinx-copybutton
 sphinx-jsonschema
-sphinx>=1.7


### PR DESCRIPTION
Followup version bumps to align the pre-commit config with jupyterhub-idle-culler and such where we have more modern versions of the hooks and have started using the non-deprecated flake8 hook inside a dedicated github repo.
