### PR TITLE
Vertical filtering

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -65,7 +65,7 @@ class APIHandler(BaseHandler):
             return False
         return True
 
-    @functools.lru_cache
+    @functools.lru_cache()
     def get_scope_filter(self, req_scope):
         """Produce a filter for `*ListAPIHandlers* so that GET method knows which models to return.
         Filter is a callable that takes a resource name and outputs true or false"""

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -34,6 +34,7 @@ class APIHandler(BaseHandler):
         self.raw_scopes = set()
         self.parsed_scopes = {}
         self._parse_scopes()
+        # todo: Check if okay
 
     def _parse_scopes(self):
         """Parse raw scope collection into a dict with filters that can be used to resolve API access"""

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -2,6 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
+import re
 from datetime import datetime
 from http.client import responses
 
@@ -9,6 +10,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from tornado import web
 
 from .. import orm
+from .. import roles
 from ..handlers import BaseHandler
 from ..handlers import scopes
 from ..utils import isoformat
@@ -24,7 +26,26 @@ class APIHandler(BaseHandler):
     - strict referer checking for Cookie-authenticated requests
     - strict content-security-policy
     - methods for REST API models
+    - scope loading
     """
+
+    async def prepare(self):
+        await super().prepare()
+        self.raw_scopes = set()
+        self.parsed_scopes = {}
+        self._parse_scopes()
+
+    def _parse_scopes(self):
+        """Parse raw scope collection into a dict with filters that can be used to resolve API access"""
+        self.log.debug("Parsing scopes")
+        if self.current_user is not None:
+            self.raw_scopes = roles.get_subscopes(*self.current_user.roles)
+        oauth_token = self.get_current_user_oauth_token()
+        if oauth_token:
+            self.raw_scopes |= scopes.get_user_scopes(oauth_token.name)
+        if 'all' in self.raw_scopes:
+            self.raw_scopes |= scopes.get_user_scopes(self.current_user.name)
+        self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
 
     @property
     def content_security_policy(self):
@@ -64,36 +85,41 @@ class APIHandler(BaseHandler):
         return True
 
     def get_scope_filter(self, req_scope):
-        """Produce a filter for `*ListAPIHandlers* so that GET method knows which models to return"""
-        scope_translator = {
-            'read:users': 'users',
-            'read:services': 'services',
-            'read:groups': 'groups',
-        }
-        if req_scope not in scope_translator:
-            raise AttributeError("Internal error: inconsistent scope situation")
-        kind = scope_translator[req_scope]
-        Resource = orm.get_class(kind)
+        """Produce a filter for `*ListAPIHandlers* so that GET method knows which models to return.
+        Filter is a callable that takes a resource name and outputs true or false"""
+        kind_regex = re.compile(r':?(user|service|group)s:?')
+        try:
+            kind = re.search(kind_regex, req_scope).group(1)
+        except AttributeError:
+            self.log.warning(
+                "Regex error while processing scope %s, throwing 500", req_scope
+            )
+            raise web.HTTPError(
+                log_message="Unrecognized scope guard on method: %s" % req_scope
+            )
         try:
             sub_scope = self.parsed_scopes[req_scope]
         except AttributeError:
             raise web.HTTPError(
                 403,
-                "Resource scope %s (that was just accessed) not found in scopes anymore"
+                "Resource scope %s (that was just accessed) not found in parsed scope model"
                 % req_scope,
             )
-        if sub_scope == scopes.Scope.ALL:
-            return None  # Full access
-        sub_scope_values = next(iter(sub_scope.values()))
-        query = self.db.query(Resource).filter(Resource.name.in_(sub_scope_values))
-        scope_filter = {entry.name for entry in query.all()}
-        if 'group' in sub_scope and kind == 'users':
-            groups = orm.Group.name.in_(sub_scope['group'])
-            users_in_groups = (
-                self.db.query(orm.User).join(orm.Group.users).filter(groups)
-            )
-            scope_filter |= {user.name for user in users_in_groups}
-        return scope_filter
+
+        def has_access(resource_name):
+            if sub_scope == scopes.Scope.ALL:
+                found_resource = True
+            else:
+                found_resource = resource_name in sub_scope[kind]
+            if not found_resource:  # Try group-based access
+                if 'groups' in sub_scope and kind == 'users':
+                    user = self.current_user()
+                    if user:
+                        user_in_group = bool(user.groups & sub_scope['groups'])
+                        found_resource |= user_in_group
+            return found_resource
+
+        return has_access
 
     def get_current_user_cookie(self):
         """Override get_user_cookie to check Referer header"""
@@ -234,24 +260,12 @@ class APIHandler(BaseHandler):
             'last_activity': isoformat(user.last_activity),
         }
         access_map = {
-            'read:users': {
-                'kind',
-                'name',
-                'admin',
-                'roles',
-                'groups',
-                'server',
-                'servers',
-                'pending',
-                'created',
-                'last_activity',
-            },
-            'read:users:name': {'kind', 'name'},
+            'read:users': set(model.keys()),  # All available components
+            'read:users:names': {'kind', 'name'},
             'read:users:groups': {'kind', 'name', 'groups'},
             'read:users:activity': {'kind', 'name', 'last_activity'},
             'read:users:servers': {'kind', 'name', 'servers'},
         }
-        # Todo: Should 'name' be included in all access?
         self.log.debug(
             "Asking for user models with scopes [%s]" % ", ".join(self.raw_scopes)
         )
@@ -259,24 +273,23 @@ class APIHandler(BaseHandler):
         for scope in access_map:
             if scope in self.parsed_scopes:
                 scope_filter = self.get_scope_filter(scope)
-                if scope_filter is None or user.name in scope_filter:
+                if scope_filter(user.name):
                     allowed_keys |= access_map[scope]
         model = {key: model[key] for key in allowed_keys if key in model}
-        if not model:
-            return model  # No access to this user
-        if '' in user.spawners and 'pending' in allowed_keys:
-            model['pending'] = user.spawners[''].pending
-        if not (include_servers and 'servers' in allowed_keys):
-            model['servers'] = None
-        else:
-            servers = model['servers'] = {}
-            for name, spawner in user.spawners.items():
-                # include 'active' servers, not just ready
-                # (this includes pending events)
-                if spawner.active:
-                    servers[name] = self.server_model(
-                        spawner, include_state=include_state
-                    )
+        if model:
+            if '' in user.spawners and 'pending' in allowed_keys:
+                model['pending'] = user.spawners[''].pending
+            if not (include_servers and 'servers' in allowed_keys):
+                model['servers'] = None
+            else:
+                servers = model['servers'] = {}
+                for name, spawner in user.spawners.items():
+                    # include 'active' servers, not just ready
+                    # (this includes pending events)
+                    if spawner.active:
+                        servers[name] = self.server_model(
+                            spawner, include_state=include_state
+                        )
         return model
 
     def group_model(self, group):

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -85,14 +85,14 @@ class APIHandler(BaseHandler):
             param kind: 'users' or 'services' or 'groups'
             """
             if sub_scope == scopes.Scope.ALL:
-                found_resource = True
+                return True
             else:
                 found_resource = orm_resource.name in sub_scope[kind]
             if not found_resource:  # Try group-based access
                 if 'group' in sub_scope and kind == 'user':
                     group_names = {group.name for group in orm_resource.groups}
                     user_in_group = bool(group_names & set(sub_scope['group']))
-                    found_resource |= user_in_group
+                    found_resource = user_in_group
             return found_resource
 
         return has_access

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -237,7 +237,7 @@ class APIHandler(BaseHandler):
         }
         access_map = {
             'read:users': set(model.keys()),  # All available components
-            'read:users:names': {'kind', 'name'},
+            'read:users:name': {'kind', 'name'},
             'read:users:groups': {'kind', 'name', 'groups'},
             'read:users:activity': {'kind', 'name', 'last_activity'},
             'read:users:servers': {'kind', 'name', 'servers'},

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -39,7 +39,7 @@ class GroupListAPIHandler(_GroupAPIHandler):
         """List groups"""
         groups = self.db.query(orm.Group)
         scope_filter = self.get_scope_filter('read:groups')
-        data = [self.group_model(g) for g in groups if scope_filter(g)]
+        data = [self.group_model(g) for g in groups if scope_filter(g, kind='group')]
         self.write(json.dumps(data))
 
     @needs_scope('admin:groups')

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -38,10 +38,8 @@ class GroupListAPIHandler(_GroupAPIHandler):
     def get(self):
         """List groups"""
         groups = self.db.query(orm.Group)
-        scope_filter = self.get_scope_filter(self.db)
-        if scope_filter is not None:
-            groups = groups.filter(orm.Group.name.in_(scope_filter))
-        data = [self.group_model(g) for g in groups]
+        scope_filter = self.get_scope_filter('read:groups')
+        data = [self.group_model(g) for g in groups if scope_filter(g)]
         self.write(json.dumps(data))
 
     @needs_scope('admin:groups')

--- a/jupyterhub/apihandlers/groups.py
+++ b/jupyterhub/apihandlers/groups.py
@@ -35,9 +35,10 @@ class _GroupAPIHandler(APIHandler):
 
 class GroupListAPIHandler(_GroupAPIHandler):
     @needs_scope('read:groups')
-    def get(self, scope_filter=None):
+    def get(self):
         """List groups"""
         groups = self.db.query(orm.Group)
+        scope_filter = self.get_scope_filter(self.db)
         if scope_filter is not None:
             groups = groups.filter(orm.Group.name.in_(scope_filter))
         data = [self.group_model(g) for g in groups]

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -32,16 +32,11 @@ class ServiceListAPIHandler(APIHandler):
     @needs_scope('read:services')
     def get(self):
         scope_filter = self.get_scope_filter('read:services')
-        if scope_filter is None:
-            data = {
-                name: service_model(service) for name, service in self.services.items()
-            }
-        else:
-            data = {
-                name: service_model(service)
-                for name, service in self.services.items()
-                if name in scope_filter
-            }
+        data = {
+            name: service_model(service)
+            for name, service in self.services.items()
+            if scope_filter(service)
+        }
         self.write(json.dumps(data))
 
 

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -35,7 +35,7 @@ class ServiceListAPIHandler(APIHandler):
         data = {
             name: service_model(service)
             for name, service in self.services.items()
-            if scope_filter(service)
+            if scope_filter(service, kind='service')
         }
         self.write(json.dumps(data))
 

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -31,9 +31,16 @@ def service_model(service):
 class ServiceListAPIHandler(APIHandler):
     @needs_scope('read:services')
     def get(self, scope_filter=None):
-        data = {name: service_model(service) for name, service in self.services.items()}
-        if scope_filter is not None:
-            data = dict(filter(lambda tup: tup[0] in scope_filter, data.items()))
+        if scope_filter is None:
+            data = {
+                name: service_model(service) for name, service in self.services.items()
+            }
+        else:
+            data = {
+                name: service_model(service)
+                for name, service in self.services.items()
+                if name in scope_filter
+            }
         self.write(json.dumps(data))
 
 

--- a/jupyterhub/apihandlers/services.py
+++ b/jupyterhub/apihandlers/services.py
@@ -30,7 +30,8 @@ def service_model(service):
 
 class ServiceListAPIHandler(APIHandler):
     @needs_scope('read:services')
-    def get(self, scope_filter=None):
+    def get(self):
+        scope_filter = self.get_scope_filter('read:services')
         if scope_filter is None:
             data = {
                 name: service_model(service) for name, service in self.services.items()
@@ -46,7 +47,7 @@ class ServiceListAPIHandler(APIHandler):
 
 def admin_or_self(method):
     """Decorator for restricting access to either the target service or admin"""
-    """***Deprecated in favor of RBAC, use scope-based decorator***"""
+    """***Deprecated in favor of RBAC. Use scope-based decorator***"""
 
     def decorated_method(self, name):
         current = self.current_user

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -55,7 +55,7 @@ class UserListAPIHandler(APIHandler):
 
     @needs_scope(
         'read:users',
-        'read:users:names',
+        'read:users:name',
         'reda:users:servers',
         'read:users:groups',
         'read:users:activity',

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -81,8 +81,11 @@ class BaseHandler(RequestHandler):
         The current user (None if not logged in) may be accessed
         via the `self.current_user` property during the handling of any request.
         """
+        self.raw_scopes = set()
+        self.parsed_scopes = {}
         try:
             await self.get_current_user()
+            scopes.build_scope_schema(self)
         except Exception:
             self.log.exception("Failed to get current user")
             self._jupyterhub_user = None

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -81,8 +81,6 @@ class BaseHandler(RequestHandler):
         The current user (None if not logged in) may be accessed
         via the `self.current_user` property during the handling of any request.
         """
-        self.raw_scopes = set()
-        self.parsed_scopes = set()
         try:
             await self.get_current_user()
         except Exception:
@@ -431,15 +429,7 @@ class BaseHandler(RequestHandler):
                 # don't let errors here raise more than once
                 self._jupyterhub_user = None
                 self.log.exception("Error getting current user")
-        self._parse_scopes()
         return self._jupyterhub_user
-
-    def _parse_scopes(self):
-        if self._jupyterhub_user is not None or self.get_current_user_oauth_token():
-            self.raw_scopes = roles.get_subscopes(*self._jupyterhub_user.roles)
-            if 'all' in self.raw_scopes:
-                self.raw_scopes |= scopes.get_user_scopes(self.current_user.name)
-            self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
 
     @property
     def current_user(self):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -447,6 +447,7 @@ class BaseHandler(RequestHandler):
         else:  # deprecated oauth tokens
             user_from_oauth = self.get_current_user_oauth_token()
             self.raw_scopes = scopes.get_scopes_for(user_from_oauth)
+        app_log.debug("Found scopes [%s]", ",".join(self.raw_scopes))
         self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
 
     @property

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -440,17 +440,17 @@ class BaseHandler(RequestHandler):
         self.raw_scopes = set()
         app_log.debug("Loading and parsing scopes")
         if not self.current_user:
-            app_log.debug("No user found, no scopes loaded")
-            try:  # check for oauth tokens as long as #3380 not merged
-                user_from_oauth = self.get_current_user_oauth_token()
+            # check for oauth tokens as long as #3380 not merged
+            user_from_oauth = self.get_current_user_oauth_token()
+            if user_from_oauth is not None:
                 self.raw_scopes = {f'read:users!user={user_from_oauth.name}'}
-            except:
-                pass
+            else:
+                app_log.debug("No user found, no scopes loaded")
         else:
             api_token = self.get_token()
             if api_token:
                 self.raw_scopes = scopes.get_scopes_for(api_token)
-            elif self.current_user:
+            else:
                 self.raw_scopes = scopes.get_scopes_for(self.current_user)
         self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
         app_log.debug("Found scopes [%s]", ",".join(self.raw_scopes))

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -617,8 +617,8 @@ class APIToken(Hashed, Base):
         db.add(orm_token)
         # load default roles if they haven't been initiated
         # correct to have this here? otherwise some tests fail
-        user_role = Role.find(db, 'user')
-        if not user_role:
+        token_role = Role.find(db, 'token')
+        if not token_role:
             default_roles = get_default_roles()
             for role in default_roles:
                 add_role(db, role)

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -12,8 +12,8 @@ def get_default_roles():
     default_roles = [
         {
             'name': 'user',
-            'description': 'Everything the user can do',
-            'scopes': ['all'],
+            'description': 'Standard user privileges',
+            'scopes': ['self'],
         },
         {
             'name': 'admin',
@@ -37,11 +37,41 @@ def get_default_roles():
             'description': 'Post activity only',
             'scopes': ['users:activity!user=username'],
         },
+        # {'name': 'token',
+        #  'description': 'Token with same rights as token owner',
+        #  'scopes': ['all']}
     ]
     return default_roles
 
 
-def get_scopes():
+def expand_self_scope(name, read_only=False):
+    """
+    Users have a metascope 'self' that should be expanded to standard user privileges.
+    At the moment that is a user-filtered version (optional read) access to
+    users
+    users:name
+    users:groups
+    users:activity
+    users:servers
+    users:tokens
+    """
+    scope_list = [
+        'users',
+        'users:name',
+        'users:groups',
+        'users:activity',
+        'users:servers',
+        'users:tokens',
+    ]
+    read_scope_list = ['read:' + scope for scope in scope_list]
+    if read_only:
+        scope_list = read_scope_list
+    else:
+        scope_list.extend(read_scope_list)
+    return {"{}!user={}".format(scope, name) for scope in scope_list}
+
+
+def get_scope_hierarchy():
     """
     Returns a dictionary of scopes:
     scopes.keys() = scopes of highest level and scopes that have their own subscopes
@@ -49,7 +79,7 @@ def get_scopes():
     """
 
     scopes = {
-        'all': ['read:all'],
+        'all': ['read:all'],  # Todo: optional
         'users': ['read:users', 'users:activity', 'users:servers'],
         'read:users': [
             'read:users:name',
@@ -74,7 +104,7 @@ def get_scopes():
 def expand_scope(scopename):
     """Returns a set of all subscopes"""
 
-    scopes = get_scopes()
+    scopes = get_scope_hierarchy()
     subscopes = [scopename]
 
     def expand_subscopes(index):
@@ -97,6 +127,15 @@ def expand_scope(scopename):
     expanded_scope = set(subscopes)
 
     return expanded_scope
+
+
+def get_scopes_for(orm_object):
+    """Get the scopes for User/Service/Group/Token"""
+    scopes = get_subscopes(*orm_object.roles)
+    if 'self' in scopes:
+        scopes.remove('self')
+        scopes += expand_self_scope(orm_object.name)
+    return scopes
 
 
 def get_subscopes(*args):

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -22,7 +22,11 @@ def get_scopes_for(orm_object):
         owner = orm_object.user or orm_object.service
         owner_name = owner.name
         token_scopes = roles.get_subscopes(*orm_object.roles)
+        if 'all' in token_scopes:
+            token_scopes |= get_user_scopes(owner_name)
         user_scopes = roles.get_subscopes(*owner.roles)
+        if 'all' in user_scopes:
+            user_scopes |= get_user_scopes(owner_name)
         scopes = token_scopes & user_scopes
         discarded_token_scopes = token_scopes - scopes
         # Not taking symmetric difference here because token owner can naturally have more scopes than token
@@ -34,8 +38,10 @@ def get_scopes_for(orm_object):
     else:
         owner_name = orm_object.name
         scopes = roles.get_subscopes(*orm_object.roles)
-    if 'all' in scopes:
-        scopes |= get_user_scopes(owner_name)
+        if 'all' in scopes:
+            scopes |= get_user_scopes(
+                owner_name
+            )  # Todo: Expand scopes in separate method
     return scopes
 
 

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import re
 from enum import Enum
 
 from tornado import web
@@ -58,58 +59,46 @@ def _check_user_in_expanded_scope(handler, user_name, scope_group_names):
     return bool(set(scope_group_names) & group_names)
 
 
-def _get_scope_filter(db, req_scope, sub_scope):
-    """Produce a filter for `*ListAPIHandlers* so that get method knows which models to return"""
-    scope_translator = {
-        'read:users': 'users',
-        'read:services': 'services',
-        'read:groups': 'groups',
-    }
-    if req_scope not in scope_translator:
-        raise AttributeError("Internal error: inconsistent scope situation")
-    kind = scope_translator[req_scope]
-    Resource = orm.get_class(kind)
-    sub_scope_values = next(iter(sub_scope.values()))
-    query = db.query(Resource).filter(Resource.name.in_(sub_scope_values))
-    scope_filter = {entry.name for entry in query.all()}
-    if 'group' in sub_scope and kind == 'users':
-        groups = orm.Group.name.in_(sub_scope['group'])
-        users_in_groups = db.query(orm.User).join(orm.Group.users).filter(groups)
-        scope_filter |= {user.name for user in users_in_groups}
-    return scope_filter
-
-
 def _check_scope(api_handler, req_scope, **kwargs):
     """Check if scopes satisfy requirements
-    Returns either Scope.ALL for unrestricted access, Scope.NONE for refused access or
+    Returns either True for unrestricted access, False for refused access or
     an iterable with a filter
     """
     # Parse user name and server name together
+    try:
+        api_name = api_handler.request.path
+    except:
+        api_name = type(api_handler).__name__
     if 'user' in kwargs and 'server' in kwargs:
         kwargs['server'] = "{}/{}".format(kwargs['user'], kwargs['server'])
     if req_scope not in api_handler.parsed_scopes:
+        app_log.debug("No scopes present to access %s" % api_name)
         return False
     if api_handler.parsed_scopes[req_scope] == Scope.ALL:
+        app_log.debug("Unrestricted access to %s call", api_name)
         return True
     # Apply filters
     sub_scope = api_handler.parsed_scopes[req_scope]
-    if 'scope_filter' in kwargs:
-        scope_filter = _get_scope_filter(api_handler.db, req_scope, sub_scope)
-        return scope_filter
-    else:
-        if not kwargs:
-            return False  # Separated from 404 error below because in this case we don't leak information
-        # Interface change: Now can have multiple filters
-        for (filter_, filter_value) in kwargs.items():
-            if filter_ in sub_scope and filter_value in sub_scope[filter_]:
+    if not kwargs:
+        app_log.debug(
+            "Client has restricted access to %s. In-method filtering" % api_name
+        )
+        return True
+    for (filter_, filter_value) in kwargs.items():
+        if filter_ in sub_scope and filter_value in sub_scope[filter_]:
+            app_log.debug(
+                "Restricted client access supported by endpoint %s" % api_name
+            )
+            return True
+        if _needs_scope_expansion(filter_, filter_value, sub_scope):
+            group_names = sub_scope['group']
+            if _check_user_in_expanded_scope(api_handler, filter_value, group_names):
+                app_log.debug("Restricted client access supported with group expansion")
                 return True
-            if _needs_scope_expansion(filter_, filter_value, sub_scope):
-                group_names = sub_scope['group']
-                if _check_user_in_expanded_scope(
-                    api_handler, filter_value, group_names
-                ):
-                    return True
-        raise web.HTTPError(404, "No access to resources or resources not found")
+    app_log.debug(
+        "Client access refused; filters do not match API endpoint %s request" % api_name
+    )
+    raise web.HTTPError(404, "No access to resources or resources not found")
 
 
 def parse_scopes(scope_list):
@@ -120,7 +109,7 @@ def parse_scopes(scope_list):
     would lead to scope model
     {
        "users":scope.ALL,
-       "users:admin":{
+       "admin:users":{
           "user":[
              "alice"
           ]
@@ -148,7 +137,7 @@ def parse_scopes(scope_list):
     return parsed_scopes
 
 
-def needs_scope(scope):
+def needs_scope(*scopes):
     """Decorator to restrict access to users or services with the required scope"""
 
     def scope_decorator(func):
@@ -163,30 +152,25 @@ def needs_scope(scope):
                 if resource_name in bound_sig.arguments:
                     resource_value = bound_sig.arguments[resource_name]
                     s_kwargs[resource] = resource_value
-            if 'scope_filter' in bound_sig.arguments:
-                s_kwargs['scope_filter'] = None
-            scope_filter = _check_scope(self, scope, **s_kwargs)
-            # todo: This checks if True/False or set of resource names. Can be improved
-            if isinstance(scope_filter, set):
-                kwargs['scope_filter'] = scope_filter
-            if scope_filter:
+            has_access = False
+            for scope in scopes:
+                has_access |= _check_scope(self, scope, **s_kwargs)
+            if has_access:
                 return func(self, *args, **kwargs)
             else:
-                # catching attr error occurring for older_requirements test
-                # could be done more elegantly?
                 try:
-                    request_path = self.request.path
+                    end_point = self.request.path
                 except AttributeError:
-                    request_path = 'the requested API'
+                    end_point = self.__name__
                 app_log.warning(
-                    "Not authorizing access to {}. Requires scope {}, not derived from scopes [{}]".format(
-                        request_path, scope, ", ".join(self.raw_scopes)
+                    "Not authorizing access to {}. Requires any of [{}], not derived from scopes [{}]".format(
+                        end_point, ", ".join(scopes), ", ".join(self.raw_scopes)
                     )
                 )
                 raise web.HTTPError(
                     403,
-                    "Action is not authorized with current scopes; requires {}".format(
-                        scope
+                    "Action is not authorized with current scopes; requires any of [{}]".format(
+                        ", ".join(scopes)
                     ),
                 )
 

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -150,14 +150,6 @@ def needs_scope(*scopes):
             bound_sig = sig.bind(self, *args, **kwargs)
             bound_sig.apply_defaults()
             s_kwargs = {}
-            # current_user = self.current_user()
-            # if current_user is not None or self.get_current_user_oauth_token():
-            #     self.raw_scopes = roles.get_subscopes(*current_user.roles)
-            #     if 'all' in self.raw_scopes:
-            #         self.raw_scopes |= get_user_scopes(self.current_user.name)
-            #     self.parsed_scopes = parse_scopes(self.raw_scopes)
-            # else:
-            #     app_log.warning("No user found in access checking, so no scopes loaded")
             for resource in {'user', 'server', 'group', 'service'}:
                 resource_name = resource + '_name'
                 if resource_name in bound_sig.arguments:

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -23,6 +23,7 @@ def get_scopes_for(orm_object):
         token_scopes = roles.get_scopes_for(orm_object)
         owner_scopes = roles.get_scopes_for(owner)
         if 'all' in token_scopes:
+            token_scopes.remove('all')
             token_scopes |= owner_scopes
         scopes = token_scopes & owner_scopes
         discarded_token_scopes = token_scopes - scopes

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -45,6 +45,7 @@ from . import mocking
 from .. import crypto
 from .. import orm
 from ..roles import mock_roles
+from ..roles import update_roles
 from ..utils import random_port
 from .mocking import MockHub
 from .test_services import mockservice_cmd
@@ -249,6 +250,8 @@ def _mockservice(request, app, url=False):
         mock_roles(app, name, 'services')
         assert name in app._service_map
         service = app._service_map[name]
+        token = service.orm.api_tokens[0]
+        update_roles(app.db, token, 'tokens', roles=['token'])
 
         async def start():
             # wait for proxy to be updated before starting the service

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -53,7 +53,6 @@ from ..spawner import SimpleLocalProcessSpawner
 from ..utils import random_port
 from ..utils import url_path_join
 from .utils import async_requests
-from .utils import get_scopes
 from .utils import public_host
 from .utils import public_url
 from .utils import ssl_setup
@@ -305,7 +304,6 @@ class MockHub(JupyterHub):
         super().init_tornado_application()
         # reconnect tornado_settings so that mocks can update the real thing
         self.tornado_settings = self.users.settings = self.tornado_application.settings
-        self.tornado_settings['mock_scopes'] = get_scopes()
 
     def init_services(self):
         # explicitly expire services before reinitializing

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1702,7 +1702,7 @@ async def test_update_activity_403(app, user, admin_user):
 
 
 async def test_update_activity_admin(app, user, admin_user):
-    token = admin_user.new_api_token()
+    token = admin_user.new_api_token(roles=['admin'])
     r = await api_request(
         app,
         "users/{}/activity".format(user.name),

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1319,7 +1319,7 @@ async def test_token_for_user(app, as_user, for_user, status):
     if for_user != 'missing':
         for_user_obj = add_user(app.db, app, name=for_user)
     data = {'username': for_user}
-    headers = {'Authorization': 'token %s' % u.new_api_token(roles=[as_user])}
+    headers = {'Authorization': 'token %s' % u.new_api_token()}
     r = await api_request(
         app,
         'users',
@@ -1414,7 +1414,7 @@ async def test_token_list(app, as_user, for_user, status):
     u = add_user(app.db, app, name=as_user)
     if for_user != 'missing':
         for_user_obj = add_user(app.db, app, name=for_user)
-    headers = {'Authorization': 'token %s' % u.new_api_token(roles=[as_user])}
+    headers = {'Authorization': 'token %s' % u.new_api_token()}
     r = await api_request(app, 'users', for_user, 'tokens', headers=headers)
     assert r.status_code == status
     if status != 200:

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1319,7 +1319,7 @@ async def test_token_for_user(app, as_user, for_user, status):
     if for_user != 'missing':
         for_user_obj = add_user(app.db, app, name=for_user)
     data = {'username': for_user}
-    headers = {'Authorization': 'token %s' % u.new_api_token()}
+    headers = {'Authorization': 'token %s' % u.new_api_token(roles=[as_user])}
     r = await api_request(
         app,
         'users',
@@ -1414,7 +1414,7 @@ async def test_token_list(app, as_user, for_user, status):
     u = add_user(app.db, app, name=as_user)
     if for_user != 'missing':
         for_user_obj = add_user(app.db, app, name=for_user)
-    headers = {'Authorization': 'token %s' % u.new_api_token()}
+    headers = {'Authorization': 'token %s' % u.new_api_token(roles=[as_user])}
     r = await api_request(app, 'users', for_user, 'tokens', headers=headers)
     assert r.status_code == status
     if status != 200:

--- a/jupyterhub/tests/test_auth_expiry.py
+++ b/jupyterhub/tests/test_auth_expiry.py
@@ -101,7 +101,6 @@ async def test_auth_expired_page(app, user, disable_refresh):
     assert user._auth_refreshed == before
 
 
-# Fixme: Why does this text fail?
 async def test_auth_expired_api(app, user, disable_refresh):
     cookies = await app.login_user(user.name)
     assert user._auth_refreshed

--- a/jupyterhub/tests/test_auth_expiry.py
+++ b/jupyterhub/tests/test_auth_expiry.py
@@ -101,6 +101,7 @@ async def test_auth_expired_page(app, user, disable_refresh):
     assert user._auth_refreshed == before
 
 
+# Fixme: Why does this text fail?
 async def test_auth_expired_api(app, user, disable_refresh):
     cookies = await app.login_user(user.name)
     assert user._auth_refreshed

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -396,7 +396,7 @@ async def test_group_scope_filter(app):
 async def test_vertical_filter(app):
     user_name = 'lindsey'
     add_user(app.db, name=user_name)
-    test_role = generate_test_role(user_name, ['read:users:names'])
+    test_role = generate_test_role(user_name, ['read:users:name'])
     roles.add_role(app.db, test_role)
     roles.add_obj(app.db, objname=user_name, kind='users', rolename='test')
     roles.remove_obj(app.db, objname=user_name, kind='users', rolename='user')

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -318,6 +318,7 @@ async def test_exceeding_user_permissions(app):
     keys = {key for user in r.json() for key in user.keys()}
     assert 'groups' in keys
     assert 'last_activity' not in keys
+    roles.remove_obj(app.db, user_name, 'users', 'reader_role')
 
 
 async def test_user_service_separation(app, mockservice_url):

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -9,6 +9,7 @@ from subprocess import Popen
 from async_generator import asynccontextmanager
 from tornado.ioloop import IOLoop
 
+from ..roles import update_roles
 from ..utils import maybe_future
 from ..utils import random_port
 from ..utils import url_path_join
@@ -93,6 +94,8 @@ async def test_external_service(app):
         await app.proxy.add_all_services(app._service_map)
 
         service = app._service_map[name]
+        api_token = service.orm.api_tokens[0]
+        update_roles(app.db, api_token, 'tokens', roles=['token'])
         url = public_url(app, service) + '/api/users'
         r = await async_requests.get(url, allow_redirects=False)
         r.raise_for_status()

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -50,11 +50,9 @@ async def test_singleuser_auth(app):
     assert urlparse(r.url).path.endswith('/oauth2/authorize')
     # submit the oauth form to complete authorization
     r = await s.post(r.url, data={'scopes': ['identify']}, headers={'Referer': r.url})
-    assert (
-        urlparse(r.url)
-        .path.rstrip('/')
-        .endswith(url_path_join('/user/nandy', user.spawner.default_url or "/tree"))
-    )
+    final_url = urlparse(r.url).path.rstrip('/')
+    final_path = url_path_join('/user/nandy', user.spawner.default_url or "/tree")
+    assert final_url.endswith(final_path)
     # user isn't authorized, should raise 403
     assert r.status_code == 403
     assert 'burgess' in r.text

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -120,16 +120,17 @@ def add_user(db, app=None, **kwargs):
         return orm_user
 
 
-def auth_header(db, name, role=None):
-    """Return header with user's API authorization token."""
+def auth_header(db, name, inherit=True):
+    """Return header with user's API authorization token.
+    If inherit is True, copies the roles of the invoking user
+    """
     user = find_user(db, name)
     if user is None:
         raise KeyError(f"No such user: {name}")
-    roles = []
-    if role:
-        roles = [role]
-    elif name == 'admin':
-        roles = ['admin']
+    if inherit:
+        roles = [role.name for role in user.roles]
+    else:
+        roles = None
     token = user.new_api_token(roles=roles)
     return {'Authorization': 'token %s' % token}
 

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -120,18 +120,14 @@ def add_user(db, app=None, **kwargs):
         return orm_user
 
 
-def auth_header(db, name, inherit=True):
+def auth_header(db, name):
     """Return header with user's API authorization token.
     If inherit is True, copies the roles of the invoking user
     """
     user = find_user(db, name)
     if user is None:
         raise KeyError(f"No such user: {name}")
-    if inherit:
-        roles = [role.name for role in user.roles]
-    else:
-        roles = None
-    token = user.new_api_token(roles=roles)
+    token = user.new_api_token()
     return {'Authorization': 'token %s' % token}
 
 

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -121,9 +121,7 @@ def add_user(db, app=None, **kwargs):
 
 
 def auth_header(db, name):
-    """Return header with user's API authorization token.
-    If inherit is True, copies the roles of the invoking user
-    """
+    """Return header with user's API authorization token."""
     user = find_user(db, name)
     if user is None:
         raise KeyError(f"No such user: {name}")


### PR DESCRIPTION
Implemented filters to restrict access to components in user, group and service models.
These changes affect the following API endpoints:

 - UserListAPIHandler
 - GroupListAPIHandler
 - ServiceListAPIHandler

### Changes/highlights:
 - If client has no access to `servers` in the user model, this component is not included in the model, rather than sending `{'servers':None}`.
 - Scopes `read:users:activity`, `read:users:groups`, and `read:users:servers` return a user model with components `kind` and `name`, in addition to the resource present in the scope.

## Additional changes 
 - Token scope limitation also done at API request level
 - `all` scope is now a metascope only valid for tokens that expands to all the scopes of the token owner
 - `self` scope is now a metascope only valid for users that expands to all the scopes used to read their own data
 - Default token role is `token` with scope `all`
 - Default user role is `user` with scope `self`
 
## Errors
 - Test `test_singleuser.py::test_singleuser_auth` fails. I think it is related to OAuth vs API tokens so I didn't spend too much time on debugging it.
 - Test `test_auth_expiry.py::test_auth_expired_api` fails too. In the test, cookies get invalidated by letting the user authorization expire. But the API token is still active, which is how authorization succeeds anyway. Not sure if this is an error in test assumptions or in the code?

## Future work (not included in this PR)
 - Any token should have access to the name of its owner
 - Create an `identify` scope that sees the name/groups/servers of an owner
 - Create an `auth_state` scope that allows obtaining users' `auth_state`
 - Ensure that horizontal filtering and vertical filtering is resolved correctly when an token and its owner have non-overlapping scope models