### PR TITLE
Always raise on failed token creation

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1876,7 +1876,7 @@ class JupyterHub(Application):
                         # don't allow bad tokens to create users
                         db.delete(obj)
                         db.commit()
-                        raise
+                    raise
             else:
                 self.log.debug("Not duplicating token %s", orm_token)
         db.commit()


### PR DESCRIPTION
the logic was there but at the wrong indentation level causing it to only raise sometimes, when it should always raise.

closes #3367, which creates a token that fails [check_token](https://github.com/jupyterhub/jupyterhub/blob/1.3.0/jupyterhub/orm.py#L394).