### PR TITLE
Merge OAuth and API tokens

### DIFF
--- a/ci/init-db.sh
+++ b/ci/init-db.sh
@@ -20,7 +20,7 @@ fi
 
 # Configure a set of databases in the database server for upgrade tests
 set -x
-for SUFFIX in '' _upgrade_072 _upgrade_081 _upgrade_094; do
+for SUFFIX in '' _upgrade_100 _upgrade_122 _upgrade_130; do
     $SQL_CLIENT "DROP DATABASE jupyterhub${SUFFIX};" 2>/dev/null || true
     $SQL_CLIENT "CREATE DATABASE jupyterhub${SUFFIX} ${EXTRA_CREATE_DATABASE_ARGS:-};"
 done

--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -3,8 +3,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 version_info = (
-    1,
-    4,
+    2,
+    0,
     0,
     "",  # release (b1, rc1, or "" for final or dev)
     "dev",  # dev or nothing for beta/rc/stable releases

--- a/jupyterhub/alembic/versions/833da8570507_rbac.py
+++ b/jupyterhub/alembic/versions/833da8570507_rbac.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    # FIXME: currently drops all api tokens and forces recreation!
+    # FIXME, maybe: currently drops all api tokens and forces recreation!
     # this ensures a consistent database, but requires:
     # 1. all servers to be stopped for upgrade (maybe unavoidable anyway)
     # 2. any manually issued/stored tokens to be re-issued
@@ -31,84 +31,14 @@ def upgrade():
     # 3. copy oauth tokens into api tokens
     # 4. give oauth tokens 'identify' scopes
 
-    c = op.get_bind()
-    naming_convention = {
-        "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-    }
-    with op.batch_alter_table(
-        "api_tokens",
-        naming_convention=naming_convention,
-    ) as batch_op:
-        batch_op.add_column(
-            sa.Column(
-                'client_id',
-                sa.Unicode(255),
-                # sa.ForeignKey('oauth_clients.identifier', ondelete='CASCADE'),
-                nullable=True,
-            ),
-        )
-        # batch_cursor = op.get_bind()
-        # batch_cursor.execute(
-        #     """
-        #     UPDATE api_tokens
-        #     SET client_id='jupyterhub'
-        #     WHERE client_id IS NULL
-        #     """
-        # )
-        batch_op.create_foreign_key(
-            "fk_api_token_client_id",
-            # 'api_tokens',
-            'oauth_clients',
-            ['client_id'],
-            ['identifier'],
-            ondelete='CASCADE',
-        )
-
-    c.execute(
-        """
-            UPDATE api_tokens
-            SET client_id='jupyterhub'
-            WHERE client_id IS NULL
-        """
-    )
-
-    op.add_column(
-        'api_tokens',
-        sa.Column(
-            'grant_type',
-            sa.Enum(
-                'authorization_code',
-                'implicit',
-                'password',
-                'client_credentials',
-                'refresh_token',
-                name='granttype',
-            ),
-            server_default='authorization_code',
-            nullable=False,
-        ),
-    )
-    op.add_column(
-        'api_tokens', sa.Column('refresh_token', sa.Unicode(length=255), nullable=True)
-    )
-    op.add_column(
-        'api_tokens', sa.Column('session_id', sa.Unicode(length=255), nullable=True)
-    )
-
-    # TODO: migrate OAuth tokens into APIToken table
-
-    op.drop_index('ix_oauth_access_tokens_prefix', table_name='oauth_access_tokens')
-    op.drop_table('oauth_access_tokens')
-
 
 def downgrade():
     # delete OAuth tokens for non-jupyterhub clients
     # drop new columns from api tokens
     op.drop_constraint(None, 'api_tokens', type_='foreignkey')
     op.drop_column('api_tokens', 'session_id')
-    op.drop_column('api_tokens', 'refresh_token')
-    op.drop_column('api_tokens', 'grant_type')
     op.drop_column('api_tokens', 'client_id')
+
     # FIXME: only drop tokens whose client id is not 'jupyterhub'
     # until then, drop all tokens
     op.drop_table("api_tokens")

--- a/jupyterhub/alembic/versions/833da8570507_rbac.py
+++ b/jupyterhub/alembic/versions/833da8570507_rbac.py
@@ -1,0 +1,119 @@
+"""rbac
+
+Revision ID: 833da8570507
+Revises: 4dc2d5a8c53c
+Create Date: 2021-02-17 15:03:04.360368
+
+"""
+# revision identifiers, used by Alembic.
+revision = '833da8570507'
+down_revision = '4dc2d5a8c53c'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # FIXME: currently drops all api tokens and forces recreation!
+    # this ensures a consistent database, but requires:
+    # 1. all servers to be stopped for upgrade (maybe unavoidable anyway)
+    # 2. any manually issued/stored tokens to be re-issued
+
+    # tokens loaded via configuration will be recreated on launch and unaffected
+    op.drop_table('api_tokens')
+    op.drop_table('oauth_access_tokens')
+    return
+    # TODO: explore in-place migration. This seems hard!
+    # 1. add new columns in api tokens
+    # 2. fill default fields (client_id='jupyterhub') for all api tokens
+    # 3. copy oauth tokens into api tokens
+    # 4. give oauth tokens 'identify' scopes
+
+    c = op.get_bind()
+    naming_convention = {
+        "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    }
+    with op.batch_alter_table(
+        "api_tokens",
+        naming_convention=naming_convention,
+    ) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'client_id',
+                sa.Unicode(255),
+                # sa.ForeignKey('oauth_clients.identifier', ondelete='CASCADE'),
+                nullable=True,
+            ),
+        )
+        # batch_cursor = op.get_bind()
+        # batch_cursor.execute(
+        #     """
+        #     UPDATE api_tokens
+        #     SET client_id='jupyterhub'
+        #     WHERE client_id IS NULL
+        #     """
+        # )
+        batch_op.create_foreign_key(
+            "fk_api_token_client_id",
+            # 'api_tokens',
+            'oauth_clients',
+            ['client_id'],
+            ['identifier'],
+            ondelete='CASCADE',
+        )
+
+    c.execute(
+        """
+            UPDATE api_tokens
+            SET client_id='jupyterhub'
+            WHERE client_id IS NULL
+        """
+    )
+
+    op.add_column(
+        'api_tokens',
+        sa.Column(
+            'grant_type',
+            sa.Enum(
+                'authorization_code',
+                'implicit',
+                'password',
+                'client_credentials',
+                'refresh_token',
+                name='granttype',
+            ),
+            server_default='authorization_code',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'api_tokens', sa.Column('refresh_token', sa.Unicode(length=255), nullable=True)
+    )
+    op.add_column(
+        'api_tokens', sa.Column('session_id', sa.Unicode(length=255), nullable=True)
+    )
+
+    # TODO: migrate OAuth tokens into APIToken table
+
+    op.drop_index('ix_oauth_access_tokens_prefix', table_name='oauth_access_tokens')
+    op.drop_table('oauth_access_tokens')
+
+
+def downgrade():
+    # delete OAuth tokens for non-jupyterhub clients
+    # drop new columns from api tokens
+    op.drop_constraint(None, 'api_tokens', type_='foreignkey')
+    op.drop_column('api_tokens', 'session_id')
+    op.drop_column('api_tokens', 'refresh_token')
+    op.drop_column('api_tokens', 'grant_type')
+    op.drop_column('api_tokens', 'client_id')
+    # FIXME: only drop tokens whose client id is not 'jupyterhub'
+    # until then, drop all tokens
+    op.drop_table("api_tokens")
+
+    op.drop_table('api_token_role_map')
+    op.drop_table('service_role_map')
+    op.drop_table('user_role_map')
+    op.drop_table('roles')

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -30,8 +30,6 @@ class TokenAPIHandler(APIHandler):
         )
         orm_token = orm.APIToken.find(self.db, token)
         if orm_token is None:
-            orm_token = orm.OAuthAccessToken.find(self.db, token)
-        if orm_token is None:
             raise web.HTTPError(404)
 
         owner = orm_token.user or orm_token.service

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -205,23 +205,6 @@ class APIHandler(BaseHandler):
 
     def token_model(self, token):
         """Get the JSON model for an APIToken"""
-        expires_at = None
-        if isinstance(token, orm.APIToken):
-            kind = 'api_token'
-            roles = [r.name for r in token.roles]
-            extra = {'note': token.note}
-            expires_at = token.expires_at
-        elif isinstance(token, orm.OAuthAccessToken):
-            kind = 'oauth'
-            # oauth tokens do not bear roles
-            roles = []
-            extra = {'oauth_client': token.client.description or token.client.client_id}
-            if token.expires_at:
-                expires_at = datetime.fromtimestamp(token.expires_at)
-        else:
-            raise TypeError(
-                "token must be an APIToken or OAuthAccessToken, not %s" % type(token)
-            )
 
         if token.user:
             owner_key = 'user'
@@ -234,13 +217,14 @@ class APIHandler(BaseHandler):
         model = {
             owner_key: owner,
             'id': token.api_id,
-            'kind': kind,
-            'roles': [role for role in roles],
+            'kind': 'api_token',
+            'roles': [r.name for r in token.roles],
             'created': isoformat(token.created),
             'last_activity': isoformat(token.last_activity),
-            'expires_at': isoformat(expires_at),
+            'expires_at': isoformat(token.expires_at),
+            'note': token.note,
+            'oauth_client': token.client.description or token.client.client_id,
         }
-        model.update(extra)
         return model
 
     def user_model(self, user):

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -33,9 +33,6 @@ class SelfAPIHandler(APIHandler):
     async def get(self):
         user = self.current_user
         if user is None:
-            # whoami can be accessed via oauth token
-            user = self.get_current_user_oauth_token()
-        if user is None:
             raise web.HTTPError(403)
         if isinstance(user, orm.Service):
             model = self.service_model(user)
@@ -316,17 +313,7 @@ class UserTokenListAPIHandler(APIHandler):
                 continue
             api_tokens.append(self.token_model(token))
 
-        oauth_tokens = []
-        # OAuth tokens use integer timestamps
-        now_timestamp = now.timestamp()
-        for token in sorted(user.oauth_tokens, key=sort_key):
-            if token.expires_at and token.expires_at < now_timestamp:
-                # exclude expired tokens
-                self.db.delete(token)
-                self.db.commit()
-                continue
-            oauth_tokens.append(self.token_model(token))
-        self.write(json.dumps({'api_tokens': api_tokens, 'oauth_tokens': oauth_tokens}))
+        self.write(json.dumps({'api_tokens': api_tokens}))
 
     # Todo: Set to @needs_scope('users:tokens')
     async def post(self, user_name):
@@ -410,19 +397,15 @@ class UserTokenAPIHandler(APIHandler):
         (e.g. wrong owner, invalid key format, etc.)
         """
         not_found = "No such token %s for user %s" % (token_id, user.name)
-        prefix, id_ = token_id[0], token_id[1:]
-        if prefix == 'a':
-            Token = orm.APIToken
-        elif prefix == 'o':
-            Token = orm.OAuthAccessToken
-        else:
+        prefix, id_ = token_id[:1], token_id[1:]
+        if prefix != 'a':
             raise web.HTTPError(404, not_found)
         try:
             id_ = int(id_)
         except ValueError:
             raise web.HTTPError(404, not_found)
 
-        orm_token = self.db.query(Token).filter(Token.id == id_).first()
+        orm_token = self.db.query(orm.APIToken).filter_by(id=id_).first()
         if orm_token is None or orm_token.user is not user.orm_user:
             raise web.HTTPError(404, "Token not found %s", orm_token)
         return orm_token
@@ -444,10 +427,10 @@ class UserTokenAPIHandler(APIHandler):
             raise web.HTTPError(404, "No such user: %s" % user_name)
         token = self.find_token_by_id(user, token_id)
         # deleting an oauth token deletes *all* oauth tokens for that client
-        if isinstance(token, orm.OAuthAccessToken):
-            client_id = token.client_id
+        client_id = token.client_id
+        if token.client_id != "jupyterhub":
             tokens = [
-                token for token in user.oauth_tokens if token.client_id == client_id
+                token for token in user.api_tokens if token.client_id == client_id
             ]
         else:
             tokens = [token]

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -214,6 +214,8 @@ class NewToken(Application):
         hub = JupyterHub(parent=self)
         hub.load_config_file(hub.config_file)
         hub.init_db()
+        hub.init_hub()
+        hub.init_oauth()
 
         def init_users():
             loop = asyncio.new_event_loop()

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -419,17 +419,10 @@ class BaseHandler(RequestHandler):
     def _resolve_scopes(self):
         self.raw_scopes = set()
         app_log.debug("Loading and parsing scopes")
-        if not self.current_user:
-            # check for oauth tokens as long as #3380 not merged
-            user_from_oauth = self.get_current_user_oauth_token()
-            if user_from_oauth is not None:
-                self.raw_scopes = {f'read:users!user={user_from_oauth.name}'}
-            else:
-                app_log.debug("No user found, no scopes loaded")
-        else:
-            api_token = self.get_token()
-            if api_token:
-                self.raw_scopes = scopes.get_scopes_for(api_token)
+        if self.current_user:
+            orm_token = self.get_token()
+            if orm_token:
+                self.raw_scopes = scopes.get_scopes_for(orm_token)
             else:
                 self.raw_scopes = scopes.get_scopes_for(self.current_user)
         self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -552,36 +552,32 @@ class TokenPageHandler(BaseHandler):
             return (token.last_activity or never, token.created or never)
 
         now = datetime.utcnow()
-        api_tokens = []
-        for token in sorted(user.api_tokens, key=sort_key, reverse=True):
-            if token.expires_at and token.expires_at < now:
-                self.db.delete(token)
-                self.db.commit()
-                continue
-            api_tokens.append(token)
 
         # group oauth client tokens by client id
-        # AccessTokens have expires_at as an integer timestamp
-        now_timestamp = now.timestamp()
-        oauth_tokens = defaultdict(list)
-        for token in user.oauth_tokens:
-            if token.expires_at and token.expires_at < now_timestamp:
-                self.log.warning("Deleting expired token")
+        all_tokens = defaultdict(list)
+        for token in sorted(user.api_tokens, key=sort_key, reverse=True):
+            if token.expires_at and token.expires_at < now:
+                self.log.warning(f"Deleting expired token {token}")
                 self.db.delete(token)
                 self.db.commit()
                 continue
             if not token.client_id:
                 # token should have been deleted when client was deleted
-                self.log.warning("Deleting stale oauth token for %s", user.name)
+                self.log.warning("Deleting stale oauth token {token}")
                 self.db.delete(token)
                 self.db.commit()
                 continue
-            oauth_tokens[token.client_id].append(token)
+            all_tokens[token.client_id].append(token)
 
+        # individually list tokens issued by jupyterhub itself
+        api_tokens = all_tokens.pop("jupyterhub", [])
+
+        # group all other tokens issued under their owners
         # get the earliest created and latest last_activity
         # timestamp for a given oauth client
         oauth_clients = []
-        for client_id, tokens in oauth_tokens.items():
+
+        for client_id, tokens in all_tokens.items():
             created = tokens[0].created
             last_activity = tokens[0].last_activity
             for token in tokens[1:]:

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -345,18 +345,19 @@ class JupyterHubRequestValidator(RequestValidator):
         # FIXME: pick a role
         # this will be empty for now
         roles = list(self.db.query(orm.Role).filter_by(name='identify'))
-        orm_access_token = orm.APIToken.new(
+        # FIXME: support refresh tokens
+        # These should be in a new table
+        token.pop("refresh_token", None)
+
+        # APIToken.new commits the token to the db
+        orm.APIToken.new(
             client_id=client.identifier,
-            grant_type=orm.GrantType.authorization_code,
-            expires_at=orm.APIToken.now() + timedelta(seconds=token['expires_in']),
-            refresh_token=token['refresh_token'],
+            expires_in=token['expires_in'],
             roles=roles,
             token=token['access_token'],
             session_id=request.session_id,
             user=request.user,
         )
-        self.db.add(orm_access_token)
-        self.db.commit()
         return client.redirect_uri
 
     def validate_bearer_token(self, token, scopes, request):

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -342,13 +342,15 @@ class JupyterHubRequestValidator(RequestValidator):
             .filter_by(identifier=request.client.client_id)
             .first()
         )
+        # FIXME: pick a role
+        # this will be empty for now
+        roles = list(self.db.query(orm.Role).filter_by(name='identify'))
         orm_access_token = orm.APIToken.new(
             client_id=client.identifier,
             grant_type=orm.GrantType.authorization_code,
             expires_at=orm.APIToken.now() + timedelta(seconds=token['expires_in']),
             refresh_token=token['refresh_token'],
-            # TODO: save scopes,
-            # scopes=scopes,
+            roles=roles,
             token=token['access_token'],
             session_id=request.session_id,
             user=request.user,

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -277,9 +277,6 @@ class User(Base):
     last_activity = Column(DateTime, nullable=True)
 
     api_tokens = relationship("APIToken", backref="user", cascade="all, delete-orphan")
-    oauth_tokens = relationship(
-        "OAuthAccessToken", backref="user", cascade="all, delete-orphan"
-    )
     oauth_codes = relationship(
         "OAuthCode", backref="user", cascade="all, delete-orphan"
     )
@@ -485,7 +482,9 @@ class Hashed(Expiring):
     @classmethod
     def check_token(cls, db, token):
         """Check if a token is acceptable"""
+        print("checking", cls, token, len(token), cls.min_length)
         if len(token) < cls.min_length:
+            print("raising")
             raise ValueError(
                 "Tokens must be at least %i characters, got %r"
                 % (cls.min_length, token)
@@ -530,6 +529,20 @@ class Hashed(Expiring):
                 return orm_token
 
 
+# ------------------------------------
+# OAuth tables
+# ------------------------------------
+
+
+class GrantType(enum.Enum):
+    # we only use authorization_code for now
+    authorization_code = 'authorization_code'
+    implicit = 'implicit'
+    password = 'password'
+    client_credentials = 'client_credentials'
+    refresh_token = 'refresh_token'
+
+
 class APIToken(Hashed, Base):
     """An API token"""
 
@@ -547,6 +560,15 @@ class APIToken(Hashed, Base):
     @property
     def api_id(self):
         return 'a%i' % self.id
+
+    # added in 2.0
+    client_id = Column(
+        Unicode(255), ForeignKey('oauth_clients.identifier', ondelete='CASCADE')
+    )
+    grant_type = Column(Enum(GrantType), nullable=False)
+    refresh_token = Column(Unicode(255))
+    # the browser session id associated with a given token
+    session_id = Column(Unicode(255))
 
     # token metadata for bookkeeping
     now = datetime.utcnow  # for expiry
@@ -566,8 +588,12 @@ class APIToken(Hashed, Base):
             # this shouldn't happen
             kind = 'owner'
             name = 'unknown'
-        return "<{cls}('{pre}...', {kind}='{name}')>".format(
-            cls=self.__class__.__name__, pre=self.prefix, kind=kind, name=name
+        return "<{cls}('{pre}...', {kind}='{name}', client_id={client_id!r})>".format(
+            cls=self.__class__.__name__,
+            pre=self.prefix,
+            kind=kind,
+            name=name,
+            client_id=self.client_id,
         )
 
     @classmethod
@@ -588,6 +614,14 @@ class APIToken(Hashed, Base):
             raise ValueError("kind must be 'user', 'service', or None, not %r" % kind)
         for orm_token in prefix_match:
             if orm_token.match(token):
+                if not orm_token.client_id:
+                    app_log.warning(
+                        "Deleting stale oauth token for %s with no client",
+                        orm_token.user and orm_token.user.name,
+                    )
+                    db.delete(orm_token)
+                    db.commit()
+                    return
                 return orm_token
 
     @classmethod
@@ -600,6 +634,7 @@ class APIToken(Hashed, Base):
         note='',
         generated=True,
         expires_in=None,
+        client_id='jupyterhub',
     ):
         """Generate a new API token for a user or service"""
         assert user or service
@@ -614,7 +649,12 @@ class APIToken(Hashed, Base):
             cls.check_token(db, token)
         # two stages to ensure orm_token.generated has been set
         # before token setter is called
-        orm_token = cls(generated=generated, note=note or '')
+        orm_token = cls(
+            generated=generated,
+            note=note or '',
+            grant_type=GrantType.authorization_code,
+            client_id=client_id,
+        )
         orm_token.token = token
         if user:
             assert user.id is not None
@@ -639,76 +679,6 @@ class APIToken(Hashed, Base):
 
         db.commit()
         return token
-
-
-# ------------------------------------
-# OAuth tables
-# ------------------------------------
-
-
-class GrantType(enum.Enum):
-    # we only use authorization_code for now
-    authorization_code = 'authorization_code'
-    implicit = 'implicit'
-    password = 'password'
-    client_credentials = 'client_credentials'
-    refresh_token = 'refresh_token'
-
-
-class OAuthAccessToken(Hashed, Base):
-    __tablename__ = 'oauth_access_tokens'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-
-    @staticmethod
-    def now():
-        return datetime.utcnow().timestamp()
-
-    @property
-    def api_id(self):
-        return 'o%i' % self.id
-
-    client_id = Column(
-        Unicode(255), ForeignKey('oauth_clients.identifier', ondelete='CASCADE')
-    )
-    grant_type = Column(Enum(GrantType), nullable=False)
-    expires_at = Column(Integer)
-    refresh_token = Column(Unicode(255))
-    # TODO: drop refresh_expires_at. Refresh tokens shouldn't expire
-    refresh_expires_at = Column(Integer)
-    user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
-    service = None  # for API-equivalence with APIToken
-
-    # the browser session id associated with a given token
-    session_id = Column(Unicode(255))
-
-    # from Hashed
-    hashed = Column(Unicode(255), unique=True)
-    prefix = Column(Unicode(16), index=True)
-
-    created = Column(DateTime, default=datetime.utcnow)
-    last_activity = Column(DateTime, nullable=True)
-
-    def __repr__(self):
-        return "<{cls}('{prefix}...', client_id={client_id!r}, user={user!r}, expires_in={expires_in}>".format(
-            cls=self.__class__.__name__,
-            client_id=self.client_id,
-            user=self.user and self.user.name,
-            prefix=self.prefix,
-            expires_in=self.expires_in,
-        )
-
-    @classmethod
-    def find(cls, db, token):
-        orm_token = super().find(db, token)
-        if orm_token and not orm_token.client_id:
-            app_log.warning(
-                "Deleting stale oauth token for %s with no client",
-                orm_token.user and orm_token.user.name,
-            )
-            db.delete(orm_token)
-            db.commit()
-            return
-        return orm_token
 
 
 class OAuthCode(Expiring, Base):
@@ -752,7 +722,7 @@ class OAuthClient(Base):
         return self.identifier
 
     access_tokens = relationship(
-        OAuthAccessToken, backref='client', cascade='all, delete-orphan'
+        APIToken, backref='client', cascade='all, delete-orphan'
     )
     codes = relationship(OAuthCode, backref='client', cascade='all, delete-orphan')
 

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -51,6 +51,7 @@ from traitlets import Dict
 from traitlets import HasTraits
 from traitlets import Instance
 from traitlets import Unicode
+from traitlets import validate
 from traitlets.config import LoggingConfigurable
 
 from .. import orm
@@ -283,6 +284,15 @@ class Service(LoggingConfigurable):
     @default('oauth_client_id')
     def _default_client_id(self):
         return 'service-%s' % self.name
+
+    @validate("oauth_client_id")
+    def _validate_client_id(self, proposal):
+        if not proposal.value.startswith("service-"):
+            raise ValueError(
+                f"service {self.name} has oauth_client_id='{proposal.value}'."
+                " Service oauth client ids must start with 'service-'"
+            )
+        return proposal.value
 
     oauth_redirect_uri = Unicode(
         help="""OAuth redirect URI for this service.

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -125,16 +125,14 @@ def db():
     """Get a db session"""
     global _db
     if _db is None:
-        _db = orm.new_session_factory('sqlite:///:memory:')()
+        # make sure some initial db contents are filled out
+        # specifically, the 'default' jupyterhub oauth client
+        app = MockHub(db_url='sqlite:///:memory:')
+        app.init_db()
+        _db = app.db
         user = orm.User(name=getuser())
         _db.add(user)
         _db.commit()
-        # make sure some initial db contents are filled out
-        # specifically, the 'default' jupyterhub oauth client
-        app = MockHub()
-        app.db = _db
-        app.init_hub()
-        app.init_oauth()
     return _db
 
 

--- a/jupyterhub/tests/populate_db.py
+++ b/jupyterhub/tests/populate_db.py
@@ -6,6 +6,7 @@ used in test_db.py
 """
 import os
 from datetime import datetime
+from functools import partial
 
 import jupyterhub
 from jupyterhub import orm
@@ -69,13 +70,15 @@ def populate_db(url):
     db.add(code)
     db.commit()
     if jupyterhub.version_info < (2, 0):
-        Token = orm.OAuthAccessToken
+        Token = partial(
+            orm.OAuthAccessToken,
+            grant_type=orm.GrantType.authorization_code,
+        )
     else:
         Token = orm.APIToken
     access_token = Token(
         client_id=client.identifier,
         user_id=user.id,
-        grant_type=orm.GrantType.authorization_code,
     )
     db.add(access_token)
     db.commit()

--- a/jupyterhub/tests/populate_db.py
+++ b/jupyterhub/tests/populate_db.py
@@ -70,7 +70,11 @@ def populate_db(url):
         code = orm.OAuthCode(client_id=client.identifier)
         db.add(code)
         db.commit()
-        access_token = orm.OAuthAccessToken(
+        if jupyterhub.version_info < (2, 0):
+            Token = orm.OAuthAccessToken
+        else:
+            Token = orm.APIToken
+        access_token = Token(
             client_id=client.identifier,
             user_id=user.id,
             grant_type=orm.GrantType.authorization_code,

--- a/jupyterhub/tests/populate_db.py
+++ b/jupyterhub/tests/populate_db.py
@@ -62,36 +62,33 @@ def populate_db(url):
         db.commit()
 
     # create some oauth objects
-    if jupyterhub.version_info >= (0, 8):
-        # create oauth client
-        client = orm.OAuthClient(identifier='oauth-client')
-        db.add(client)
-        db.commit()
-        code = orm.OAuthCode(client_id=client.identifier)
-        db.add(code)
-        db.commit()
-        if jupyterhub.version_info < (2, 0):
-            Token = orm.OAuthAccessToken
-        else:
-            Token = orm.APIToken
-        access_token = Token(
-            client_id=client.identifier,
-            user_id=user.id,
-            grant_type=orm.GrantType.authorization_code,
-        )
-        db.add(access_token)
-        db.commit()
+    client = orm.OAuthClient(identifier='oauth-client')
+    db.add(client)
+    db.commit()
+    code = orm.OAuthCode(client_id=client.identifier)
+    db.add(code)
+    db.commit()
+    if jupyterhub.version_info < (2, 0):
+        Token = orm.OAuthAccessToken
+    else:
+        Token = orm.APIToken
+    access_token = Token(
+        client_id=client.identifier,
+        user_id=user.id,
+        grant_type=orm.GrantType.authorization_code,
+    )
+    db.add(access_token)
+    db.commit()
 
     # set some timestamps added in 0.9
-    if jupyterhub.version_info >= (0, 9):
-        assert user.created
-        assert admin.created
-        # set last_activity
-        user.last_activity = datetime.utcnow()
-        spawner = user.orm_spawners['']
-        spawner.started = datetime.utcnow()
-        spawner.last_activity = datetime.utcnow()
-        db.commit()
+    assert user.created
+    assert admin.created
+    # set last_activity
+    user.last_activity = datetime.utcnow()
+    spawner = user.orm_spawners['']
+    spawner.started = datetime.utcnow()
+    spawner.last_activity = datetime.utcnow()
+    db.commit()
 
 
 if __name__ == '__main__':

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -277,7 +277,6 @@ async def test_get_self(app):
         user=u.orm_user,
         client=oauth_client,
         token=token,
-        grant_type=orm.GrantType.authorization_code,
     )
     db.add(oauth_token)
     db.commit()

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -273,7 +273,7 @@ async def test_get_self(app):
     oauth_client = orm.OAuthClient(identifier='eurydice')
     db.add(oauth_client)
     db.commit()
-    oauth_token = orm.OAuthAccessToken(
+    oauth_token = orm.APIToken(
         user=u.orm_user,
         client=oauth_client,
         token=token,
@@ -1423,12 +1423,11 @@ async def test_token_list(app, as_user, for_user, status):
     if status != 200:
         return
     reply = r.json()
-    assert sorted(reply) == ['api_tokens', 'oauth_tokens']
+    assert sorted(reply) == ['api_tokens']
     assert len(reply['api_tokens']) == len(for_user_obj.api_tokens)
     assert all(token['user'] == for_user for token in reply['api_tokens'])
-    assert all(token['user'] == for_user for token in reply['oauth_tokens'])
     # validate individual token ids
-    for token in reply['api_tokens'] + reply['oauth_tokens']:
+    for token in reply['api_tokens']:
         r = await api_request(
             app, 'users', for_user, 'tokens', token['id'], headers=headers
         )

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -36,7 +36,7 @@ def generate_old_db(env_dir, hub_version, db_url):
     check_call([env_py, populate_db, db_url])
 
 
-@pytest.mark.parametrize('hub_version', ['0.7.2', '0.8.1', '0.9.4'])
+@pytest.mark.parametrize('hub_version', ['1.0.0', "1.2.2", "1.3.0"])
 async def test_upgrade(tmpdir, hub_version):
     db_url = os.getenv('JUPYTERHUB_TEST_DB_URL')
     if db_url:

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -355,7 +355,7 @@ def test_user_delete_cascade(db):
     spawner.server = server = orm.Server()
     oauth_code = orm.OAuthCode(client=oauth_client, user=user)
     db.add(oauth_code)
-    oauth_token = orm.OAuthAccessToken(
+    oauth_token = orm.APIToken(
         client=oauth_client, user=user, grant_type=orm.GrantType.authorization_code
     )
     db.add(oauth_token)
@@ -377,7 +377,7 @@ def test_user_delete_cascade(db):
     assert_not_found(db, orm.Spawner, spawner_id)
     assert_not_found(db, orm.Server, server_id)
     assert_not_found(db, orm.OAuthCode, oauth_code_id)
-    assert_not_found(db, orm.OAuthAccessToken, oauth_token_id)
+    assert_not_found(db, orm.APIToken, oauth_token_id)
 
 
 def test_oauth_client_delete_cascade(db):
@@ -391,12 +391,12 @@ def test_oauth_client_delete_cascade(db):
     # these should all be deleted automatically when the user goes away
     oauth_code = orm.OAuthCode(client=oauth_client, user=user)
     db.add(oauth_code)
-    oauth_token = orm.OAuthAccessToken(
+    oauth_token = orm.APIToken(
         client=oauth_client, user=user, grant_type=orm.GrantType.authorization_code
     )
     db.add(oauth_token)
     db.commit()
-    assert user.oauth_tokens == [oauth_token]
+    assert user.tokens == [oauth_token]
 
     # record all of the ids
     oauth_code_id = oauth_code.id
@@ -408,8 +408,8 @@ def test_oauth_client_delete_cascade(db):
 
     # verify that everything gets deleted
     assert_not_found(db, orm.OAuthCode, oauth_code_id)
-    assert_not_found(db, orm.OAuthAccessToken, oauth_token_id)
-    assert user.oauth_tokens == []
+    assert_not_found(db, orm.APIToken, oauth_token_id)
+    assert user.tokens == []
     assert user.oauth_codes == []
 
 
@@ -510,32 +510,32 @@ def test_expiring_api_token(app, user):
 def test_expiring_oauth_token(app, user):
     db = app.db
     token = "abc123"
-    now = orm.OAuthAccessToken.now
+    now = orm.APIToken.now
     client = orm.OAuthClient(identifier="xxx", secret="yyy")
     db.add(client)
-    orm_token = orm.OAuthAccessToken(
+    orm_token = orm.APIToken(
         token=token,
         grant_type=orm.GrantType.authorization_code,
         client=client,
         user=user,
-        expires_at=now() + 30,
+        expires_at=now() + datetime.timedelta(seconds=30),
     )
     db.add(orm_token)
     db.commit()
 
-    found = orm.OAuthAccessToken.find(db, token)
+    found = orm.APIToken.find(db, token)
     assert found is orm_token
     # purge_expired doesn't delete non-expired
-    orm.OAuthAccessToken.purge_expired(db)
-    found = orm.OAuthAccessToken.find(db, token)
+    orm.APIToken.purge_expired(db)
+    found = orm.APIToken.find(db, token)
     assert found is orm_token
 
-    with mock.patch.object(orm.OAuthAccessToken, 'now', lambda: now() + 60):
-        found = orm.OAuthAccessToken.find(db, token)
+    with mock.patch.object(orm.APIToken, 'now', lambda: now() + 60):
+        found = orm.APIToken.find(db, token)
         assert found is None
-        assert orm_token in db.query(orm.OAuthAccessToken)
-        orm.OAuthAccessToken.purge_expired(db)
-        assert orm_token not in db.query(orm.OAuthAccessToken)
+        assert orm_token in db.query(orm.APIToken)
+        orm.APIToken.purge_expired(db)
+        assert orm_token not in db.query(orm.APIToken)
 
 
 def test_expiring_oauth_code(app, user):

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -356,7 +356,8 @@ def test_user_delete_cascade(db):
     oauth_code = orm.OAuthCode(client=oauth_client, user=user)
     db.add(oauth_code)
     oauth_token = orm.APIToken(
-        client=oauth_client, user=user, grant_type=orm.GrantType.authorization_code
+        client=oauth_client,
+        user=user,
     )
     db.add(oauth_token)
     db.commit()
@@ -392,11 +393,12 @@ def test_oauth_client_delete_cascade(db):
     oauth_code = orm.OAuthCode(client=oauth_client, user=user)
     db.add(oauth_code)
     oauth_token = orm.APIToken(
-        client=oauth_client, user=user, grant_type=orm.GrantType.authorization_code
+        client=oauth_client,
+        user=user,
     )
     db.add(oauth_token)
     db.commit()
-    assert user.tokens == [oauth_token]
+    assert user.api_tokens == [oauth_token]
 
     # record all of the ids
     oauth_code_id = oauth_code.id
@@ -409,7 +411,7 @@ def test_oauth_client_delete_cascade(db):
     # verify that everything gets deleted
     assert_not_found(db, orm.OAuthCode, oauth_code_id)
     assert_not_found(db, orm.APIToken, oauth_token_id)
-    assert user.tokens == []
+    assert user.api_tokens == []
     assert user.oauth_codes == []
 
 
@@ -515,10 +517,9 @@ def test_expiring_oauth_token(app, user):
     db.add(client)
     orm_token = orm.APIToken(
         token=token,
-        grant_type=orm.GrantType.authorization_code,
         client=client,
         user=user,
-        expires_at=now() + datetime.timedelta(seconds=30),
+        expires_at=now() + timedelta(seconds=30),
     )
     db.add(orm_token)
     db.commit()
@@ -530,7 +531,7 @@ def test_expiring_oauth_token(app, user):
     found = orm.APIToken.find(db, token)
     assert found is orm_token
 
-    with mock.patch.object(orm.APIToken, 'now', lambda: now() + 60):
+    with mock.patch.object(orm.APIToken, 'now', lambda: now() + timedelta(seconds=60)):
         found = orm.APIToken.find(db, token)
         assert found is None
         assert orm_token in db.query(orm.APIToken)

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -870,7 +870,8 @@ async def test_oauth_token_page(app):
     client = orm.OAuthClient(identifier='token')
     app.db.add(client)
     oauth_token = orm.APIToken(
-        client=client, user=user, grant_type=orm.GrantType.authorization_code
+        client=client,
+        user=user,
     )
     app.db.add(oauth_token)
     app.db.commit()

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -869,7 +869,7 @@ async def test_oauth_token_page(app):
     user = app.users[orm.User.find(app.db, name)]
     client = orm.OAuthClient(identifier='token')
     app.db.add(client)
-    oauth_token = orm.OAuthAccessToken(
+    oauth_token = orm.APIToken(
         client=client, user=user, grant_type=orm.GrantType.authorization_code
     )
     app.db.add(oauth_token)

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -444,11 +444,7 @@ async def test_oauth_logout(app, mockservice_url):
 
     def auth_tokens():
         """Return list of OAuth access tokens for the user"""
-        return list(
-            app.db.query(orm.OAuthAccessToken).filter(
-                orm.OAuthAccessToken.user_id == app_user.id
-            )
-        )
+        return list(app.db.query(orm.APIToken).filter_by(user_id=app_user.id))
 
     # ensure we start empty
     assert auth_tokens() == []


### PR DESCRIPTION
With RBAC attaching scopes to tokens, we no longer need a distinction between OAuth tokens and other API tokens. Instead, the goal of separate OAuth tokens is achieved by a

- [x] remove OAuthAccessToken
- [x] merge oauth-related columns from OAuthAccessToken into APIToken
- [x] create oauth client 'jupyterhub' which owns tokens issued by the hub itself
- [ ] set appropriate scopes on oauth-issued tokens to match current behavior of limited permissions (read:user:name, read:user:groups)
- [ ] make access token scopes configurable?

db upgrade is currently achieved by dropping both token tables, forcing issuing of fresh tokens on next hub start. Migration will be very complicated if we want to do it (filling out default scopes, etc.), but without it, this will be our most disruptive upgrade yet.