### PR TITLE
Stop specifying `--ip` and `--port` on the command-line

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -899,7 +899,7 @@ Bugfixes on 0.6:
 
 ### [0.6.0] - 2016-04-25
 
-- JupyterHub has moved to a new `jupyterhub` namespace on GitHub and Docker. What was `juptyer/jupyterhub` is now `jupyterhub/jupyterhub`, etc.
+- JupyterHub has moved to a new `jupyterhub` namespace on GitHub and Docker. What was `jupyter/jupyterhub` is now `jupyterhub/jupyterhub`, etc.
 - `jupyterhub/jupyterhub` image on DockerHub no longer loads the jupyterhub_config.py in an ONBUILD step. A new `jupyterhub/jupyterhub-onbuild` image does this
 - Add statsd support, via `c.JupyterHub.statsd_{host,port,prefix}`
 - Update to traitlets 4.1 `@default`, `@observe` APIs for traits

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -402,7 +402,7 @@ class SingleUserNotebookAppMixin(Configurable):
         return value
 
     @default('log_level')
-    def _log_level_defaul(self):
+    def _log_level_default(self):
         if _bool_env("JUPYTERHUB_DEBUG"):
             return logging.DEBUG
         else:

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -999,17 +999,6 @@ class Spawner(LoggingConfigurable):
         """
         args = []
 
-        if self.ip:
-            args.append('--ip=%s' % _quote_safe(self.ip))
-
-        if self.port:
-            args.append('--port=%i' % self.port)
-        elif self.server and self.server.port:
-            self.log.warning(
-                "Setting port from user.server is deprecated as of JupyterHub 0.7."
-            )
-            args.append('--port=%i' % self.server.port)
-
         if self.notebook_dir:
             notebook_dir = self.format_string(self.notebook_dir)
             args.append('--notebook-dir=%s' % _quote_safe(notebook_dir))

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -565,10 +565,17 @@ async def test_spawn(app):
     r = await async_requests.get(ujoin(url, 'args'), **kwargs)
     assert r.status_code == 200
     argv = r.json()
-    assert '--port' in ' '.join(argv)
+    assert '--port' not in ' '.join(argv)
+    # we pass no CLI args anymore:
+    assert len(argv) == 1
     r = await async_requests.get(ujoin(url, 'env'), **kwargs)
     env = r.json()
-    for expected in ['JUPYTERHUB_USER', 'JUPYTERHUB_BASE_URL', 'JUPYTERHUB_API_TOKEN']:
+    for expected in [
+        'JUPYTERHUB_USER',
+        'JUPYTERHUB_BASE_URL',
+        'JUPYTERHUB_API_TOKEN',
+        'JUPYTERHUB_SERVICE_URL',
+    ]:
         assert expected in env
     if app.subdomain_host:
         assert env['JUPYTERHUB_HOST'] == app.subdomain_host


### PR DESCRIPTION
JUPYTERHUB_SERVICE_URL env is already enough and has been around for some time

Specifying CLI args can cause some issues for custom commands

closes jupyterhub/dockerspawner#319