### PR TITLE
alpine dockerfile: avoid compilation by getting some deps from apk

### DIFF
--- a/dockerfiles/Dockerfile.alpine
+++ b/dockerfiles/Dockerfile.alpine
@@ -1,9 +1,14 @@
-FROM python:3.6.3-alpine3.6
-
-ARG JUPYTERHUB_VERSION=0.8.1
-
-RUN pip3 install --no-cache jupyterhub==${JUPYTERHUB_VERSION}
+FROM alpine:3.13
 ENV LANG=en_US.UTF-8
+RUN apk add --no-cache \
+        python3 \
+        py3-pip \
+        py3-ruamel.yaml \
+        py3-cryptography \
+        py3-sqlalchemy
+
+ARG JUPYTERHUB_VERSION=1.3.0
+RUN pip3 install --no-cache jupyterhub==${JUPYTERHUB_VERSION}
 
 USER nobody
 CMD ["jupyterhub"]


### PR DESCRIPTION
cryptography is the big one, which needs rust and is a huge pain

The latest release of cryptography is causing our dockerfile tests to fail on CI, due to the added requirement of rust

this simplifies the dockerfile and makes everything faster and smaller by getting a few compiled dependencies from apk