### PR TITLE
[rbac] ensure /authorizations/token can read the owner model of the token itself

### DIFF
--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -185,3 +185,25 @@ def needs_scope(*scopes):
         return _auth_func
 
     return scope_decorator
+
+
+def identify_scopes(obj):
+    """Return 'identify' scopes for an orm object
+
+    Arguments:
+      obj: orm.User or orm.Service
+
+    Returns:
+      scopes (set): set of scopes needed for 'identify' endpoints
+    """
+    if isinstance(obj, orm.User):
+        return {
+            f"read:users:{field}!user={obj.name}"
+            for field in {"name", "admin", "groups"}
+        }
+    elif isinstance(obj, orm.Service):
+        return {
+            f"read:services:{field}!service={obj.name}" for field in {"name", "admin"}
+        }
+    else:
+        raise TypeError(f"Expected orm.User or orm.Service, got {obj!r}")

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -85,6 +85,8 @@ class MockAPIHandler:
     def __init__(self):
         self.raw_scopes = {'users'}
         self.parsed_scopes = {}
+        self.request = mock.Mock(spec=HTTPServerRequest)
+        self.request.path = '/path'
 
     @needs_scope('users')
     def user_thing(self, user_name):
@@ -169,7 +171,6 @@ class MockAPIHandler:
 def test_scope_method_access(scopes, method, arguments, is_allowed):
     obj = MockAPIHandler()
     obj.current_user = mock.Mock(name=arguments[0])
-    obj.request = mock.Mock(spec=HTTPServerRequest)
     obj.raw_scopes = set(scopes)
     obj.parsed_scopes = parse_scopes(obj.raw_scopes)
     api_call = getattr(obj, method)
@@ -183,7 +184,6 @@ def test_scope_method_access(scopes, method, arguments, is_allowed):
 def test_double_scoped_method_succeeds():
     obj = MockAPIHandler()
     obj.current_user = mock.Mock(name='lucille')
-    obj.request = mock.Mock(spec=HTTPServerRequest)
     obj.raw_scopes = {'users', 'read:services'}
     obj.parsed_scopes = parse_scopes(obj.raw_scopes)
     assert obj.secret_thing()
@@ -192,7 +192,6 @@ def test_double_scoped_method_succeeds():
 def test_double_scoped_method_denials():
     obj = MockAPIHandler()
     obj.current_user = mock.Mock(name='lucille2')
-    obj.request = mock.Mock(spec=HTTPServerRequest)
     obj.raw_scopes = {'users', 'read:groups'}
     obj.parsed_scopes = parse_scopes(obj.raw_scopes)
     with pytest.raises(web.HTTPError):


### PR DESCRIPTION
This fixes the failing rbac test

The case was when one user attempts to access the other user's server, an API request is made to:

`/api/authorizations/token/:visitor-token` with the server owner's token in the Authorization header.

This meant there were really two tokens involved in the same request, and if the server didn't have permission to read the visitor's user model, the return would be an empty dict instead of the visitor's name, etc.

Ensuring that the token owner's read scope is added prior to resolving the model fixes this,
but we should really deprecate this strategy in favor of user `/api/user` 'self' handler to resolve token owners.
That would be much more like other OAuth providers. We can also take this big refactor opportunity to remove the old 'shared cookie' auth that has been deprecated for a long time. I will take a stab at that.