### PR TITLE
[rbac] Add temporary default service role (no scopes)

### DIFF
--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -42,6 +42,11 @@ def get_default_roles():
             'description': 'Token with same rights as token owner',
             'scopes': ['all'],
         },
+        {
+            'name': 'service',
+            'description': 'Temporary no scope role for services',
+            'scopes': [],
+        },
     ]
     return default_roles
 
@@ -218,9 +223,13 @@ def remove_obj(db, objname, kind, rolename):
 
 
 def switch_default_role(db, obj, kind, admin):
-    """Switch between default user and admin roles for users/services"""
+    """Switch between default user/service and admin roles for users/services"""
 
     user_role = orm.Role.find(db, 'user')
+    # temporary fix of default service role
+    if kind == 'services':
+        user_role = orm.Role.find(db, 'service')
+
     admin_role = orm.Role.find(db, 'admin')
 
     def add_and_remove(db, obj, kind, current_role, new_role):


### PR DESCRIPTION
Changes default role assignment for services from `user` to temporarily added `service` role with no scopes. 

Admin services still gain `admin` role as default. 