### PR TITLE
avoid deprecated engine.table_names

### DIFF
--- a/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
+++ b/jupyterhub/alembic/versions/1cebaf56856c_session_id.py
@@ -23,7 +23,7 @@ tables = ('oauth_access_tokens', 'oauth_codes')
 
 def add_column_if_table_exists(table, column):
     engine = op.get_bind().engine
-    if table not in engine.table_names():
+    if table not in sa.inspect(engine).get_table_names():
         # table doesn't exist, no need to upgrade
         # because jupyterhub will create it on launch
         logger.warning("Skipping upgrade of absent table: %s", table)

--- a/jupyterhub/alembic/versions/4dc2d5a8c53c_user_options.py
+++ b/jupyterhub/alembic/versions/4dc2d5a8c53c_user_options.py
@@ -17,7 +17,8 @@ from jupyterhub.orm import JSONDict
 
 
 def upgrade():
-    tables = op.get_bind().engine.table_names()
+    engine = op.get_bind().engine
+    tables = sa.inspect(engine).get_table_names()
     if 'spawners' in tables:
         op.add_column('spawners', sa.Column('user_options', JSONDict()))
 

--- a/jupyterhub/alembic/versions/56cc5a70207e_token_tracking.py
+++ b/jupyterhub/alembic/versions/56cc5a70207e_token_tracking.py
@@ -20,7 +20,8 @@ logger = logging.getLogger('alembic')
 
 
 def upgrade():
-    tables = op.get_bind().engine.table_names()
+    engine = op.get_bind().engine
+    tables = sa.inspect(engine).get_table_names()
     op.add_column('api_tokens', sa.Column('created', sa.DateTime(), nullable=True))
     op.add_column(
         'api_tokens', sa.Column('last_activity', sa.DateTime(), nullable=True)

--- a/jupyterhub/alembic/versions/99a28a4418e1_user_created.py
+++ b/jupyterhub/alembic/versions/99a28a4418e1_user_created.py
@@ -31,7 +31,7 @@ def upgrade():
         % (now,)
     )
 
-    tables = c.engine.table_names()
+    tables = sa.inspect(c.engine).get_table_names()
 
     if 'spawners' in tables:
         op.add_column('spawners', sa.Column('started', sa.DateTime, nullable=True))

--- a/jupyterhub/alembic/versions/d68c98b66cd4_client_description.py
+++ b/jupyterhub/alembic/versions/d68c98b66cd4_client_description.py
@@ -16,7 +16,8 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    tables = op.get_bind().engine.table_names()
+    engine = op.get_bind().engine
+    tables = sa.inspect(engine).get_table_names()
     if 'oauth_clients' in tables:
         op.add_column(
             'oauth_clients', sa.Column('description', sa.Unicode(length=1023))

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -768,7 +768,7 @@ def check_db_revision(engine):
     - Empty databases are tagged with the current revision
     """
     # Check database schema version
-    current_table_names = set(engine.table_names())
+    current_table_names = set(inspect(engine).get_table_names())
     my_table_names = set(Base.metadata.tables.keys())
 
     from .dbutil import _temp_alembic_ini


### PR DESCRIPTION
deprecated in sqlalchemy 1.4

use `inspect(engine).get_table_names()` instead, as recommended by the deprecation warning. This appears to be available in all supported sqlalchemy versions.