### PR TITLE
Added Azure AD as a supported authenticator.

### DIFF
--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -91,7 +91,6 @@ JupyterHub's [OAuthenticator][] currently supports the following
 popular services:
 
 - Auth0
-- AzureAD
 - Bitbucket
 - CILogon
 - GitHub

--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -91,6 +91,7 @@ JupyterHub's [OAuthenticator][] currently supports the following
 popular services:
 
 - Auth0
+- AzureAD
 - Bitbucket
 - CILogon
 - GitHub

--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -91,6 +91,7 @@ JupyterHub's [OAuthenticator][] currently supports the following
 popular services:
 
 - Auth0
+- Azure AD
 - Bitbucket
 - CILogon
 - GitHub


### PR DESCRIPTION
Azure AD is listed as a supported service in OAuthenticators README.md, but it is not listed in the JupyterHub documents.