### PR TITLE
Don't delete all oauth clients on startup

### DIFF
--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -563,7 +563,6 @@ class JupyterHubOAuthServer(WebApplicationServer):
         # so we do this manually. It's protected inside a
         # transaction, so should fail if there are multiple
         # rows with the same identifier.
-        # TODO: Is this safe?
         orm_client = (
             self.db.query(orm.OAuthClient).filter_by(identifier=client_id).one_or_none()
         )
@@ -571,11 +570,13 @@ class JupyterHubOAuthServer(WebApplicationServer):
             orm_client = orm.OAuthClient(
                 identifier=client_id,
             )
-
+            self.db.add(orm_client)
+            app_log.info(f'Creating oauth client {client_id}')
+        else:
+            app_log.info(f'Updating oauth client {client_id}')
         orm_client.secret = hash_token(client_secret)
         orm_client.redirect_uri = redirect_uri
         orm_client.description = description
-        self.db.add(orm_client)
         self.db.commit()
 
     def fetch_by_client_id(self, client_id):


### PR DESCRIPTION
When an oauth client changes, we delete all the tokens
associated with that client. This invalidates all user sessions
for that oauth client, and the oauth client's users will need to
go through the OAuth workflow again after the cache period (specified
by cache_max_age in HubAuth, 5min by default). This is fine in theory,
since oauth client information doesn't change frequently.

However, we were deleting and re-adding all oauth clients each time
the hub started! This was unnecessary, since the data was going to
be the same 99% of the time. Rest of the time, we should just update,
preventing unnecessary churn.

This PR does that.

Ref https://github.com/yuvipanda/jupyterhub-configurator/issues/2
Ref https://github.com/berkeley-dsep-infra/datahub/issues/2284
Chat Log starting at https://gitter.im/jupyterhub/jupyterhub?at=606eda5446a93d4a19b30e46