### PR TITLE
make oauth token expiry configurable

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -358,8 +358,10 @@ class JupyterHub(Application):
     ).tag(config=True)
 
     oauth_token_expires_in = Integer(
-        24 * 3600,
         help="""Expiry (in seconds) of OAuth access tokens.
+
+        The default is to expire when the cookie storing them expires,
+        according to `cookie_max_age_days` config.
 
         These are the tokens stored in cookies when you visit
         a single-user server or service.
@@ -376,11 +378,19 @@ class JupyterHub(Application):
         .. versionadded:: 1.4
             OAuth token expires_in was not previously configurable.
         .. versionchanged:: 1.4
-            Default is now one day.
+            Default now uses cookie_max_age_days so that oauth tokens
+            which are generally stored in cookies,
+            expire when the cookies storing them expire.
             Previously, it was one hour.
         """,
         config=True,
     )
+
+    @default("oauth_token_expires_in")
+    def _cookie_max_age_seconds(self):
+        """default to cookie max age, where these tokens are stored"""
+        # convert cookie max age days to seconds
+        return int(self.cookie_max_age_days * 24 * 3600)
 
     redirect_to_server = Bool(
         True, help="Redirect user to server (if running), instead of control panel."

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -356,6 +356,32 @@ class JupyterHub(Application):
         Default is two weeks.
         """,
     ).tag(config=True)
+
+    oauth_token_expires_in = Integer(
+        24 * 3600,
+        help="""Expiry (in seconds) of OAuth access tokens.
+
+        These are the tokens stored in cookies when you visit
+        a single-user server or service.
+        When they expire, you must re-authenticate with the Hub,
+        even if your Hub authentication is still valid.
+        If your Hub authentication is valid,
+        logging in may be a transparent redirect as you refresh the page.
+        
+        This does not affect JupyterHub API tokens in general,
+        which do not expire by default.
+        Only tokens issued during the oauth flow
+        accessing services and single-user servers are affected.
+
+        .. versionadded:: 1.4
+            OAuth token expires_in was not previously configurable.
+        .. versionchanged:: 1.4
+            Default is now one day.
+            Previously, it was one hour.
+        """,
+        config=True,
+    )
+
     redirect_to_server = Bool(
         True, help="Redirect user to server (if running), instead of control panel."
     ).tag(config=True)
@@ -2164,6 +2190,7 @@ class JupyterHub(Application):
             lambda: self.db,
             url_prefix=url_path_join(base_url, 'api/oauth2'),
             login_url=url_path_join(base_url, 'login'),
+            token_expires_in=self.oauth_token_expires_in,
         )
 
     def cleanup_oauth_clients(self):

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -584,9 +584,9 @@ class JupyterHubOAuthServer(WebApplicationServer):
         return self.db.query(orm.OAuthClient).filter_by(identifier=client_id).first()
 
 
-def make_provider(session_factory, url_prefix, login_url):
+def make_provider(session_factory, url_prefix, login_url, **oauth_server_kwargs):
     """Make an OAuth provider"""
     db = session_factory()
     validator = JupyterHubRequestValidator(db)
-    server = JupyterHubOAuthServer(db, validator)
+    server = JupyterHubOAuthServer(db, validator, **oauth_server_kwargs)
     return server

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -475,6 +475,10 @@ async def test_oauth_logout(app, mockservice_url):
     session_id = s.cookies['jupyterhub-session-id']
 
     assert len(auth_tokens()) == 1
+    token = auth_tokens()[0]
+    assert token.expires_in is not None
+    # verify that oauth_token_expires_in has its desired effect
+    assert abs(app.oauth_token_expires_in - token.expires_in) < 30
 
     # hit hub logout URL
     r = await s.get(public_url(app, path='hub/logout'))


### PR DESCRIPTION
and default to cookie_max_age_days instead of 1 hour, since it makes sense for the token in the cookie to expire when the cookie itself is set to expire.