### PR TITLE
Fix link to jupyterhub/jupyterhub-the-hard-way

### DIFF
--- a/docs/source/installation-guide-hard.rst
+++ b/docs/source/installation-guide-hard.rst
@@ -3,4 +3,4 @@
 JupyterHub the hard way
 =======================
 
-This guide has moved to https://github.com/manics/jupyterhub-the-hard-way/blob/jupyterhub-alternative-doc/docs/installation-guide-hard.md
+This guide has moved to https://github.com/jupyterhub/jupyterhub-the-hard-way/blob/master/docs/installation-guide-hard.md


### PR DESCRIPTION
I managed to mess up the link in my last PR