### PR TITLE
Log the exception raised in Spawner.post_stop_hook instead of raising it

### DIFF
--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -826,10 +826,7 @@ class User:
             try:
                 await maybe_future(spawner.run_post_stop_hook())
             except:
-                spawner.clear_state()
-                spawner.orm_spawner.state = spawner.get_state()
-                self.db.commit()
-                raise
+                self.log.exception("Error in Spawner.post_stop_hook for %s", self)
             spawner.clear_state()
             spawner.orm_spawner.state = spawner.get_state()
             self.db.commit()


### PR DESCRIPTION
When an exception is raised in the asynchronous Spawner.post_stop_hook, spawner._stop_pending is not changed to False in some cases. This prevents the spawner from spawning until the Hub process restarts.
For example, the asynchronous Spawner.post_stop_hook is called in the user_stopped function in the base.py file, but spawner._stop_pending is not modified to False when the exception is raised.
The exception raised in Spawner.post_stop_hook should not block the subsequent logic of spawner stop. So a reasonable way to solve the above problem is to log the exception instead of raising it.