### PR TITLE
login-template: Add a "login_container" block inside the div-container.

### DIFF
--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -10,6 +10,7 @@
 
 {% block login %}
 <div id="login-main" class="container">
+{% block login_container %}
 {% if custom_html %}
 {{ custom_html | safe }}
 {% elif login_service %}
@@ -83,6 +84,7 @@
   </div>
 </form>
 {% endif %}
+{% endblock login_container %}
 </div>
 {% endblock login %}
 


### PR DESCRIPTION
This allows for more flexible customization of the login page,
since it allows to re-use the login form in an extending template
by reusing the new block.

This was not cleanly possible before since the main container
was part of the very same block as the form code.

fixes #3414