### PR TITLE
Disable docker jupyterhub-demo arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,23 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-20.04
+
+    services:
+      # So that we can test this in PRs/branches
+      local-registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
     steps:
-      - name: Should we push this image to a registry?
+      - name: Should we push this image to a public registry?
         run: |
-          echo "PUSH_IMAGE=${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master') }}" >> $GITHUB_ENV
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master') }}" = "true" ]; then
+              # Empty => Docker Hub
+              echo "REGISTRY=" >> $GITHUB_ENV
+          else
+              echo "REGISTRY=localhost:5000/" >> $GITHUB_ENV
+          fi
 
       - uses: actions/checkout@v2
 
@@ -86,11 +99,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          # Allows pushing to registry on localhost:5000
+          driver-opts: network=host
 
       # https://github.com/docker/login-action/tree/v1.8.0#docker-hub
       - name: Login to Docker Hub
         uses: docker/login-action@v1
-        if: ${{ env.PUSH_IMAGE == 'true' }}
+        if: env.REGISTRY != 'localhost:5000/'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -107,14 +123,14 @@ jobs:
         uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          prefix: "jupyterhub/jupyterhub:"
+          prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub:"
 
       - name: Build and push jupyterhub
         uses: docker/build-push-action@v2
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ env.PUSH_IMAGE == 'true' }}
+          push: true
           # tags parameter must be a string input so convert `gettags` JSON
           # array into a comma separated list of tags
           tags: ${{ join(fromJson(steps.jupyterhubtags.outputs.tags)) }}
@@ -126,10 +142,9 @@ jobs:
         uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          prefix: "jupyterhub-onbuild/jupyterhub:"
+          prefix: "${{ env.REGISTRY }}jupyterhub-onbuild/jupyterhub:"
 
       - name: Build and push jupyterhub-onbuild
-        if: ${{ env.PUSH_IMAGE == 'true' }}
         uses: docker/build-push-action@v2
         with:
           build-args: |
@@ -146,10 +161,9 @@ jobs:
         uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          prefix: "jupyterhub-demo/jupyterhub:"
+          prefix: "${{ env.REGISTRY }}jupyterhub-demo/jupyterhub:"
 
       - name: Build and push jupyterhub-demo
-        if: ${{ env.PUSH_IMAGE == 'true' }}
         uses: docker/build-push-action@v2
         with:
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,11 @@ jobs:
       # If GITHUB_TOKEN isn't available (e.g. in PRs) returns no tags [].
       - name: Get list of jupyterhub tags
         id: jupyterhubtags
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: manics/action-major-minor-tag-calculator@noref
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub:"
+          defaultTag: "${{ env.REGISTRY }}jupyterhub/jupyterhub:noref"
 
       - name: Build and push jupyterhub
         uses: docker/build-push-action@v2
@@ -139,10 +140,11 @@ jobs:
 
       - name: Get list of jupyterhub-onbuild tags
         id: onbuildtags
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: manics/action-major-minor-tag-calculator@noref
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub-onbuild/jupyterhub:"
+          defaultTag: "${{ env.REGISTRY }}jupyterhub-onbuild/jupyterhub:noref"
 
       - name: Build and push jupyterhub-onbuild
         uses: docker/build-push-action@v2
@@ -158,10 +160,11 @@ jobs:
 
       - name: Get list of jupyterhub-demo tags
         id: demotags
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: manics/action-major-minor-tag-calculator@noref
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub-demo/jupyterhub:"
+          defaultTag: "${{ env.REGISTRY }}jupyterhub-demo/jupyterhub:noref"
 
       - name: Build and push jupyterhub-demo
         uses: docker/build-push-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       # If GITHUB_TOKEN isn't available (e.g. in PRs) returns no tags [].
       - name: Get list of jupyterhub tags
         id: jupyterhubtags
-        uses: manics/action-major-minor-tag-calculator@noref
+        uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub:"
@@ -140,7 +140,7 @@ jobs:
 
       - name: Get list of jupyterhub-onbuild tags
         id: onbuildtags
-        uses: manics/action-major-minor-tag-calculator@noref
+        uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub-onbuild/jupyterhub:"
@@ -160,7 +160,7 @@ jobs:
 
       - name: Get list of jupyterhub-demo tags
         id: demotags
-        uses: manics/action-major-minor-tag-calculator@noref
+        uses: jupyterhub/action-major-minor-tag-calculator@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub-demo/jupyterhub:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       # If GITHUB_TOKEN isn't available (e.g. in PRs) returns no tags [].
       - name: Get list of jupyterhub tags
         id: jupyterhubtags
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: jupyterhub/action-major-minor-tag-calculator@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub:"
@@ -140,7 +140,7 @@ jobs:
 
       - name: Get list of jupyterhub-onbuild tags
         id: onbuildtags
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: jupyterhub/action-major-minor-tag-calculator@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub-onbuild/jupyterhub:"
@@ -160,7 +160,7 @@ jobs:
 
       - name: Get list of jupyterhub-demo tags
         id: demotags
-        uses: jupyterhub/action-major-minor-tag-calculator@main
+        uses: jupyterhub/action-major-minor-tag-calculator@v1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub-demo/jupyterhub:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,9 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ fromJson(steps.onbuildtags.outputs.tags)[0] }}
           context: demo-image
-          platforms: linux/amd64,linux/arm64
+          # linux/arm64 currently fails:
+          # ERROR: Could not build wheels for argon2-cffi which use PEP 517 and cannot be installed directly
+          # ERROR: executor failed running [/bin/sh -c python3 -m pip install notebook]: exit code: 1
+          platforms: linux/amd64
           push: true
           tags: ${{ join(fromJson(steps.demotags.outputs.tags)) }}


### PR DESCRIPTION
Fixes an issue from https://github.com/jupyterhub/jupyterhub/pull/3421

The `jupyterhub-demo` image requires the `notebook` package, but not all dependencies are available as wheels for arm64 so I've disabled the arm64 build of that image for now. I've also added a localhost registry so that pushes always occur- this is needed because when `docker buildx` builds multiple platforms you can't load the images into the local docker engine so AFAIK there's no way to reference them in a subsequent build step without a registry.

The other build failure after merging was related to whether the GitHub secrets have permission to push to `jupyterhub/jupyterhub-onbuild` and `jupyterhub/jupyterhub-demo`... let's see

- [x] Requires https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/66