### PR TITLE
[rbac] Fix log message for modifying existing roles

### DIFF
--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -221,8 +221,11 @@ def _overwrite_role(role, role_dict):
                     'admin role description or scopes cannot be overwritten'
                 )
             else:
-                setattr(role, attr, role_dict[attr])
-                app_log.info('Role %r %r attribute has been changed', role.name, attr)
+                if role_dict[attr] != getattr(role, attr):
+                    setattr(role, attr, role_dict[attr])
+                    app_log.info(
+                        'Role %r %r attribute has been changed', role.name, attr
+                    )
 
 
 def create_role(db, role_dict):

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -154,8 +154,6 @@ def _expand_scope(scopename):
 
 
 def expand_roles_to_scopes(orm_object):
-    """Get the scopes listed in the roles of the User/Service/Group/Token"""
-    scopes = _get_subscopes(*orm_object.roles)
     """Get the scopes listed in the roles of the User/Service/Group/Token
     If User, take into account the user's groups roles as well"""
 

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -246,6 +246,16 @@ async def test_load_default_roles(tmpdir, request):
             'info',
             app_log.info('Role new-role added to database'),
         ),
+        (
+            'the-same-role',
+            {
+                'name': 'new-role',
+                'description': 'Some description',
+                'scopes': ['groups'],
+            },
+            'no-log',
+            None,
+        ),
         ('no_name', {'scopes': ['users']}, 'error', KeyError),
         (
             'no_scopes',
@@ -271,34 +281,42 @@ async def test_load_default_roles(tmpdir, request):
             'info',
             app_log.info('Role user scopes attribute has been changed'),
         ),
+        # rewrite the user role back to 'default'
+        (
+            'user',
+            {'name': 'user', 'scopes': ['self']},
+            'info',
+            app_log.info('Role user scopes attribute has been changed'),
+        ),
     ],
 )
-async def test_adding_new_roles(
-    tmpdir, request, role, role_def, response_type, response
-):
-    """Test raising errors and warnings when creating new roles"""
+async def test_creating_roles(app, role, role_def, response_type, response):
+    """Test raising errors and warnings when creating/modifying roles"""
 
-    kwargs = {'load_roles': [role_def]}
-    ssl_enabled = getattr(request.module, "ssl_enabled", False)
-    if ssl_enabled:
-        kwargs['internal_certs_location'] = str(tmpdir)
-    hub = MockHub(**kwargs)
-    hub.init_db()
-    db = hub.db
+    db = app.db
 
     if response_type == 'error':
         with pytest.raises(response):
-            await hub.init_roles()
+            roles.create_role(db, role_def)
 
     elif response_type == 'warning' or response_type == 'info':
         with pytest.warns(response):
-            await hub.init_roles()
+            roles.create_role(db, role_def)
+        # check the role has been created/modified
         role = orm.Role.find(db, role_def['name'])
         assert role is not None
         if 'description' in role_def.keys():
             assert role.description == role_def['description']
         if 'scopes' in role_def.keys():
             assert role.scopes == role_def['scopes']
+
+    # make sure no warnings/info logged when the role exists and its definition hasn't been changed
+    elif response_type == 'no-log':
+        with pytest.warns(response) as record:
+            roles.create_role(db, role_def)
+        assert not record.list
+        role = orm.Role.find(db, role_def['name'])
+        assert role is not None
 
 
 @mark.role


### PR DESCRIPTION
- Fixes the log message about modifying existing role (in `_overwrite_role()`) appearing on next startup even if the role definition in config file not modified.
- Adds the possibility to tests in `create_roles()` and simplifies the test.
- Removes duplicate `scopes` assignment in `expand_roles_to_scopes()`.

@0mar, @minrk could you have a quick look? 
