### PR TITLE
Support Proxy.extra_routes

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -123,6 +123,12 @@ class Proxy(LoggingConfigurable):
         a URL as target. The hub will ensure this route is present
         in the proxy.
 
+        If the hub is running in host based mode (with 
+        JupyterHub.subdomain_host set), the routespec *must*
+        have a domain component (example.com/my-url/). If the
+        hub is not running in host based mode, the routespec
+        *must not* have a domain component (/my-url/).
+
         Helpful when the hub is running in API-only mode.
         """,
     )

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -120,7 +120,10 @@ class Proxy(LoggingConfigurable):
         Additional routes to be maintained in the proxy.
 
         A dictionary with a route specification as key, and
-        a URL as target.
+        a URL as target. The hub will ensure this route is present
+        in the proxy.
+
+        Helpful when the hub is running in API-only mode.
         """,
     )
 

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -32,6 +32,7 @@ from tornado.ioloop import PeriodicCallback
 from traitlets import Any
 from traitlets import Bool
 from traitlets import default
+from traitlets import Dict
 from traitlets import Instance
 from traitlets import Integer
 from traitlets import observe
@@ -109,6 +110,17 @@ class Proxy(LoggingConfigurable):
         If True, the Hub will start the proxy and stop it.
         Set to False if the proxy is managed externally,
         such as by systemd, docker, or another service manager.
+        """,
+    )
+
+    extra_routes = Dict(
+        {},
+        config=True,
+        help="""
+        Additional routes to be maintained in the proxy.
+
+        A dictionary with a route specification as key, and
+        a URL as target.
         """,
     )
 
@@ -383,6 +395,11 @@ class Proxy(LoggingConfigurable):
                         service.server.host,
                     )
                     futures.append(self.add_service(service))
+
+        # Add extra routes we've been configured for
+        for routespec, url in self.extra_routes.items():
+            good_routes.add(routespec)
+            futures.append(self.add_route(routespec, url, {'hub': True}))
 
         # Now delete the routes that shouldn't be there
         for routespec in routes:

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -408,7 +408,7 @@ class Proxy(LoggingConfigurable):
         # Add extra routes we've been configured for
         for routespec, url in self.extra_routes.items():
             good_routes.add(routespec)
-            futures.append(self.add_route(routespec, url, {'hub': True}))
+            futures.append(self.add_route(routespec, url, {'extra': True}))
 
         # Now delete the routes that shouldn't be there
         for routespec in routes:

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -197,7 +197,13 @@ async def test_check_routes(app, username, disable_check_routes):
 
 async def test_extra_routes(app):
     proxy = app.proxy
-    route_spec = '/test-extra-routs/'
+    # When using host_routing, it's up to the admin to
+    # provide routespecs that have a domain in them.
+    # We don't explicitly validate that here.
+    if app.subdomain_host:
+        route_spec = 'example.com/test-extra-routes/'
+    else:
+        route_spec = '/test-extra-routes/'
     target = 'http://localhost:9999/test'
     proxy.extra_routes = {route_spec: target}
 

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -195,6 +195,19 @@ async def test_check_routes(app, username, disable_check_routes):
     assert before == after
 
 
+async def test_extra_routes(app):
+    proxy = app.proxy
+    route_spec = '/test-extra-routs/'
+    target = 'http://localhost:9999/test'
+    proxy.extra_routes = {route_spec: target}
+
+    await proxy.check_routes(app.users, app._service_map)
+
+    routes = await app.proxy.get_all_routes()
+    assert route_spec in routes
+    assert routes[route_spec]['target'] == target
+
+
 @pytest.mark.parametrize(
     "routespec",
     [


### PR DESCRIPTION
When the hub is running in API-only mode, it's
very useful to have the proxy know where to send
URLs that would normally be serviced by the hub.
For example, / might go to a service that renders
a home page, while `/user` might go to a service that
tells the user their server is dead.

Right now, this happens 'out of band', with a process
that has to talk to the proxy directly. This is a
bit messy - the routes need to be re-added when the
proxy restarts, the hub might try to remove them, etc.
By adding support for this in the hub itself, all
this complexity is now removed and the hub continues
to own all the routes in the proxy