### PR TITLE
Persist roles through OAuth process

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1377,14 +1377,16 @@ class JupyterHub(Application):
             max(self.log_level, logging.INFO)
         )
 
-        # hook up tornado 3's loggers to our app handlers
         for log in (app_log, access_log, gen_log):
             # ensure all log statements identify the application they come from
             log.name = self.log.name
-        logger = logging.getLogger('tornado')
-        logger.propagate = True
-        logger.parent = self.log
-        logger.setLevel(self.log.level)
+
+        # hook up tornado's and oauthlib's loggers to our own
+        for name in ("tornado", "oauthlib"):
+            logger = logging.getLogger(name)
+            logger.propagate = True
+            logger.parent = self.log
+            logger.setLevel(self.log.level)
 
     @staticmethod
     def add_url_prefix(prefix, handlers):

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -351,7 +351,7 @@ class JupyterHubRequestValidator(RequestValidator):
         orm.APIToken.new(
             client_id=client.identifier,
             expires_in=token['expires_in'],
-            roles=request._jupyterhub_roles,
+            roles=[rolename for rolename in request.scopes],
             token=token['access_token'],
             session_id=request.session_id,
             user=request.user,
@@ -454,7 +454,6 @@ class JupyterHubRequestValidator(RequestValidator):
         request.user = orm_code.user
         request.session_id = orm_code.session_id
         request.scopes = [role.name for role in orm_code.roles]
-        request._jupyterhub_roles = orm_code.roles
         return True
 
     def validate_grant_type(
@@ -573,6 +572,7 @@ class JupyterHubRequestValidator(RequestValidator):
         app_log.debug(
             f"Allowing request for role(s) for {client_id}:  {','.join(requested_roles) or '[]'}"
         )
+        # these will be stored on the OAuthCode object
         request._jupyterhub_roles = [
             client_allowed_roles[name]
             for name in requested_roles

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -163,10 +163,8 @@ def _expand_scope(scopename):
 def expand_roles_to_scopes(orm_object):
     """Get the scopes listed in the roles of the User/Service/Group/Token
     If User, take into account the user's groups roles as well"""
-    from .user import User
-
-    if isinstance(orm_object, User):
-        orm_object = User.orm_user
+    if not isinstance(orm_object, orm.Base):
+        raise TypeError(f"Only orm objects allowed, got {orm_object}")
 
     pass_roles = orm_object.roles
 

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -163,22 +163,24 @@ def _expand_scope(scopename):
 def expand_roles_to_scopes(orm_object):
     """Get the scopes listed in the roles of the User/Service/Group/Token
     If User, take into account the user's groups roles as well"""
+    from .user import User
+
+    if isinstance(orm_object, User):
+        orm_object = User.orm_user
 
     pass_roles = orm_object.roles
+
     if isinstance(orm_object, orm.User):
         groups_roles = []
         for group in orm_object.groups:
             groups_roles.extend(group.roles)
         pass_roles.extend(groups_roles)
-    scopes = _get_subscopes(*pass_roles)
-    if 'self' in scopes:
-        scopes.remove('self')
-        if isinstance(orm_object, orm.User) or hasattr(orm_object, 'orm_user'):
-            scopes |= expand_self_scope(orm_object.name)
+
+    scopes = _get_subscopes(*pass_roles, owner=orm_object)
     return scopes
 
 
-def _get_subscopes(*args):
+def _get_subscopes(*args, owner=None):
     """Returns a set of all available subscopes for a specified role or list of roles"""
 
     scope_list = []
@@ -187,6 +189,11 @@ def _get_subscopes(*args):
         scope_list.extend(role.scopes)
 
     scopes = set(chain.from_iterable(list(map(_expand_scope, scope_list))))
+
+    if 'self' in scopes:
+        scopes.remove('self')
+        if owner and isinstance(owner, orm.User):
+            scopes |= expand_self_scope(owner.name)
 
     return scopes
 
@@ -380,32 +387,36 @@ def _token_allowed_role(db, token, role):
     """Returns True if token allowed to have requested role through
     comparing the requested scopes with the set of token's owner scopes"""
 
-    standard_permissions = {'all', 'read:all'}
+    owner = token.user
+    if owner is None:
+        owner = token.service
 
-    token_scopes = _get_subscopes(role)
-    extra_scopes = token_scopes - standard_permissions
+    if owner is None:
+        raise ValueError(f"Owner not found for {token}")
+
+    token_scopes = _get_subscopes(role, owner=owner)
+
+    implicit_permissions = {'all', 'read:all'}
+    explicit_scopes = token_scopes - implicit_permissions
     # ignore horizontal filters
-    raw_extra_scopes = {
-        scope.split('!', 1)[0] if '!' in scope else scope for scope in extra_scopes
+    raw_scopes = {
+        scope.split('!', 1)[0] if '!' in scope else scope for scope in explicit_scopes
     }
-    # find the owner and their roles
-    owner = None
-    if token.user_id:
-        owner = db.query(orm.User).get(token.user_id)
-    elif token.service_id:
-        owner = db.query(orm.Service).get(token.service_id)
-    if owner:
-        owner_scopes = expand_roles_to_scopes(owner)
-        # ignore horizontal filters
-        raw_owner_scopes = {
-            scope.split('!', 1)[0] if '!' in scope else scope for scope in owner_scopes
-        }
-        if raw_extra_scopes.issubset(raw_owner_scopes):
-            return True
-        else:
-            return False
+    # find the owner's scopes
+    owner_scopes = expand_roles_to_scopes(owner)
+    # ignore horizontal filters
+    raw_owner_scopes = {
+        scope.split('!', 1)[0] if '!' in scope else scope for scope in owner_scopes
+    }
+    disallowed_scopes = raw_scopes.difference(raw_owner_scopes)
+    if not disallowed_scopes:
+        # no scopes requested outside owner's own scopes
+        return True
     else:
-        raise ValueError('Owner the token %r not found', token)
+        app_log.warning(
+            f"Token requesting scopes exceeding owner {owner.name}: {disallowed_scopes}"
+        )
+        return False
 
 
 def assign_default_roles(db, entity):
@@ -440,12 +451,10 @@ def update_roles(db, entity, roles):
                 )
                 if _token_allowed_role(db, entity, role):
                     role.tokens.append(entity)
-                    app_log.info('Adding role %s for token: %s', role.name, entity)
+                    app_log.info('Adding role %s to token: %s', role.name, entity)
                 else:
                     raise ValueError(
-                        'Requested token role %r of %r has more permissions than the token owner',
-                        rolename,
-                        entity,
+                        f'Requested token role {rolename} of {entity} has more permissions than the token owner'
                     )
             else:
                 raise NameError('Role %r does not exist' % rolename)

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -18,7 +18,18 @@ def get_scopes_for(orm_object):
     scopes = set()
     if orm_object is None:
         return scopes
-    elif isinstance(orm_object, orm.APIToken):
+
+    if not isinstance(orm_object, orm.Base):
+        from .user import User
+
+        if isinstance(orm_object, User):
+            orm_object = orm_object.orm_user
+        else:
+            raise TypeError(
+                f"Only allow orm objects or User wrappers, got {orm_object}"
+            )
+
+    if isinstance(orm_object, orm.APIToken):
         app_log.warning(f"Authenticated with token {orm_object}")
         owner = orm_object.user or orm_object.service
         token_scopes = roles.expand_roles_to_scopes(orm_object)

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -530,7 +530,7 @@ async def test_metascope_self_expansion(
     app, kind, has_user_scopes, create_user_with_scopes, create_service_with_scopes
 ):
     if kind == 'users':
-        orm_obj = create_user_with_scopes('self')
+        orm_obj = create_user_with_scopes('self').orm_user
     else:
         orm_obj = create_service_with_scopes('self')
     # test expansion of user/service scopes


### PR DESCRIPTION
- [x] Attach role limit to OAuthClient.allowed_roles
- [x] Attach authorized roles to OAuthCode.roles
- [x] pass OAuthCode.roles to APIToken.roles on completion
- [x] test requesting subset of roles
    
standard 'scopes' in oauth process are matched against our 'roles' instead of our actual low-level scopes.

Not in this PR:

- setting OAuthClient.allowed_roles via config:
  - for services (presumably Service.allowed_roles)
  - for single-user servers (different for different users?)

It doesn't feel 100% great that this maps the standard scopes in the oauth flow onto roles. However, we have to do this because tokens currently only have roles, not direct assignment of scopes. It means that the scopes part of an oauth flow for a given service may vary depending on the configuration of the Hub deployment.

In practice, an oauth service will usually define its own role and only be allowed to request that one and only role. This is functionally equivalent, but a bit more verbose than putting scopes directly on the client itself.

We *could* use actual scopes here if we made one of these changes instead:

- attach scopes directly to API Tokens, in addition to (or instead of?) roles
- generate roles on demand for scope bundles, e.g. `oauth-role-$hashOfScopes`
- generate single roles for oauth clients, and disallow requesting specific scopes in oauth flow


