### PR TITLE
be strict about role names

### DIFF
--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -227,7 +227,7 @@ def _overwrite_role(role, role_dict):
                     )
 
 
-_role_name_pattern = re.compile(r'^[a-z][a-z0-9\-]{1,253}[a-z0-9]$')
+_role_name_pattern = re.compile(r'^[a-z][a-z0-9\-_~\.]{1,253}[a-z0-9]$')
 
 
 def _validate_role_name(name):
@@ -240,9 +240,9 @@ def _validate_role_name(name):
             f"Invalid role name: {name!r}."
             " Role names must:\n"
             " - be 3-255 characters\n"
-            " - contain only lowercase ascii letters, numbers, and '-'\n"
+            " - contain only lowercase ascii letters, numbers, and URL unreserved special characters '-.~_'\n"
             " - start with a letter\n"
-            " - not end with '-'\n"
+            " - end with letter or number\n"
         )
     return True
 

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -1,6 +1,7 @@
 """Roles utils"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import re
 from itertools import chain
 
 from sqlalchemy import func
@@ -226,6 +227,26 @@ def _overwrite_role(role, role_dict):
                     )
 
 
+_role_name_pattern = re.compile(r'^[a-z][a-z0-9\-]{1,253}[a-z0-9]$')
+
+
+def _validate_role_name(name):
+    """Ensure a role has a valid name
+
+    Raises ValueError if role name is invalid
+    """
+    if not _role_name_pattern.match(name):
+        raise ValueError(
+            f"Invalid role name: {name!r}."
+            " Role names must:\n"
+            " - be 3-255 characters\n"
+            " - contain only lowercase ascii letters, numbers, and '-'\n"
+            " - start with a letter\n"
+            " - not end with '-'\n"
+        )
+    return True
+
+
 def create_role(db, role_dict):
     """Adds a new role to database or modifies an existing one"""
 
@@ -235,6 +256,7 @@ def create_role(db, role_dict):
         raise KeyError('Role definition must have a name')
     else:
         name = role_dict['name']
+        _validate_role_name(name)
         role = orm.Role.find(db, name)
 
     description = role_dict.get('description')

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -878,3 +878,25 @@ async def test_self_expansion(app, kind, has_user_scopes):
     assert bool(token_scopes) == has_user_scopes
     app.db.delete(orm_obj)
     app.db.delete(test_role)
+
+
+@mark.role
+@mark.parametrize(
+    "name, valid",
+    [
+        ('abc', True),
+        ('group', True),
+        ("a-pretty-long-name-with-123", True),
+        ("0-abc", False),  # starts with number
+        ("role-", False),  # ends with -
+        ("has-Uppercase", False),  # Uppercase
+        ("a" * 256, False),  # too long
+        ("has space", False),  # space is illegal
+    ],
+)
+async def test_valid_names(name, valid):
+    if valid:
+        assert roles._validate_role_name(name)
+    else:
+        with pytest.raises(ValueError):
+            roles._validate_role_name(name)


### PR DESCRIPTION
Role names must be:

- 3-255 characters
- ascii lowercase, numbers, 'unreserved' URL punctuation '-_.~'
- must start with a letter
- must end with letter or number

this lets us avoid url escaping issues, etc. in e.g. oauth params