### PR TITLE
Remove handling of jupyterhub 0.8 oauth client ids

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2274,10 +2274,6 @@ class JupyterHub(Application):
         for user in self.users.values():
             for spawner in user.spawners.values():
                 oauth_client_ids.add(spawner.oauth_client_id)
-                # avoid deleting clients created by 0.8
-                # 0.9 uses `jupyterhub-user-...` for the client id, while
-                # 0.8 uses just `user-...`
-                oauth_client_ids.add(spawner.oauth_client_id.split('-', 1)[1])
 
         for i, oauth_client in enumerate(self.db.query(orm.OAuthClient)):
             if oauth_client.identifier not in oauth_client_ids:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -804,14 +804,8 @@ class User:
                 if orm_token:
                     self.db.delete(orm_token)
                 # remove oauth client as well
-                # handle upgrades from 0.8, where client id will be `user-USERNAME`,
-                # not just `jupyterhub-user-USERNAME`
-                client_ids = (
-                    spawner.oauth_client_id,
-                    spawner.oauth_client_id.split('-', 1)[1],
-                )
-                for oauth_client in self.db.query(orm.OAuthClient).filter(
-                    orm.OAuthClient.identifier.in_(client_ids)
+                for oauth_client in self.db.query(orm.OAuthClient).filter_by(
+                    identifier=spawner.oauth_client_id,
                 ):
                     self.log.debug("Deleting oauth client %s", oauth_client.identifier)
                     self.db.delete(oauth_client)


### PR DESCRIPTION
These only affected Hub deployments upgrading directly from 0.8 with still-running servers

0.8 was a long time ago, it's okay to require restarting servers for an upgrade that long