### PR TITLE
Fixed scope checking in UserTokenListAPIHandler

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -301,7 +301,6 @@ class UserTokenListAPIHandler(APIHandler):
 
         self.write(json.dumps({'api_tokens': api_tokens}))
 
-    # @needs_scope('users:tokens') #Todo: needs internal scope checking
     async def post(self, user_name):
         body = self.get_json_body() or {}
         if not isinstance(body, dict):
@@ -330,13 +329,16 @@ class UserTokenListAPIHandler(APIHandler):
         if requester is None:
             # couldn't identify requester
             raise web.HTTPError(403)
+        self._jupyterhub_user = requester
+        self._resolve_scopes()
         user = self.find_user(user_name)
-        if requester is not user and not requester.admin:
-            raise web.HTTPError(403, "Only admins can request tokens for other users")
-        if not user:
-            raise web.HTTPError(404, "No such user: %s" % user_name)
-        if requester is not user:
-            kind = 'user' if isinstance(requester, User) else 'service'
+        kind = 'user' if isinstance(requester, User) else 'service'
+        scope_filter = self.get_scope_filter('users:tokens')
+        if user is None or not scope_filter(user, kind):
+            raise web.HTTPError(
+                404,
+                f"{kind.title()} {user_name} not found or no permissions to generate tokens",
+            )
 
         note = body.get('note')
         if not note:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -336,7 +336,7 @@ class UserTokenListAPIHandler(APIHandler):
         scope_filter = self.get_scope_filter('users:tokens')
         if user is None or not scope_filter(user, kind):
             raise web.HTTPError(
-                404,
+                403,
                 f"{kind.title()} {user_name} not found or no permissions to generate tokens",
             )
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1311,7 +1311,7 @@ async def test_get_new_token(app, headers, status, note, expires_in):
     [
         ('admin', 'other', 200),
         ('admin', 'missing', 404),
-        ('user', 'other', 403),
+        ('user', 'other', 404),
         ('user', 'user', 200),
     ],
 )

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1310,8 +1310,8 @@ async def test_get_new_token(app, headers, status, note, expires_in):
     "as_user, for_user, status",
     [
         ('admin', 'other', 200),
-        ('admin', 'missing', 404),
-        ('user', 'other', 404),
+        ('admin', 'missing', 403),
+        ('user', 'other', 403),
         ('user', 'user', 200),
     ],
 )


### PR DESCRIPTION
Since the `UserTokenListAPIHandler` allows authentication with username and password, it bypasses some standard `APIHandler` setup. The handler has been patched so it checks for the relevant scopes. Also, we no longer distinguish between 'user not present' and 'user present but no valid scopes' for security purposes.
