### PR TITLE
Add service.oauth_roles configuration

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2127,7 +2127,6 @@ class JupyterHub(Application):
             name = spec['name']
             # get/create orm
             orm_service = orm.Service.find(self.db, name=name)
-            allowed_roles = spec.get('allowed_roles', [])
             if orm_service is None:
                 # not found, create a new one
                 orm_service = orm.Service(name=name)
@@ -2192,7 +2191,7 @@ class JupyterHub(Application):
                     client_id=service.oauth_client_id,
                     client_secret=service.api_token,
                     redirect_uri=service.oauth_redirect_uri,
-                    allowed_roles=allowed_roles,
+                    allowed_roles=service.oauth_roles,
                     description="JupyterHub service %s" % service.name,
                 )
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -111,14 +111,12 @@ from .objects import Hub, Server
 # For faking stats
 from .emptyclass import EmptyClass
 
-
 common_aliases = {
     'log-level': 'Application.log_level',
     'f': 'JupyterHub.config_file',
     'config': 'JupyterHub.config_file',
     'db': 'JupyterHub.db_url',
 }
-
 
 aliases = {
     'base-url': 'JupyterHub.base_url',
@@ -2129,6 +2127,7 @@ class JupyterHub(Application):
             name = spec['name']
             # get/create orm
             orm_service = orm.Service.find(self.db, name=name)
+            allowed_roles = spec.get('allowed_roles', [])
             if orm_service is None:
                 # not found, create a new one
                 orm_service = orm.Service(name=name)
@@ -2193,6 +2192,7 @@ class JupyterHub(Application):
                     client_id=service.oauth_client_id,
                     client_secret=service.api_token,
                     redirect_uri=service.oauth_redirect_uri,
+                    allowed_roles=allowed_roles,
                     description="JupyterHub service %s" % service.name,
                 )
 

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -587,7 +587,7 @@ class JupyterHubOAuthServer(WebApplicationServer):
         super().__init__(validator, *args, **kwargs)
 
     def add_client(
-        self, client_id, client_secret, redirect_uri, allowed_roles, description=''
+        self, client_id, client_secret, redirect_uri, allowed_roles=None, description=''
     ):
         """Add a client
 
@@ -609,6 +609,8 @@ class JupyterHubOAuthServer(WebApplicationServer):
             app_log.info(f'Creating oauth client {client_id}')
         else:
             app_log.info(f'Updating oauth client {client_id}')
+        if allowed_roles == None:
+            allowed_roles = []
         orm_client.secret = hash_token(client_secret) if client_secret else ""
         orm_client.redirect_uri = redirect_uri
         orm_client.description = description

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -586,7 +586,9 @@ class JupyterHubOAuthServer(WebApplicationServer):
         self.db = db
         super().__init__(validator, *args, **kwargs)
 
-    def add_client(self, client_id, client_secret, redirect_uri, description=''):
+    def add_client(
+        self, client_id, client_secret, redirect_uri, allowed_roles, description=''
+    ):
         """Add a client
 
         hash its client_secret before putting it in the database.
@@ -610,6 +612,7 @@ class JupyterHubOAuthServer(WebApplicationServer):
         orm_client.secret = hash_token(client_secret) if client_secret else ""
         orm_client.redirect_uri = redirect_uri
         orm_client.description = description
+        orm_client.allowed_roles = allowed_roles
         self.db.commit()
 
     def fetch_by_client_id(self, client_id):

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -192,9 +192,15 @@ class Service(LoggingConfigurable):
 
     oauth_roles = List(
         help="""OAuth allowed roles.
-    
-    List of roles that are passed to generated tokens if the service act as an OAuth client
-    on behalf of users"""
+
+        This sets the maximum and default roles
+        assigned to oauth tokens issued for this service
+        (i.e. tokens stored in browsers after authenticating with the server),
+        defining what actions the service can take on behalf of logged-in users.
+
+        Default is an empty list, meaning minimal permissions to identify users,
+        no actions can be taken on their behalf.
+      """
     ).tag(input=True)
 
     api_token = Unicode(

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -190,7 +190,7 @@ class Service(LoggingConfigurable):
         """
     ).tag(input=True)
 
-    allowed_roles = List(
+    oauth_roles = List(
         help="""OAuth allowed roles.
     
     List of roles that are passed to generated tokens if the service act as an OAuth client

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -50,6 +50,7 @@ from traitlets import default
 from traitlets import Dict
 from traitlets import HasTraits
 from traitlets import Instance
+from traitlets import List
 from traitlets import Unicode
 from traitlets import validate
 from traitlets.config import LoggingConfigurable
@@ -187,6 +188,13 @@ class Service(LoggingConfigurable):
         Only specify if the service runs an HTTP(s) endpoint that.
         If managed, will be passed as JUPYTERHUB_SERVICE_URL env.
         """
+    ).tag(input=True)
+
+    allowed_roles = List(
+        help="""OAuth allowed roles.
+    
+    List of roles that are passed to generated tokens if the service act as an OAuth client
+    on behalf of users"""
     ).tag(input=True)
 
     api_token = Unicode(

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -219,6 +219,11 @@ class Spawner(LoggingConfigurable):
     oauth_client_id = Unicode()
     handler = Any()
 
+    allowed_roles = List(
+        help="""OAuth allowed roles for single-user servers
+    """
+    ).tag(input=True)
+
     will_resume = Bool(
         False,
         help="""Whether the Spawner will resume on next start

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -219,10 +219,19 @@ class Spawner(LoggingConfigurable):
     oauth_client_id = Unicode()
     handler = Any()
 
-    allowed_roles = List(
-        help="""OAuth allowed roles for single-user servers
-    """
-    ).tag(input=True)
+    oauth_roles = Union(
+        [Callable(), List()],
+        help="""Allowed roles for oauth tokens.
+
+        This sets the maximum and default roles
+        assigned to oauth tokens issued by a single-user server's
+        oauth client (i.e. tokens stored in browsers after authenticating with the server),
+        defining what actions the server can take on behalf of logged-in users.
+
+        Default is an empty list, meaning minimal permissions to identify users,
+        no actions can be taken on their behalf.
+    """,
+    ).tag(config=True)
 
     will_resume = Bool(
         False,

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -13,6 +13,7 @@ from .. import roles
 from ..scopes import get_scopes_for
 from ..utils import maybe_future
 from .mocking import MockHub
+from .test_scopes import create_temp_role
 from .utils import add_user
 from .utils import api_request
 
@@ -898,3 +899,19 @@ async def test_valid_names(name, valid):
     else:
         with pytest.raises(ValueError):
             roles._validate_role_name(name)
+
+
+async def test_oauth_allowed_roles(app, create_temp_role):
+    allowed_roles = ['oracle', 'goose']
+    service = {
+        'name': 'oas1',
+        'api_token': 'some-token',
+        'allowed_roles': ['oracle', 'goose'],
+    }
+    for role in allowed_roles:
+        create_temp_role('read:users', role_name=role)
+    app.services.append(service)
+    app.init_services()
+    app_service = app.services[0]
+    assert app_service['name'] == 'oas1'
+    assert set(app_service['allowed_roles']) == set(allowed_roles)

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -906,7 +906,7 @@ async def test_oauth_allowed_roles(app, create_temp_role):
     service = {
         'name': 'oas1',
         'api_token': 'some-token',
-        'allowed_roles': ['oracle', 'goose'],
+        'oauth_roles': ['oracle', 'goose'],
     }
     for role in allowed_roles:
         create_temp_role('read:users', role_name=role)
@@ -914,4 +914,4 @@ async def test_oauth_allowed_roles(app, create_temp_role):
     app.init_services()
     app_service = app.services[0]
     assert app_service['name'] == 'oas1'
-    assert set(app_service['allowed_roles']) == set(allowed_roles)
+    assert set(app_service['oauth_roles']) == set(allowed_roles)

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -430,5 +430,5 @@ async def test_hub_connect_url(db):
 
 async def test_spawner_oauth_roles(app):
     allowed_roles = ['lotsa', 'roles']
-    spawner = new_spawner(app.db, allowed_roles=allowed_roles)
-    assert spawner.allowed_roles == allowed_roles
+    spawner = new_spawner(app.db, oauth_roles=allowed_roles)
+    assert spawner.oauth_roles == allowed_roles

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -426,3 +426,9 @@ async def test_hub_connect_url(db):
         env["JUPYTERHUB_ACTIVITY_URL"]
         == "https://example.com/api/users/%s/activity" % name
     )
+
+
+async def test_spawner_oauth_roles(app):
+    allowed_roles = ['lotsa', 'roles']
+    spawner = new_spawner(app.db, allowed_roles=allowed_roles)
+    assert spawner.allowed_roles == allowed_roles

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -568,7 +568,8 @@ class User:
                 client_id,
                 api_token,
                 url_path_join(self.url, server_name, 'oauth_callback'),
-                description="Server at %s"  # todo: own server: 'users:servers!user={username} as allowed role?
+                allowed_roles=spawner.allowed_roles,
+                description="Server at %s"
                 % (url_path_join(self.base_url, server_name) + '/'),
             )
         db.commit()

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -568,7 +568,7 @@ class User:
                 client_id,
                 api_token,
                 url_path_join(self.url, server_name, 'oauth_callback'),
-                description="Server at %s"
+                description="Server at %s"  # todo: own server: 'users:servers!user={username} as allowed role?
                 % (url_path_join(self.base_url, server_name) + '/'),
             )
         db.commit()

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -564,11 +564,16 @@ class User:
             oauth_client = oauth_provider.fetch_by_client_id(client_id)
             # create a new OAuth client + secret on every launch
             # containers that resume will be updated below
+
+            allowed_roles = spawner.oauth_roles
+            if callable(allowed_roles):
+                allowed_roles = allowed_roles(spawner)
+
             oauth_provider.add_client(
                 client_id,
                 api_token,
                 url_path_join(self.url, server_name, 'oauth_callback'),
-                allowed_roles=spawner.allowed_roles,
+                allowed_roles=allowed_roles,
                 description="Server at %s"
                 % (url_path_join(self.base_url, server_name) + '/'),
             )


### PR DESCRIPTION
PR that adds a list of allowed roles for API tokens from a service when service acts as OAuth client (see #3431)