### PR TITLE
Add setting user_options in the DELETE logic of UserServerAPIHandler

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -531,7 +531,9 @@ class UserServerAPIHandler(APIHandler):
             # include notify, so that a server that died is noticed immediately
             status = await spawner.poll_and_notify()
             if status is None:
-                stop_future = await self.stop_single_user(user, server_name, options=options)
+                stop_future = await self.stop_single_user(
+                    user, server_name, options=options
+                )
 
         if remove:
             if stop_future:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -531,7 +531,7 @@ class UserServerAPIHandler(APIHandler):
             # include notify, so that a server that died is noticed immediately
             status = await spawner.poll_and_notify()
             if status is None:
-                stop_future = await self.stop_single_user(user, server_name)
+                stop_future = await self.stop_single_user(user, server_name, options=options)
 
         if remove:
             if stop_future:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1086,7 +1086,7 @@ class BaseHandler(RequestHandler):
 
         await user.stop(server_name)
 
-    async def stop_single_user(self, user, server_name=''):
+    async def stop_single_user(self, user, server_name='', options=None):
         if server_name not in user.spawners:
             raise KeyError("User %s has no such spawner %r", user.name, server_name)
         spawner = user.spawners[server_name]
@@ -1110,7 +1110,7 @@ class BaseHandler(RequestHandler):
                     status=ProxyDeleteStatus.success
                 ).observe(time.perf_counter() - tic)
 
-                await user.stop(server_name)
+                await user.stop(server_name, options)
                 toc = time.perf_counter()
                 self.log.info(
                     "User %s server took %.3f seconds to stop", user.name, toc - tic

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -804,7 +804,7 @@ class User:
             spawner._start_pending = False
         return spawner
 
-    async def stop(self, server_name=''):
+    async def stop(self, server_name='', options=None):
         """Stop the user's spawner
 
         and cleanup after it.
@@ -820,6 +820,8 @@ class User:
 
         try:
             api_token = spawner.api_token
+            if options:
+                spawner.user_options = options
             status = await spawner.poll()
             if status is None:
                 await spawner.stop()


### PR DESCRIPTION
I wanted to selectively remove containers created with spawner using jupyterhub api.

I used dockerspawner, but the remove option provided by dockerspawner is set to True or False when running jupyterhub and cannot be changed.

In the POST logic of UserServerAPIHandler, the property values received as the body are put into the user_options property of the user's spawner object and used in start() of the dockerspawner.

However, in the DELETE logic of UserServerAPIHandler, only the remove property received as the body is assigned to the variable and is used only within the controller.

I wanted to pass an additional body property to remove the container, put it in the user_options property of the user's spawner object, and use the user_options property in the condition clause of the if statement about removing the container in stop() of dockerspawner.

In the DELETE logic of UserServerAPIHandler, if you put it in the user_options property of the user's spawner object, it will be convenient to customize in the stop() part of the Spawner implementation.