### PR TITLE
prepare to rename default branch to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Should we push this image to a public registry?
         run: |
-          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master') }}" = "true" ]; then
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then
               # Empty => Docker Hub
               echo "REGISTRY=" >> $GITHUB_ENV
           else

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-Please refer to [Project Jupyter's Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).
+Please refer to [Project Jupyter's Code of Conduct](https://github.com/jupyter/governance/blob/HEAD/conduct/code_of_conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Welcome! As a [Jupyter](https://jupyter.org) project,
 you can follow the [Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html).
 
-Make sure to also follow [Project Jupyter's Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)
+Make sure to also follow [Project Jupyter's Code of Conduct](https://github.com/jupyter/governance/blob/HEAD/conduct/code_of_conduct.md)
 for a friendly and welcoming collaborative environment.
 
 ## Setting up a development environment

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/jupyterhub/Test?logo=github&label=tests)](https://github.com/jupyterhub/jupyterhub/actions)
 [![DockerHub build status](https://img.shields.io/docker/build/jupyterhub/jupyterhub?logo=docker&label=build)](https://hub.docker.com/r/jupyterhub/jupyterhub/tags)
 [![CircleCI build status](https://img.shields.io/circleci/build/github/jupyterhub/jupyterhub?logo=circleci)](https://circleci.com/gh/jupyterhub/jupyterhub)<!-- CircleCI Token: b5b65862eb2617b9a8d39e79340b0a6b816da8cc -->
-[![Test coverage of code](https://codecov.io/gh/jupyterhub/jupyterhub/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyterhub/jupyterhub)
+[![Test coverage of code](https://codecov.io/gh/jupyterhub/jupyterhub/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyterhub/jupyterhub)
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/jupyterhub/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue?logo=gitter)](https://gitter.im/jupyterhub/jupyterhub)
@@ -46,7 +46,7 @@ Basic principles for operation are:
   servers.
 
 JupyterHub also provides a
-[REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
+[REST API](https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/HEAD/docs/rest-api.yml#/default)
 for administration of the Hub and its users.
 
 ## Installation
@@ -239,7 +239,7 @@ our JupyterHub [Gitter](https://gitter.im/jupyterhub/jupyterhub) channel.
 - [Reporting Issues](https://github.com/jupyterhub/jupyterhub/issues)
 - [JupyterHub tutorial](https://github.com/jupyterhub/jupyterhub-tutorial)
 - [Documentation for JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) | [PDF (latest)](https://media.readthedocs.org/pdf/jupyterhub/latest/jupyterhub.pdf) | [PDF (stable)](https://media.readthedocs.org/pdf/jupyterhub/stable/jupyterhub.pdf)
-- [Documentation for JupyterHub's REST API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/master/docs/rest-api.yml#/default)
+- [Documentation for JupyterHub's REST API](https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyterhub/HEAD/docs/rest-api.yml#/default)
 - [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
 - [Project Jupyter website](https://jupyter.org)
 - [Project Jupyter community](https://jupyter.org/community)

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -1,4 +1,4 @@
-# see me at: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#/default
+# see me at: https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/HEAD/docs/rest-api.yml#/default
 swagger: "2.0"
 info:
   title: JupyterHub
@@ -312,7 +312,7 @@ paths:
           type: string
         - name: server_name
           description: |
-            name given to a named-server. 
+            name given to a named-server.
 
             Note that depending on your JupyterHub infrastructure there are chracterter size limitation to `server_name`. Default spawner with K8s pod will not allow Jupyter Notebooks to be spawned with a name that contains more than 253 characters (keep in mind that the pod will be spawned with extra characters to identify the user and hub).
           in: path

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -18,7 +18,7 @@ information on:
 - learning more about JupyterHub's API
 
 The same JupyterHub API spec, as found here, is available in an interactive form
-`here (on swagger's petstore) <http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#!/default>`__.
+`here (on swagger's petstore) <https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/HEAD/docs/rest-api.yml#!/default>`__.
 The `OpenAPI Initiative`_ (fka Swagger™) is a project used to describe
 and document RESTful APIs.
 

--- a/docs/source/contributing/docs.rst
+++ b/docs/source/contributing/docs.rst
@@ -13,7 +13,7 @@ Building documentation locally
 We use `sphinx <http://sphinx-doc.org>`_ to build our documentation. It takes
 our documentation source files (written in `markdown
 <https://daringfireball.net/projects/markdown/>`_ or `reStructuredText
-<http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ &
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ &
 stored under the ``docs/source`` directory) and converts it into various
 formats for people to read. To make sure the documentation you write or
 change renders correctly, it is good practice to test it locally.
@@ -39,8 +39,8 @@ change renders correctly, it is good practice to test it locally.
    along with the filename / line number in which they occurred. Fix them,
    and re-run the ``make html`` command to re-render the documentation.
 
-#. View the rendered documentation by opening ``build/html/index.html`` in 
-   a web browser. 
+#. View the rendered documentation by opening ``build/html/index.html`` in
+   a web browser.
 
    .. tip::
 

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -6,8 +6,8 @@ We want you to contribute to JupyterHub in ways that are most exciting
 & useful to you. We value documentation, testing, bug reporting & code equally,
 and are glad to have your contributions in whatever form you wish :)
 
-Our `Code of Conduct <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`_
-(`reporting guidelines <https://github.com/jupyter/governance/blob/master/conduct/reporting_online.md>`_)
+Our `Code of Conduct <https://github.com/jupyter/governance/blob/HEAD/conduct/code_of_conduct.md>`_
+(`reporting guidelines <https://github.com/jupyter/governance/blob/HEAD/conduct/reporting_online.md>`_)
 helps keep our community welcoming to as many people as possible.
 
 .. toctree::

--- a/docs/source/gallery-jhub-deployments.md
+++ b/docs/source/gallery-jhub-deployments.md
@@ -30,7 +30,7 @@ Please submit pull requests to update information or to add new institutions or 
 
 ### University of California Davis
 
-- [Spinning up multiple Jupyter Notebooks on AWS for a tutorial](https://github.com/mblmicdiv/course2017/blob/master/exercises/sourmash-setup.md)
+- [Spinning up multiple Jupyter Notebooks on AWS for a tutorial](https://github.com/mblmicdiv/course2017/blob/HEAD/exercises/sourmash-setup.md)
 
 Although not technically a JupyterHub deployment, this tutorial setup
 may be helpful to others in the Jupyter community.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,8 +115,8 @@ We want you to contribute to JupyterHub in ways that are most exciting
 & useful to you. We value documentation, testing, bug reporting & code equally,
 and are glad to have your contributions in whatever form you wish :)
 
-Our `Code of Conduct <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`_
-(`reporting guidelines <https://github.com/jupyter/governance/blob/master/conduct/reporting_online.md>`_)
+Our `Code of Conduct <https://github.com/jupyter/governance/blob/HEAD/conduct/code_of_conduct.md>`_
+(`reporting guidelines <https://github.com/jupyter/governance/blob/HEAD/conduct/reporting_online.md>`_)
 helps keep our community welcoming to as many people as possible.
 
 .. toctree::
@@ -147,4 +147,4 @@ Questions? Suggestions?
 
 .. _JupyterHub: https://github.com/jupyterhub/jupyterhub
 .. _Jupyter notebook: https://jupyter-notebook.readthedocs.io/en/latest/
-.. _REST API: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#!/default
+.. _REST API: https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/HEAD/docs/rest-api.yml#!/default

--- a/docs/source/installation-guide-hard.rst
+++ b/docs/source/installation-guide-hard.rst
@@ -3,4 +3,4 @@
 JupyterHub the hard way
 =======================
 
-This guide has moved to https://github.com/jupyterhub/jupyterhub-the-hard-way/blob/master/docs/installation-guide-hard.md
+This guide has moved to https://github.com/jupyterhub/jupyterhub-the-hard-way/blob/HEAD/docs/installation-guide-hard.md

--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -259,7 +259,7 @@ PAM session.
 
 Beginning with version 0.8, JupyterHub is an OAuth provider.
 
-[authenticator]: https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/auth.py
+[authenticator]: https://github.com/jupyterhub/jupyterhub/blob/HEAD/jupyterhub/auth.py
 [pam]: https://en.wikipedia.org/wiki/Pluggable_authentication_module
 [oauth]: https://en.wikipedia.org/wiki/OAuth
 [github oauth]: https://developer.github.com/v3/oauth/

--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -230,7 +230,7 @@ be viewed in a more [interactive style on swagger's petstore][].
 Both resources contain the same information and differ only in its display.
 Note: The Swagger specification is being renamed the [OpenAPI Initiative][].
 
-[interactive style on swagger's petstore]: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/docs/rest-api.yml#!/default
+[interactive style on swagger's petstore]: https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyterhub/jupyterhub/HEAD/docs/rest-api.yml#!/default
 [openapi initiative]: https://www.openapis.org/
 [jupyterhub rest api]: ./rest-api
-[jupyter notebook rest api]: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml
+[jupyter notebook rest api]: https://petstore3.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/HEAD/notebook/services/api/api.yaml

--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -230,7 +230,7 @@ configurable by the `cookie_cache_max_age` setting (default: five minutes).
 For example, you have a Flask service that returns information about a user.
 JupyterHub's HubAuth class can be used to authenticate requests to the Flask
 service. See the `service-whoami-flask` example in the
-[JupyterHub GitHub repo](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-whoami-flask)
+[JupyterHub GitHub repo](https://github.com/jupyterhub/jupyterhub/tree/HEAD/examples/service-whoami-flask)
 for more details.
 
 ```python

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -125,7 +125,7 @@ If the `Spawner.options_form` is defined, when a user tries to start their serve
 
 If `Spawner.options_form` is undefined, the user's server is spawned directly, and no spawn page is rendered.
 
-See [this example](https://github.com/jupyterhub/jupyterhub/blob/master/examples/spawn-form/jupyterhub_config.py) for a form that allows custom CLI args for the local spawner.
+See [this example](https://github.com/jupyterhub/jupyterhub/blob/HEAD/examples/spawn-form/jupyterhub_config.py) for a form that allows custom CLI args for the local spawner.
 
 ### `Spawner.options_from_form`
 
@@ -166,7 +166,7 @@ which would return:
 
 When `Spawner.start` is called, this dictionary is accessible as `self.user_options`.
 
-[spawner]: https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/spawner.py
+[spawner]: https://github.com/jupyterhub/jupyterhub/blob/HEAD/jupyterhub/spawner.py
 
 ## Writing a custom spawner
 

--- a/docs/source/reference/templates.md
+++ b/docs/source/reference/templates.md
@@ -10,7 +10,7 @@ appearance.
 
 JupyterHub will look for custom templates in all of the paths in the
 `JupyterHub.template_paths` configuration option, falling back on the
-[default templates](https://github.com/jupyterhub/jupyterhub/tree/master/share/jupyterhub/templates)
+[default templates](https://github.com/jupyterhub/jupyterhub/tree/HEAD/share/jupyterhub/templates)
 if no custom template with that name is found. This fallback
 behavior is new in version 0.9; previous versions searched only those paths
 explicitly included in `template_paths`. You may override as many
@@ -21,7 +21,7 @@ or as few templates as you desire.
 Jinja provides a mechanism to [extend templates](http://jinja.pocoo.org/docs/2.10/templates/#template-inheritance).
 A base template can define a `block`, and child templates can replace or
 supplement the material in the block. The
-[JupyterHub templates](https://github.com/jupyterhub/jupyterhub/tree/master/share/jupyterhub/templates)
+[JupyterHub templates](https://github.com/jupyterhub/jupyterhub/tree/HEAD/share/jupyterhub/templates)
 make extensive use of blocks, which allows you to customize parts of the
 interface easily.
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -234,7 +234,7 @@ With a docker container, pass in the environment variable with the run command:
       -e JUPYTERHUB_API_TOKEN=my_secret_token \
       jupyter/datascience-notebook:latest
 
-[This example](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-notebook/external) demonstrates how to combine the use of the `jupyterhub-singleuser` environment variables when launching a Notebook as an externally managed service.
+[This example](https://github.com/jupyterhub/jupyterhub/tree/HEAD/examples/service-notebook/external) demonstrates how to combine the use of the `jupyterhub-singleuser` environment variables when launching a Notebook as an externally managed service.
 
 ## How do I...?
 

--- a/examples/bootstrap-script/README.md
+++ b/examples/bootstrap-script/README.md
@@ -148,9 +148,9 @@ else
     echo "...initial content loading for user ..."
     mkdir $USER_DIRECTORY/tutorials
     cd $USER_DIRECTORY/tutorials
-    wget https://github.com/jakevdp/PythonDataScienceHandbook/archive/master.zip
-    unzip -o master.zip
-    rm master.zip
+    wget https://github.com/jakevdp/PythonDataScienceHandbook/archive/HEAD.zip
+    unzip -o HEAD.zip
+    rm HEAD.zip
 fi
 
 exit 0

--- a/examples/bootstrap-script/bootstrap.sh
+++ b/examples/bootstrap-script/bootstrap.sh
@@ -40,9 +40,9 @@ else
     echo "...initial content loading for user ..."
     mkdir $USER_DIRECTORY/tutorials
     cd $USER_DIRECTORY/tutorials
-    wget https://github.com/jakevdp/PythonDataScienceHandbook/archive/master.zip
-    unzip -o master.zip
-    rm master.zip
+    wget https://github.com/jakevdp/PythonDataScienceHandbook/archive/HEAD.zip
+    unzip -o HEAD.zip
+    rm HEAD.zip
 fi
 
 exit 0

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -6,7 +6,7 @@ FROM $BASE_IMAGE
 MAINTAINER Project Jupyter <jupyter@googlegroups.com>
 
 ADD install_jupyterhub /tmp/install_jupyterhub
-ARG JUPYTERHUB_VERSION=master
+ARG JUPYTERHUB_VERSION=main
 # install pinned jupyterhub and ensure notebook is installed
 RUN python3 /tmp/install_jupyterhub && \
     python3 -m pip install notebook

--- a/singleuser/README.md
+++ b/singleuser/README.md
@@ -5,7 +5,7 @@ Built from the `jupyter/base-notebook` base image.
 This image contains a single user notebook server for use with
 [JupyterHub](https://github.com/jupyterhub/jupyterhub). In particular, it is meant
 to be used with the
-[DockerSpawner](https://github.com/jupyterhub/dockerspawner/blob/master/dockerspawner/dockerspawner.py)
+[DockerSpawner](https://github.com/jupyterhub/dockerspawner/blob/HEAD/dockerspawner/dockerspawner.py)
 class to launch user notebook servers within docker containers.
 
 The only thing this image accomplishes is pinning the jupyterhub version on top of base-notebook.

--- a/singleuser/hooks/post_push
+++ b/singleuser/hooks/post_push
@@ -13,7 +13,7 @@ function get_hub_version() {
     hub_xy="${hub_xy}.${split[3]}"
   fi
 }
-# tag e.g. 0.9 with master
+# tag e.g. 0.9 with main
 get_hub_version
 docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$hub_xy
 docker push $DOCKER_REPO:$hub_xy

--- a/singleuser/install_jupyterhub
+++ b/singleuser/install_jupyterhub
@@ -9,8 +9,8 @@ pip_install = [
     sys.executable, '-m', 'pip', 'install', '--no-cache', '--upgrade',
     '--upgrade-strategy', 'only-if-needed',
 ]
-if V == 'master':
-    req = 'https://github.com/jupyterhub/jupyterhub/archive/master.tar.gz'
+if V in {'main', 'HEAD'}:
+    req = 'https://github.com/jupyterhub/jupyterhub/archive/HEAD.tar.gz'
 else:
     version_info = [ int(part) for part in V.split('.') ]
     version_info[-1] += 1


### PR DESCRIPTION
- update references to default branch name in docs, workflows
- use HEAD in github urls, which always works regardless of default branch name
- fix petstore URLs since the old petstore links seem to have stopped working

to merge, in order:

- [x] approve this PR
- [x] rename the default branch to main in settings
- [x] merge this PR


Related tangent: I've been using [this git default-branch](https://github.com/minrk/git-stuff/blob/main/bin/git-default-branch) to help with my aliases and friends working with repos with different branch names.