### PR TITLE
(docs) Fix DummyAuthenticator class reference

### DIFF
--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -37,7 +37,7 @@ with any provider, is also available.
 ## The Dummy Authenticator
 
 When testing, it may be helpful to use the
-:class:`~jupyterhub.auth.DummyAuthenticator`. This allows for any username and
+{class}`jupyterhub.auth.DummyAuthenticator`. This allows for any username and
 password unless if a global password has been set. Once set, any username will
 still be accepted but the correct password will need to be provided.
 


### PR DESCRIPTION
Hi, not sure if there is a macro or some customization that renders that text with a link to the class docs perhaps?

It doesn't appear to be rendering correctly at the moment, at least for me.

![image](https://user-images.githubusercontent.com/304786/118426107-b0520800-b71e-11eb-9485-630650ca1ded.png)

This PR simply uses backticks instead :+1: happy to amend if there's another way to fix it.

Cheers
Bruno