### PR TITLE
[RBAC] Fixexternal oauth example

### DIFF
--- a/examples/external-oauth/jupyterhub_config.py
+++ b/examples/external-oauth/jupyterhub_config.py
@@ -13,7 +13,7 @@ if not api_token:
 c.JupyterHub.services = [
     {
         'name': 'external-oauth',
-        'oauth_client_id': "whoami-oauth-client-test",
+        'oauth_client_id': "service-oauth-client-test",
         'api_token': api_token,
         'oauth_redirect_uri': 'http://127.0.0.1:5555/oauth_callback',
     }

--- a/examples/external-oauth/launch-service-basic.sh
+++ b/examples/external-oauth/launch-service-basic.sh
@@ -9,7 +9,7 @@ if [[ -z "${JUPYTERHUB_API_TOKEN}" ]]; then
 fi
 
 # 2. oauth client ID
-export JUPYTERHUB_CLIENT_ID='whoami-oauth-client-test'
+export JUPYTERHUB_CLIENT_ID='service-oauth-client-test'
 # 3. where the Hub is
 export JUPYTERHUB_URL='http://127.0.0.1:8000'
 

--- a/examples/external-oauth/launch-service.sh
+++ b/examples/external-oauth/launch-service.sh
@@ -9,7 +9,7 @@ if [[ -z "${JUPYTERHUB_API_TOKEN}" ]]; then
 fi
 
 # 2. oauth client ID
-export JUPYTERHUB_CLIENT_ID="whoami-oauth-client-test"
+export JUPYTERHUB_CLIENT_ID="service-oauth-client-test"
 # 3. what URL to run on
 export JUPYTERHUB_SERVICE_PREFIX='/'
 export JUPYTERHUB_SERVICE_URL='http://127.0.0.1:5555'


### PR DESCRIPTION
This fixes the error on the `rbac` branch for the `external-auth` example which was failing with ` ValueError: service external-oauth has oauth_client_id='whoami-oauth-client-test'. Service oauth client ids must start with 'service-'`