### PR TITLE
handle async functions in check_db_locks

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -681,7 +681,7 @@ class APIToken(Hashed, Base):
         if not token_role:
             # FIXME: remove this.
             # Creating a token before the db has roles defined should raise an error.
-            # PR #3460 should let us fix it by ensuring default roles are define
+            # PR #3460 should let us fix it by ensuring default roles are defined
 
             warnings.warn(
                 "Token created before default roles!", RuntimeWarning, stacklevel=2

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -435,11 +435,11 @@ def assign_default_roles(db, entity):
     """Assigns the default roles to an entity:
     users and services get 'user' role, or admin role if they have admin flag
     Tokens get 'token' role"""
-    default_token_role = orm.Role.find(db, 'token')
     if isinstance(entity, orm.Group):
         pass
     elif isinstance(entity, orm.APIToken):
         app_log.debug('Assigning default roles to tokens')
+        default_token_role = orm.Role.find(db, 'token')
         if not entity.roles and (entity.user or entity.service) is not None:
             default_token_role.tokens.append(entity)
             app_log.info('Added role %s to token %s', default_token_role.name, entity)

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -84,9 +84,12 @@ def check_db_locks(func):
         maybe_future = func(app, *args, **kwargs)
 
         def _check(_=None):
-            with app.session_factory() as temp_session:
+            temp_session = app.session_factory()
+            try:
                 temp_session.execute('CREATE TABLE dummy (foo INT)')
                 temp_session.execute('DROP TABLE dummy')
+            finally:
+                temp_session.close()
 
         async def await_then_check():
             result = await maybe_future


### PR DESCRIPTION
check_db_locks checks for db lock state after the end of a function, but wasn't properly waiting when it wrapped an async function, meaning it would run the check while the async function was still outstanding, causing possible spurious failures