### PR TITLE
[rbac] Synchronize variable nomenclature across rbac utils

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -35,8 +35,8 @@ class TokenAPIHandler(APIHandler):
         if owner:
             # having a token means we should be able to read the owner's model
             # (this is the only thing this handler is for)
-            self.raw_scopes.update(scopes.identify_scopes(owner))
-            self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
+            self.expanded_scopes.update(scopes.identify_scopes(owner))
+            self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
 
         # record activity whenever we see a token
         now = orm_token.last_activity = datetime.utcnow()

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -254,7 +254,7 @@ class APIHandler(BaseHandler):
         self.log.debug(
             "Asking for user model of %s with scopes [%s]",
             user.name,
-            ", ".join(self.raw_scopes),
+            ", ".join(self.expanded_scopes),
         )
         allowed_keys = set()
         for scope in access_map:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -336,7 +336,7 @@ class UserTokenListAPIHandler(APIHandler):
             # couldn't identify requester
             raise web.HTTPError(403)
         self._jupyterhub_user = requester
-        self._resolve_scopes()
+        self._resolve_roles_and_scopes()
         user = self.find_user(user_name)
         kind = 'user' if isinstance(requester, User) else 'service'
         scope_filter = self.get_scope_filter('users:tokens')

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -37,12 +37,13 @@ class SelfAPIHandler(APIHandler):
             raise web.HTTPError(403)
         if isinstance(user, orm.Service):
             # ensure we have the minimal 'identify' scopes for the token owner
-            self.raw_scopes.update(scopes.identify_scopes(user))
-            self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
+            self.expanded_scopes.update(scopes.identify_scopes(user))
+            self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
             model = self.service_model(user)
         else:
-            self.raw_scopes.update(scopes.identify_scopes(user.orm_user))
-            self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
+            self.expanded_scopes.update(scopes.identify_scopes(user.orm_user))
+            print('Expanded scopes in selfapihandler')
+            self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
             model = self.user_model(user)
         # validate return, should have at least kind and name,
         # otherwise our filters did something wrong

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -81,7 +81,7 @@ class BaseHandler(RequestHandler):
         The current user (None if not logged in) may be accessed
         via the `self.current_user` property during the handling of any request.
         """
-        self.raw_scopes = set()
+        self.expanded_scopes = set()
         try:
             await self.get_current_user()
         except Exception:
@@ -417,16 +417,16 @@ class BaseHandler(RequestHandler):
         return self._jupyterhub_user
 
     def _resolve_roles_and_scopes(self):
-        self.raw_scopes = set()
+        self.expanded_scopes = set()
         app_log.debug("Loading and parsing scopes")
         if self.current_user:
             orm_token = self.get_token()
             if orm_token:
-                self.raw_scopes = scopes.get_scopes_for(orm_token)
+                self.expanded_scopes = scopes.get_scopes_for(orm_token)
             else:
-                self.raw_scopes = scopes.get_scopes_for(self.current_user)
-        self.parsed_scopes = scopes.parse_scopes(self.raw_scopes)
-        app_log.debug("Found scopes [%s]", ",".join(self.raw_scopes))
+                self.expanded_scopes = scopes.get_scopes_for(self.current_user)
+        self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
+        app_log.debug("Found scopes [%s]", ",".join(self.expanded_scopes))
 
     @property
     def current_user(self):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -87,7 +87,7 @@ class BaseHandler(RequestHandler):
         except Exception:
             self.log.exception("Failed to get current user")
             self._jupyterhub_user = None
-        self._resolve_scopes()
+        self._resolve_roles_and_scopes()
         return await maybe_future(super().prepare())
 
     @property
@@ -416,7 +416,7 @@ class BaseHandler(RequestHandler):
                 self.log.exception("Error getting current user")
         return self._jupyterhub_user
 
-    def _resolve_scopes(self):
+    def _resolve_roles_and_scopes(self):
         self.raw_scopes = set()
         app_log.debug("Loading and parsing scopes")
         if self.current_user:

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -401,21 +401,22 @@ def _token_allowed_role(db, token, role):
     if owner is None:
         raise ValueError(f"Owner not found for {token}")
 
-    token_scopes = _get_subscopes(role, owner=owner)
+    expanded_scopes = _get_subscopes(role, owner=owner)
 
     implicit_permissions = {'all', 'read:all'}
-    explicit_scopes = token_scopes - implicit_permissions
+    explicit_scopes = expanded_scopes - implicit_permissions
     # ignore horizontal filters
-    raw_scopes = {
+    no_filter_scopes = {
         scope.split('!', 1)[0] if '!' in scope else scope for scope in explicit_scopes
     }
     # find the owner's scopes
-    owner_scopes = expand_roles_to_scopes(owner)
+    expanded_owner_scopes = expand_roles_to_scopes(owner)
     # ignore horizontal filters
-    raw_owner_scopes = {
-        scope.split('!', 1)[0] if '!' in scope else scope for scope in owner_scopes
+    no_filter_owner_scopes = {
+        scope.split('!', 1)[0] if '!' in scope else scope
+        for scope in expanded_owner_scopes
     }
-    disallowed_scopes = raw_scopes.difference(raw_owner_scopes)
+    disallowed_scopes = no_filter_scopes.difference(no_filter_owner_scopes)
     if not disallowed_scopes:
         # no scopes requested outside owner's own scopes
         return True

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -12,8 +12,14 @@ from . import scopes
 
 
 def get_default_roles():
-    """Returns a list of default role dictionaries"""
-
+    """Returns:
+    default roles (list): default role definitions as dictionaries:
+      {
+        'name': role name,
+        'description': role description,
+        'scopes': list of scopes,
+      }
+    """
     default_roles = [
         {
             'name': 'user',
@@ -37,9 +43,7 @@ def get_default_roles():
         {
             'name': 'server',
             'description': 'Post activity only',
-            'scopes': [
-                'users:activity!user'
-            ],  # TO DO - fix scope to refer to only self once implemented
+            'scopes': ['users:activity!user'],
         },
         {
             'name': 'token',
@@ -60,6 +64,12 @@ def expand_self_scope(name):
     users:activity
     users:servers
     users:tokens
+
+    Arguments:
+      name (str): user name
+
+    Returns:
+      expanded scopes (set): set of expanded scopes covering standard user privileges
     """
     scope_list = [
         'users',
@@ -99,8 +109,13 @@ def horizontal_filter(func):
 
 @horizontal_filter
 def _expand_scope(scopename):
-    """Returns a set of all subscopes"""
+    """Returns a set of all subscopes
+    Arguments:
+      scopename (str): name of the scope to expand
 
+    Returns:
+      expanded scope (set): set of all scope's subscopes including the scope itself
+    """
     expanded_scope = []
 
     def _add_subscopes(scopename):
@@ -116,7 +131,14 @@ def _expand_scope(scopename):
 
 def expand_roles_to_scopes(orm_object):
     """Get the scopes listed in the roles of the User/Service/Group/Token
-    If User, take into account the user's groups roles as well"""
+    If User, take into account the user's groups roles as well
+
+    Arguments:
+      orm_object: orm.User, orm.Service, orm.Group or orm.APIToken
+
+    Returns:
+      expanded scopes (set): set of all expanded scopes for the orm object
+    """
     if not isinstance(orm_object, orm.Base):
         raise TypeError(f"Only orm objects allowed, got {orm_object}")
 
@@ -127,26 +149,35 @@ def expand_roles_to_scopes(orm_object):
         for group in orm_object.groups:
             pass_roles.extend(group.roles)
 
-    scopes = _get_subscopes(*pass_roles, owner=orm_object)
+    expanded_scopes = _get_subscopes(*pass_roles, owner=orm_object)
 
-    return scopes
+    return expanded_scopes
 
 
 def _get_subscopes(*args, owner=None):
-    """Returns a set of all available subscopes for a specified role or list of roles"""
+    """Returns a set of all available subscopes for a specified role or list of roles
 
+    Arguments:
+      role (obj): orm.Role
+      or
+      roles (list): list of orm.Roles
+      owner (obj, optional): orm.User or orm.Service as owner of orm.APIToken
+
+    Returns:
+      expanded scopes (set): set of all expanded scopes for the role(s)
+    """
     scope_list = []
 
     for role in args:
         scope_list.extend(role.scopes)
 
-    scopes = set(chain.from_iterable(list(map(_expand_scope, scope_list))))
+    expanded_scopes = set(chain.from_iterable(list(map(_expand_scope, scope_list))))
 
     # transform !user filter to !user=ownername
-    for scope in scopes:
+    for scope in expanded_scopes:
         base_scope, _, filter = scope.partition('!')
         if filter == 'user':
-            scopes.remove(scope)
+            expanded_scopes.remove(scope)
             if isinstance(owner, orm.APIToken):
                 token_owner = owner.user
                 if token_owner is None:
@@ -155,18 +186,26 @@ def _get_subscopes(*args, owner=None):
             else:
                 name = owner.name
             trans_scope = f'{base_scope}!user={name}'
-            scopes.add(trans_scope)
+            expanded_scopes.add(trans_scope)
 
-    if 'self' in scopes:
-        scopes.remove('self')
+    if 'self' in expanded_scopes:
+        expanded_scopes.remove('self')
         if owner and isinstance(owner, orm.User):
-            scopes |= expand_self_scope(owner.name)
+            expanded_scopes |= expand_self_scope(owner.name)
 
-    return scopes
+    return expanded_scopes
 
 
 def _check_scopes(*args, rolename=None):
-    """Check if provided scopes exist"""
+    """Check if provided scopes exist
+
+    Arguments:
+      scope (str): name of the scope to check
+      or
+      scopes (list): list of scopes to check
+
+    Raises NameError if scope does not exist
+    """
 
     allowed_scopes = set(scopes.scope_definitions.keys())
     allowed_filters = ['!user=', '!service=', '!group=', '!server=', '!user']
@@ -190,7 +229,6 @@ def _check_scopes(*args, rolename=None):
 
 def _overwrite_role(role, role_dict):
     """Overwrites role's description and/or scopes with role_dict if role not 'admin'"""
-
     for attr in role_dict.keys():
         if attr == 'description' or attr == 'scopes':
             if role.name == 'admin':
@@ -231,7 +269,6 @@ def _validate_role_name(name):
 
 def create_role(db, role_dict):
     """Adds a new role to database or modifies an existing one"""
-
     default_roles = get_default_roles()
 
     if 'name' not in role_dict.keys():
@@ -264,7 +301,6 @@ def create_role(db, role_dict):
 
 def delete_role(db, rolename):
     """Removes a role from database"""
-
     # default roles are not removable
     default_roles = get_default_roles()
     if any(role['name'] == rolename for role in default_roles):
@@ -298,7 +334,7 @@ def existing_only(func):
 
 @existing_only
 def grant_role(db, entity, rolename):
-    """Adds a role for users, services or tokens"""
+    """Adds a role for users, services, groups or tokens"""
     if isinstance(entity, orm.APIToken):
         entity_repr = entity
     else:
@@ -317,7 +353,7 @@ def grant_role(db, entity, rolename):
 
 @existing_only
 def strip_role(db, entity, rolename):
-    """Removes a role for users, services or tokens"""
+    """Removes a role for users, services, groups or tokens"""
     if isinstance(entity, orm.APIToken):
         entity_repr = entity
     else:
@@ -352,10 +388,12 @@ def _switch_default_role(db, obj, admin):
 
 
 def _token_allowed_role(db, token, role):
+    """Checks if requested role for token does not grant the token
+    higher permissions than the token's owner has
 
-    """Returns True if token allowed to have requested role through
-    comparing the requested scopes with the set of token's owner scopes"""
-
+    Returns:
+      True if requested permissions are within the owner's permissions, False otherwise
+    """
     owner = token.user
     if owner is None:
         owner = token.service
@@ -389,9 +427,10 @@ def _token_allowed_role(db, token, role):
 
 
 def assign_default_roles(db, entity):
-    """Assigns the default roles to an entity:
+    """Assigns default role to an entity:
     users and services get 'user' role, or admin role if they have admin flag
-    Tokens get 'token' role"""
+    tokens get 'token' role
+    """
     if isinstance(entity, orm.Group):
         pass
     elif isinstance(entity, orm.APIToken):
@@ -408,7 +447,9 @@ def assign_default_roles(db, entity):
 
 
 def update_roles(db, entity, roles):
-    """Updates object's roles"""
+    """Updates object's roles checking for requested permissions
+    if object is orm.APIToken
+    """
     standard_permissions = {'all', 'read:all'}
     for rolename in roles:
         if isinstance(entity, orm.APIToken):
@@ -432,10 +473,9 @@ def update_roles(db, entity, roles):
 
 
 def check_for_default_roles(db, bearer):
-
     """Checks that role bearers have at least one role (default if none).
-    Groups can be without a role"""
-
+    Groups can be without a role
+    """
     Class = orm.get_class(bearer)
     if Class == orm.Group:
         pass

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -108,7 +108,7 @@ class Scope(Enum):
     ALL = True
 
 
-def _intersect_scopes(scopes_a, scopes_b):
+def _intersect_expanded_scopes(scopes_a, scopes_b):
     """Intersect two sets of expanded scopes by comparing their permissions
 
     Arguments:
@@ -192,7 +192,7 @@ def _intersect_scopes(scopes_a, scopes_b):
 
 
 def get_scopes_for(orm_object):
-    """Find scopes for a given user or token and resolve permissions
+    """Find scopes for a given user or token from their roles and resolve permissions
 
     Arguments:
       orm_object: orm object or User wrapper
@@ -225,7 +225,7 @@ def get_scopes_for(orm_object):
             token_scopes.remove('all')
             token_scopes |= owner_scopes
 
-        intersection = _intersect_scopes(token_scopes, owner_scopes)
+        intersection = _intersect_expanded_scopes(token_scopes, owner_scopes)
         discarded_token_scopes = token_scopes - intersection
 
         # Not taking symmetric difference here because token owner can naturally have more scopes than token
@@ -263,7 +263,7 @@ def _check_user_in_expanded_scope(handler, user_name, scope_group_names):
     return bool(set(scope_group_names) & group_names)
 
 
-def _check_scope(api_handler, req_scope, **kwargs):
+def _check_scope_access(api_handler, req_scope, **kwargs):
     """Check if scopes satisfy requirements
     Returns True for (potentially restricted) access, False for refused access
     """
@@ -375,7 +375,7 @@ def needs_scope(*scopes):
                     s_kwargs[resource] = resource_value
             for scope in scopes:
                 app_log.debug("Checking access via scope %s", scope)
-                has_access = _check_scope(self, scope, **s_kwargs)
+                has_access = _check_scope_access(self, scope, **s_kwargs)
                 if has_access:
                     return func(self, *args, **kwargs)
             try:

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -363,8 +363,8 @@ def needs_scope(*scopes):
             bound_sig = sig.bind(self, *args, **kwargs)
             bound_sig.apply_defaults()
             # Load scopes in case they haven't been loaded yet
-            if not hasattr(self, 'raw_scopes'):
-                self.raw_scopes = {}
+            if not hasattr(self, 'expanded_scopes'):
+                self.expanded_scopes = {}
                 self.parsed_scopes = {}
 
             s_kwargs = {}
@@ -384,7 +384,7 @@ def needs_scope(*scopes):
                 end_point = self.__name__
             app_log.warning(
                 "Not authorizing access to {}. Requires any of [{}], not derived from scopes [{}]".format(
-                    end_point, ", ".join(scopes), ", ".join(self.raw_scopes)
+                    end_point, ", ".join(scopes), ", ".join(self.expanded_scopes)
                 )
             )
             raise web.HTTPError(

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -9,8 +9,8 @@ from tornado.httputil import HTTPServerRequest
 from .. import orm
 from .. import roles
 from ..handlers import BaseHandler
-from ..scopes import _check_scope
-from ..scopes import _intersect_scopes
+from ..scopes import _check_scope_access
+from ..scopes import _intersect_expanded_scopes
 from ..scopes import get_scopes_for
 from ..scopes import needs_scope
 from ..scopes import parse_scopes
@@ -49,37 +49,39 @@ def test_scope_precendence():
 
 def test_scope_check_present():
     handler = get_handler_with_scopes(['read:users'])
-    assert _check_scope(handler, 'read:users')
-    assert _check_scope(handler, 'read:users', user='maeby')
+    assert _check_scope_access(handler, 'read:users')
+    assert _check_scope_access(handler, 'read:users', user='maeby')
 
 
 def test_scope_check_not_present():
     handler = get_handler_with_scopes(['read:users!user=maeby'])
-    assert _check_scope(handler, 'read:users')
+    assert _check_scope_access(handler, 'read:users')
     with pytest.raises(web.HTTPError):
-        _check_scope(handler, 'read:users', user='gob')
+        _check_scope_access(handler, 'read:users', user='gob')
     with pytest.raises(web.HTTPError):
-        _check_scope(handler, 'read:users', user='gob', server='server')
+        _check_scope_access(handler, 'read:users', user='gob', server='server')
 
 
 def test_scope_filters():
     handler = get_handler_with_scopes(
         ['read:users', 'read:users!group=bluths', 'read:users!user=maeby']
     )
-    assert _check_scope(handler, 'read:users', group='bluth')
-    assert _check_scope(handler, 'read:users', user='maeby')
+    assert _check_scope_access(handler, 'read:users', group='bluth')
+    assert _check_scope_access(handler, 'read:users', user='maeby')
 
 
 def test_scope_multiple_filters():
     handler = get_handler_with_scopes(['read:users!user=george_michael'])
-    assert _check_scope(handler, 'read:users', user='george_michael', group='bluths')
+    assert _check_scope_access(
+        handler, 'read:users', user='george_michael', group='bluths'
+    )
 
 
 def test_scope_parse_server_name():
     handler = get_handler_with_scopes(
         ['users:servers!server=maeby/server1', 'read:users!user=maeby']
     )
-    assert _check_scope(handler, 'users:servers', user='maeby', server='server1')
+    assert _check_scope_access(handler, 'users:servers', user='maeby', server='server1')
 
 
 class MockAPIHandler:
@@ -828,10 +830,10 @@ async def test_resolve_token_permissions(
         ),
     ],
 )
-def test_intersect_scopes(left, right, expected, should_warn, recwarn):
+def test_intersect_expanded_scopes(left, right, expected, should_warn, recwarn):
     # run every test in both directions, to ensure symmetry of the inputs
     for a, b in [(left, right), (right, left)]:
-        intersection = _intersect_scopes(set(left), set(right))
+        intersection = _intersect_expanded_scopes(set(left), set(right))
         assert intersection == set(expected)
 
     if should_warn:

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -86,14 +86,14 @@ def test_scope_parse_server_name():
 
 class MockAPIHandler:
     def __init__(self):
-        self.raw_scopes = {'users'}
+        self.expanded_scopes = {'users'}
         self.parsed_scopes = {}
         self.request = mock.Mock(spec=HTTPServerRequest)
         self.request.path = '/path'
 
     def set_scopes(self, *scopes):
-        self.raw_scopes = set(scopes)
-        self.parsed_scopes = parse_scopes(self.raw_scopes)
+        self.expanded_scopes = set(scopes)
+        self.parsed_scopes = parse_scopes(self.expanded_scopes)
 
     @needs_scope('users')
     def user_thing(self, user_name):
@@ -195,7 +195,7 @@ def test_scope_method_access(mock_handler, scopes, method, arguments, is_allowed
 def test_double_scoped_method_succeeds(mock_handler):
     mock_handler.current_user = mock.Mock(name='lucille')
     mock_handler.set_scopes('users', 'read:services')
-    mock_handler.parsed_scopes = parse_scopes(mock_handler.raw_scopes)
+    mock_handler.parsed_scopes = parse_scopes(mock_handler.expanded_scopes)
     assert mock_handler.secret_thing()
 
 


### PR DESCRIPTION
1. Updates the RBAC utils in `roles.py` and `scopes.py` with consistent scope variable names:

- `scopes`: list of scopes with abbreviations (e.g., in role definition)
- `expanded scopes`: set of expanded scopes without abbreviations (i.e., resolved metascopes, filters and subscopes)
- `parsed scopes`: dictionary JSON like format of expanded scopes
- `intersection` : set of expanded scopes as intersection of 2 expanded scope sets
- `identify scopes`: set of expanded scopes needed for identify (whoami) endpoints

2. Updates functions' docstrings accordingly 
3. Updates some function names for clarity:
- `_intersect_scopes()` to `intersect_expanded_scopes()` (defined in `scopes.py)` to highlight that `expanded scopes` need to be passed as arguments
- `_check_scope()` to `_check_scope_access()` (defined in `scopes.py`) to distinguish it from `_check_scopes()` function in `roles.py` which checks if provided scope(s) exist 
- `_resolve_scopes()` to `_resolve_roles_and_scopes()` (defined in `handlers/base.py`) to reflect the whole process from expanding roles to scopes, including intersection for token, and parsing scopes
