### PR TITLE
[rbac] Use scopes.scope_definitions to expand scopes

### DIFF
--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -88,7 +88,7 @@ def _get_scope_hierarchy():
     ]
 
     scope_hierarchy = {}
-    for scope in scopes.scope_definitions.keys():
+    for scope, definition in scopes.scope_definitions.items():
 
         has_subscopes = scopes.scope_definitions[scope].get('subscopes')
         is_subscope = any(scope in subscope_list for subscope_list in subscope_lists)

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -37,12 +37,12 @@ scope_definitions = {
             'read:users:groups',
             'read:users:activity',
         ],
-        # TODO: add read:users:admin and read:users:roles as subscopes here once implemented
+        # TODO: add read:users:roles as subscopes here once implemented
     },
     'read:users:name': {'description': 'Read-only access to users’ names.'},
     'read:users:groups': {'description': 'Read-only access to users’ group names.'},
     'read:users:activity': {'description': 'Read-only access to users’ last activity.'},
-    # TODO: add read:users:admin and read:users:roles once implemented
+    # TODO: add read:users:roles once implemented
     'users:activity': {
         'description': 'Grants access to read and post users’ last activity only.',
         'subscopes': ['read:users:activity'],
@@ -79,10 +79,10 @@ scope_definitions = {
     'read:services': {
         'description': 'Read-only access to service models.',
         'subscopes': ['read:services:name'],
-        # TODO: add read:services:admin and read:services:roles as subscopes here once implemented
+        # TODO: add read:services:roles as subscopes here once implemented
     },
     'read:services:name': {'description': 'Read-only access to service names.'},
-    # TODO: add read:services:admin and read:services:roles once implemented
+    # TODO: add read:services:roles once implemented
     #'read:services:roles': {'description': 'Read-only access to service role names.'},
     'read:hub': {
         'description': 'Read-only access to detailed information about the Hub.'

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -36,13 +36,13 @@ scope_definitions = {
             'read:users:name',
             'read:users:groups',
             'read:users:activity',
-            'read:users:roles',
         ],
+        # TODO: add read:users:admin and read:users:roles as subscopes here once implemented
     },
     'read:users:name': {'description': 'Read-only access to users’ names.'},
     'read:users:groups': {'description': 'Read-only access to users’ group names.'},
-    'read:users:roles': {'description': 'Read-only access to users’ role names.'},
     'read:users:activity': {'description': 'Read-only access to users’ last activity.'},
+    # TODO: add read:users:admin and read:users:roles once implemented
     'users:activity': {
         'description': 'Grants access to read and post users’ last activity only.',
         'subscopes': ['read:users:activity'],
@@ -78,10 +78,12 @@ scope_definitions = {
     'read:groups': {'description': 'Read-only access to groups’ models.'},
     'read:services': {
         'description': 'Read-only access to service models.',
-        'subscopes': ['read:services:name', 'read:services:roles'],
+        'subscopes': ['read:services:name'],
+        # TODO: add read:services:admin and read:services:roles as subscopes here once implemented
     },
     'read:services:name': {'description': 'Read-only access to service names.'},
-    'read:services:roles': {'description': 'Read-only access to service role names.'},
+    # TODO: add read:services:admin and read:services:roles once implemented
+    #'read:services:roles': {'description': 'Read-only access to service role names.'},
     'read:hub': {
         'description': 'Read-only access to detailed information about the Hub.'
     },

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -213,6 +213,16 @@ def test_orm_roles_delete_cascade(db):
         (['read:users:servers'], {'read:users:servers', 'read:users:name'}),
         (['admin:groups'], {'admin:groups', 'groups', 'read:groups'}),
         (
+            ['admin:groups', 'read:users:servers'],
+            {
+                'admin:groups',
+                'groups',
+                'read:groups',
+                'read:users:servers',
+                'read:users:name',
+            },
+        ),
+        (
             ['users:tokens!group=hobbits'],
             {'users:tokens!group=hobbits', 'read:users:tokens!group=hobbits'},
         ),


### PR DESCRIPTION
~`roles._get_scope_hierarchy()` now returns scope hierarchy dictionary created from the `scopes.scope_definitions` dictionary.~

~Eliminates the need for manual update of the _get_scope_hierarchy() used for expanding scopes and checking scope names.~

**Update**:
With the `scopes.scope_definitions` dictionary there is no need to create separate dictionary of scope hierarchy (`_get_scope_hierarchy()`). The `scopes.scope_definitions` can be used directly to obtain all subscopes for a scope. Checking scope names in `_check_scopes()` can also use this dictionary directly.
