### PR TITLE
Removed default service roles from upgrade and docs

### DIFF
--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -25,8 +25,11 @@ Roles can be assigned to the following entities:
 
 An entity can have zero, one, or multiple roles, and there are no restrictions on which roles can be assigned to which entity. Roles can be added to or removed from entities at any time.
 
-**Users and services** \
-When a new user or service gets created, they are assigned their default role ( `user` or `admin`) if no custom role is requested, currently based on their admin status.
+**Users** \
+When a new user gets created, they are assigned their default role ( `user` or `admin`) if no custom role is requested, currently based on their admin status.
+
+**Services** \
+Services do not have a default role. Services without roles have no access to the guarded API end-points, so most services will require assignment of a role in order to function.
 
 **Groups** \
 A group does not require any role, and has no roles by default. If a user is a member of a group, they automatically inherit any of the group's permissions (see {ref}`resolving-roles-scopes-target` for more details). This is useful for assigning a set of common permissions to several users.

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -488,7 +488,7 @@ def check_for_default_roles(db, bearer):
     Groups can be without a role
     """
     Class = orm.get_class(bearer)
-    if Class == orm.Group:
+    if Class in {orm.Group, orm.Service}:
         pass
     else:
         for obj in (

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -521,20 +521,10 @@ async def test_load_roles_services(tmpdir, request):
     # test if predefined roles loaded and assigned
     culler_role = orm.Role.find(db, name='idle-culler')
     culler_service = orm.Service.find(db, name='idle-culler')
-    assert culler_role in culler_service.roles
-
-    # test if every service has a role (and no duplicates)
-    for service in db.query(orm.Service):
-        assert len(service.roles) > 0
-        assert len(service.roles) == len(set(service.roles))
-
-        # test default role assignment
-        if service.admin:
-            assert admin_role in service.roles
-            assert user_role not in service.roles
-        elif culler_role not in service.roles:
-            assert user_role in service.roles
-            assert admin_role not in service.roles
+    assert culler_service.roles == [culler_role]
+    user_service = orm.Service.find(db, name='user_service')
+    assert not user_service.roles
+    assert admin_service.roles == [admin_role]
 
     # delete the test services
     for service in db.query(orm.Service):


### PR DESCRIPTION
New services no longer obtain a default role upon creation (or upgrade of JH to RBAC). Docs have been adjusted to reflect this.