### PR TITLE
[rbac] Authorization page for OAuth services

### DIFF
--- a/docs/source/rbac/generate-scope-table.py
+++ b/docs/source/rbac/generate-scope-table.py
@@ -63,7 +63,7 @@ class ScopeTableGenerator:
             description = self.scopes[scopename]['description']
             meta_description = self.scopes[scopename].get('metadescription', '')
             if meta_description:
-                description = description.rstrip('.') + f" ({meta_description})."
+                description = description.rstrip('.') + f" __({meta_description})__."
             table_row = [f"{md_indent*depth}`{scopename}`", description]
             table_rows.append(table_row)
             for subscope in scope_pairs[scopename]:

--- a/docs/source/rbac/generate-scope-table.py
+++ b/docs/source/rbac/generate-scope-table.py
@@ -61,6 +61,9 @@ class ScopeTableGenerator:
 
         def _add_subscopes(table_rows, scopename, depth=0):
             description = self.scopes[scopename]['description']
+            meta_description = self.scopes[scopename].get('metadescription', '')
+            if meta_description:
+                description = description.rstrip('.') + f" ({meta_description})."
             table_row = [f"{md_indent*depth}`{scopename}`", description]
             table_rows.append(table_row)
             for subscope in scope_pairs[scopename]:
@@ -76,7 +79,7 @@ class ScopeTableGenerator:
         """Generates the scope table in markdown format and writes it into scope-table.md file"""
         filename = f"{HERE}/scope-table.md"
         table_name = ""
-        headers = ["Scope", "Description"]
+        headers = ["Scope", "Grants permission to:"]
         values = self._parse_scopes()
         writer = self.create_writer(table_name, headers, values)
 

--- a/docs/source/rbac/generate-scope-table.py
+++ b/docs/source/rbac/generate-scope-table.py
@@ -63,7 +63,7 @@ class ScopeTableGenerator:
             description = self.scopes[scopename]['description']
             meta_description = self.scopes[scopename].get('metadescription', '')
             if meta_description:
-                description = description.rstrip('.') + f" __({meta_description})__."
+                description = description.rstrip('.') + f" _({meta_description})_."
             table_row = [f"{md_indent*depth}`{scopename}`", description]
             table_rows.append(table_row)
             for subscope in scope_pairs[scopename]:

--- a/docs/source/rbac/generate-scope-table.py
+++ b/docs/source/rbac/generate-scope-table.py
@@ -61,9 +61,9 @@ class ScopeTableGenerator:
 
         def _add_subscopes(table_rows, scopename, depth=0):
             description = self.scopes[scopename]['description']
-            meta_description = self.scopes[scopename].get('metadescription', '')
-            if meta_description:
-                description = description.rstrip('.') + f" _({meta_description})_."
+            doc_description = self.scopes[scopename].get('doc_description', '')
+            if doc_description:
+                description = doc_description
             table_row = [f"{md_indent*depth}`{scopename}`", description]
             table_rows.append(table_row)
             for subscope in scope_pairs[scopename]:

--- a/examples/service-whoami/jupyterhub_config.py
+++ b/examples/service-whoami/jupyterhub_config.py
@@ -10,6 +10,7 @@ c.JupyterHub.services = [
         'name': 'whoami-oauth',
         'url': 'http://127.0.0.1:10102',
         'command': [sys.executable, './whoami-oauth.py'],
+        'oauth_roles': ['user'],
     },
 ]
 

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -1,6 +1,7 @@
 """Authorization handlers"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import itertools
 import json
 from datetime import datetime
 from urllib.parse import parse_qsl
@@ -13,6 +14,7 @@ from oauthlib import oauth2
 from tornado import web
 
 from .. import orm
+from .. import roles
 from .. import scopes
 from ..utils import token_authenticated
 from .base import APIHandler
@@ -174,12 +176,16 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
             raise
         self.send_oauth_response(headers, body, status)
 
-    def needs_oauth_confirm(self, user, oauth_client):
+    def needs_oauth_confirm(self, user, oauth_client, roles):
         """Return whether the given oauth client needs to prompt for access for the given user
 
         Checks list for oauth clients that don't need confirmation
 
-        (i.e. the user's own server)
+        Sources:
+
+        - the user's own servers
+        - Clients which already have authorization for the same roles
+        - Explicit oauth_no_confirm_list configuration (e.g. admin-operated services)
 
         .. versionadded: 1.1
         """
@@ -195,6 +201,30 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
             in self.settings.get('oauth_no_confirm_list', set())
         ):
             return False
+
+        # Check existing authorization
+        existing_tokens = self.db.query(orm.APIToken).filter_by(
+            user_id=user.id,
+            client_id=oauth_client.identifier,
+        )
+        authorized_roles = set()
+        for token in existing_tokens:
+            authorized_roles.update({role.name for role in token.roles})
+
+        if authorized_roles:
+            if set(roles).issubset(authorized_roles):
+                self.log.debug(
+                    f"User {user.name} has already authorized {oauth_client.identifier} for roles {roles}"
+                )
+                # FIXME: uncomment after debugging
+                # it's easier to run manual tests
+                # if we always show the confirmation page
+                # return False
+            else:
+                self.log.debug(
+                    f"User {user.name} has authorized {oauth_client.identifier}"
+                    f" for roles {authorized_roles}, confirming additonal roles {roles}"
+                )
         # default: require confirmation
         return True
 
@@ -211,53 +241,66 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
 
         uri, http_method, body, headers = self.extract_oauth_params()
         try:
-            scopes, credentials = self.oauth_provider.validate_authorization_request(
+            (
+                role_names,
+                credentials,
+            ) = self.oauth_provider.validate_authorization_request(
                 uri, http_method, body, headers
             )
             credentials = self.add_credentials(credentials)
             client = self.oauth_provider.fetch_by_client_id(credentials['client_id'])
-            allowed = False
-
-            # check for access to target resource
-            if client.spawner:
-                scope_filter = self.get_scope_filter("access:users:servers")
-                allowed = scope_filter(client.spawner, kind='server')
-            elif client.service:
-                scope_filter = self.get_scope_filter("access:services")
-                allowed = scope_filter(client.service, kind='service')
-            else:
-                # client is not associated with a service or spawner.
-                # This shouldn't happen, but it might if this is a stale or forged request
-                # from a service or spawner that's since been deleted
-                self.log.error(
-                    f"OAuth client {client} has no service or spawner, cannot resolve scopes."
-                )
-                raise web.HTTPError(500, "OAuth configuration error")
-
-            if not allowed:
-                self.log.error(
-                    f"User {self.current_user} not allowed to access {client.description}"
-                )
-                raise web.HTTPError(
-                    403, f"You do not have permission to access {client.description}"
-                )
-            if not self.needs_oauth_confirm(self.current_user, client):
+            if not self.needs_oauth_confirm(self.current_user, client, role_names):
                 self.log.debug(
                     "Skipping oauth confirmation for %s accessing %s",
                     self.current_user,
                     client.description,
                 )
                 # this is the pre-1.0 behavior for all oauth
-                self._complete_login(uri, headers, scopes, credentials)
+                self._complete_login(uri, headers, role_names, credentials)
                 return
 
+            # resolve roles to scopes for authorization page
+            role_objects = (
+                self.db.query(orm.Role).filter(orm.Role.name.in_(role_names)).all()
+            )
+            raw_scopes = set(itertools.chain(*(role.scopes for role in role_objects)))
+            if not raw_scopes:
+                scope_descriptions = [
+                    {
+                        "scope": None,
+                        "description": scopes.scope_definitions['(no_scope)'][
+                            'description'
+                        ],
+                        "filter": "",
+                    }
+                ]
+            elif 'all' in raw_scopes:
+                raw_scopes = ['all']
+                expanded_scopes = ['all']
+                scope_descriptions = [
+                    {
+                        "scope": "all",
+                        "description": scopes.scope_definitions['all']['description'],
+                        "filter": "",
+                    }
+                ]
+            else:
+                # expanded_scopes = roles._get_subscopes(*role_objects, owner=self.current_user.orm_user)
+                # print("expanded scopes", expanded_scopes, self.current_user)
+                # parsed_scopes = scopes.parse_scopes(expanded_scopes)
+                scope_descriptions = scopes.describe_raw_scopes(
+                    raw_scopes,
+                    username=self.current_user.name,
+                )
+            print("scope definitions", raw_scopes, scope_descriptions)
             # Render oauth 'Authorize application...' page
             auth_state = await self.current_user.get_auth_state()
             self.write(
                 await self.render_template(
                     "oauth.html",
                     auth_state=auth_state,
-                    scopes=scopes,
+                    role_names=role_names,
+                    scope_descriptions=scope_descriptions,
                     oauth_client=client,
                 )
             )

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2264,7 +2264,11 @@ class JupyterHub(Application):
                     client_id=service.oauth_client_id,
                     client_secret=service.api_token,
                     redirect_uri=service.oauth_redirect_uri,
-                    allowed_roles=service.oauth_roles,
+                    allowed_roles=list(
+                        self.db.query(orm.Role).filter(
+                            orm.Role.name.in_(service.oauth_roles)
+                        )
+                    ),
                     description="JupyterHub service %s" % service.name,
                 )
                 service.orm.oauth_client_id = service.oauth_client_id

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -81,16 +81,17 @@ def expand_self_scope(name):
     """
     scope_list = [
         'users',
-        'users:name',
-        'users:groups',
+        'read:users',
+        'read:users:name',
+        'read:users:groups',
         'users:activity',
+        'read:users:activity',
         'users:servers',
+        'read:users:servers',
         'users:tokens',
+        'read:users:tokens',
+        'access:users:servers',
     ]
-    read_scope_list = ['read:' + scope for scope in scope_list]
-    # access doesn't want the 'read:' prefix
-    scope_list.append('access:users:servers')
-    scope_list.extend(read_scope_list)
     return {"{}!user={}".format(scope, name) for scope in scope_list}
 
 
@@ -164,24 +165,22 @@ def expand_roles_to_scopes(orm_object):
     return expanded_scopes
 
 
-def _get_subscopes(*args, owner=None):
+def _get_subscopes(*roles, owner=None):
     """Returns a set of all available subscopes for a specified role or list of roles
 
     Arguments:
-      role (obj): orm.Role
-      or
-      roles (list): list of orm.Roles
+      roles (obj): orm.Roles
       owner (obj, optional): orm.User or orm.Service as owner of orm.APIToken
 
     Returns:
       expanded scopes (set): set of all expanded scopes for the role(s)
     """
-    scope_list = []
+    scopes = set()
 
-    for role in args:
-        scope_list.extend(role.scopes)
+    for role in roles:
+        scopes.update(role.scopes)
 
-    expanded_scopes = set(chain.from_iterable(list(map(_expand_scope, scope_list))))
+    expanded_scopes = set(chain.from_iterable(list(map(_expand_scope, scopes))))
 
     # transform !user filter to !user=ownername
     for scope in expanded_scopes:

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -23,82 +23,79 @@ from . import orm
 from . import roles
 
 scope_definitions = {
-    '(no_scope)': {'description': 'Allows for only identifying the owning entity.'},
+    '(no_scope)': {'description': 'Identify the owner of this entity.'},
     'self': {
-        'description': 'Metascope, grants access to user’s own resources only; resolves to (no_scope) for services.'
+        'description': 'The user’s own resources.',
+        'metadescription': 'metascope for users, resolves to (no_scope) for services',
     },
     'all': {
-        'description': 'Metascope, valid for tokens only. Grants access to everything that the token-owning entity can access.'
+        'description': 'Everything that the token-owning entity can access.',
+        'metadescription': 'metascope for tokens',
     },
     'admin:users': {
-        'description': 'Grants read, write, create and delete access to users and their authentication state, not including their servers or tokens.',
+        'description': 'Read, write, create and delete users and their authentication state, not including their servers or tokens.',
         'subscopes': ['admin:users:auth_state', 'users', 'read:users:roles'],
     },
-    'admin:users:auth_state': {
-        'description': 'Grants access to user authentication state.'
-    },
+    'admin:users:auth_state': {'description': 'Read a user’s authentication state.'},
     'users': {
-        'description': 'Grants read and write permissions to user models, not including servers, tokens and authentication state.',
+        'description': 'Read and write permissions to user models, e servers, tokens and authentication state.',
         'subscopes': ['read:users', 'users:activity'],
     },
     'read:users': {
-        'description': 'Read-only access to user models, not including servers, tokens and authentication state.',
+        'description': 'Read user models, (exluding including servers, tokens and authentication state).',
         'subscopes': [
             'read:users:name',
             'read:users:groups',
             'read:users:activity',
         ],
     },
-    'read:users:name': {'description': 'Read-only access to users’ names.'},
-    'read:users:groups': {'description': 'Read-only access to users’ group names.'},
-    'read:users:activity': {'description': 'Read-only access to users’ last activity.'},
-    # todo: describe that it only specifies timestamp of activity
-    'read:users:roles': {'description': 'Read-only access to user roles.'},
+    'read:users:name': {'description': 'Read names of users.'},
+    'read:users:groups': {'description': 'Read names of users’ groups.'},
+    'read:users:activity': {'description': 'Read time of last user activity'},
+    'read:users:roles': {'description': 'Read names of users’ roles.'},
     'users:activity': {
-        'description': 'Grants access to read and update user activity.',
+        'description': 'Update time of last user activity.',
         'subscopes': ['read:users:activity'],
     },
     'admin:users:servers': {
-        'description': 'Grants read, start/stop, create and delete permissions to user servers and their state.',
+        'description': 'Read, start, stop, create and delete user servers and their state.',
         'subscopes': ['admin:users:server_state', 'users:servers'],
     },
-    'admin:users:server_state': {'description': 'Grants access to server state only.'},
+    'admin:users:server_state': {'description': 'Read and write users’ server state.'},
     'users:servers': {
-        'description': 'Allows for starting/stopping user servers. Does not include the server state.',
+        'description': 'Start and stop user servers.',
         'subscopes': ['read:users:servers'],
     },
     'read:users:servers': {
-        'description': 'Read-only access to users’ names and their server models. Does not include the server state.',
+        'description': 'Read users’ names and their server models. Does not include the server state.',
         'subscopes': ['read:users:name'],
     },
     'users:tokens': {
-        'description': 'Grants read, write, create and delete permissions for user tokens.',
+        'description': 'Read, write, create and delete user tokens.',
         'subscopes': ['read:users:tokens'],
     },
-    'read:users:tokens': {'description': 'Read-only access to user tokens.'},
+    'read:users:tokens': {'description': 'Read user tokens.'},
     'admin:groups': {
-        'description': 'Grants read, write, create and delete access to groups.',
+        'description': 'Read and write group information, create and delete groups.',
         'subscopes': ['groups', 'read:groups:roles'],
     },
     'groups': {
-        'description': 'Grants read and write permissions to groups, including adding/removing users to/from groups.',
+        'description': 'Read and write group information, including adding/removing users to/from groups.',
         'subscopes': ['read:groups'],
     },
     'read:groups': {
-        'description': 'Read-only access to group models.',
+        'description': 'Read group models.',
         'subscopes': ['read:groups:name'],
     },
-    'read:groups:name': {'description': 'Read-only access to group names.'},
-    'read:groups:roles': {'description': 'Read-only access to group role names.'},
+    'read:groups:name': {'description': 'Read group names.'},
+    'read:groups:roles': {'description': 'Read group role names.'},
     'read:services': {
-        'description': 'Read-only access to service models.',
+        'description': 'Read service models.',
         'subscopes': ['read:services:name'],
     },
-    'read:services:name': {'description': 'Read-only access to service names.'},
-    'read:services:roles': {'description': 'Read-only access to service role names.'},
-    'read:hub': {
-        'description': 'Read-only access to detailed information about the Hub.'
-    },
+    'read:services:name': {'description': 'Read service names.'},
+    'read:services:roles': {'description': 'Read service role names.'},
+    'read:hub': {'description': 'Read detailed information about the Hub.'},
     'access:users:servers': {
         'description': 'Access user servers via API or browser.',
     },
@@ -106,9 +103,9 @@ scope_definitions = {
         'description': 'Access services via API or browser.',
     },
     'proxy': {
-        'description': 'Allows for obtaining information about the proxy’s routing table, for syncing the Hub with proxy and notifying the Hub about a new proxy.'
+        'description': 'Read information about the proxy’s routing table, sync the Hub with the proxy and notify the Hub about a new proxy.'
     },
-    'shutdown': {'description': 'Grants access to shutdown the hub.'},
+    'shutdown': {'description': 'Shutdown the hub.'},
 }
 
 

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -23,7 +23,7 @@ from . import orm
 from . import roles
 
 scope_definitions = {
-    '(no_scope)': {'description': 'Identify the owner of this entity.'},
+    '(no_scope)': {'description': 'Identify the owner of the requesting entity.'},
     'self': {
         'description': 'Your own resources',
         'doc_description': 'The user’s own resources _(metascope for users, resolves to (no_scope) for services)_',

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -38,11 +38,11 @@ scope_definitions = {
     },
     'admin:users:auth_state': {'description': 'Read a user’s authentication state.'},
     'users': {
-        'description': 'Read and write permissions to user models, e servers, tokens and authentication state.',
+        'description': 'Read and write permissions to user models (excluding servers, tokens and authentication state).',
         'subscopes': ['read:users', 'users:activity'],
     },
     'read:users': {
-        'description': 'Read user models, (exluding including servers, tokens and authentication state).',
+        'description': 'Read user models (excluding including servers, tokens and authentication state).',
         'subscopes': [
             'read:users:name',
             'read:users:groups',
@@ -51,7 +51,7 @@ scope_definitions = {
     },
     'read:users:name': {'description': 'Read names of users.'},
     'read:users:groups': {'description': 'Read names of users’ groups.'},
-    'read:users:activity': {'description': 'Read time of last user activity'},
+    'read:users:activity': {'description': 'Read time of last user activity.'},
     'read:users:roles': {'description': 'Read names of users’ roles.'},
     'users:activity': {
         'description': 'Update time of last user activity.',
@@ -67,7 +67,7 @@ scope_definitions = {
         'subscopes': ['read:users:servers'],
     },
     'read:users:servers': {
-        'description': 'Read users’ names and their server models. Does not include the server state.',
+        'description': 'Read users’ names and their server models (excluding the server state).',
         'subscopes': ['read:users:name'],
     },
     'users:tokens': {

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -25,12 +25,12 @@ from . import roles
 scope_definitions = {
     '(no_scope)': {'description': 'Identify the owner of this entity.'},
     'self': {
-        'description': 'The user’s own resources.',
-        'metadescription': 'metascope for users, resolves to (no_scope) for services',
+        'description': 'Your own resources',
+        'doc_description': 'The user’s own resources _(metascope for users, resolves to (no_scope) for services)_',
     },
     'all': {
-        'description': 'Everything that the token-owning entity can access.',
-        'metadescription': 'metascope for tokens',
+        'description': 'Anything you have access to',
+        'doc_description': 'Everything that the token-owning entity can access _(metascope for tokens)_',
     },
     'admin:users': {
         'description': 'Read, write, create and delete users and their authentication state, not including their servers or tokens.',
@@ -50,9 +50,9 @@ scope_definitions = {
         ],
     },
     'read:users:name': {'description': 'Read names of users.'},
-    'read:users:groups': {'description': 'Read names of users’ groups.'},
+    'read:users:groups': {'description': 'Read users’ group membership.'},
     'read:users:activity': {'description': 'Read time of last user activity.'},
-    'read:users:roles': {'description': 'Read names of users’ roles.'},
+    'read:users:roles': {'description': 'Read users’ role assignments.'},
     'users:activity': {
         'description': 'Update time of last user activity.',
         'subscopes': ['read:users:activity'],
@@ -88,13 +88,13 @@ scope_definitions = {
         'subscopes': ['read:groups:name'],
     },
     'read:groups:name': {'description': 'Read group names.'},
-    'read:groups:roles': {'description': 'Read group role names.'},
+    'read:groups:roles': {'description': 'Read group role assignments.'},
     'read:services': {
         'description': 'Read service models.',
         'subscopes': ['read:services:name'],
     },
     'read:services:name': {'description': 'Read service names.'},
-    'read:services:roles': {'description': 'Read service role names.'},
+    'read:services:roles': {'description': 'Read service role assignments.'},
     'read:hub': {'description': 'Read detailed information about the Hub.'},
     'access:users:servers': {
         'description': 'Access user servers via API or browser.',

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -946,6 +946,13 @@ async def test_bad_oauth_get(app, params):
     assert r.status_code == 400
 
 
+async def test_oauth_page_scope_appearance(app):
+    # Test scopes presence
+    # test subscopes presence
+    # test filter presence
+    pass
+
+
 async def test_token_page(app):
     name = "cake"
     cookies = await app.login_user(name)

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -12,8 +12,10 @@ from tornado.escape import url_escape
 from tornado.httputil import url_concat
 
 from .. import orm
+from .. import scopes
 from ..auth import Authenticator
 from ..handlers import BaseHandler
+from ..utils import url_path_join
 from ..utils import url_path_join as ujoin
 from .mocking import FalsyCallableFormSpawner
 from .mocking import FormSpawner
@@ -21,6 +23,7 @@ from .test_api import next_event
 from .utils import add_user
 from .utils import api_request
 from .utils import async_requests
+from .utils import AsyncSession
 from .utils import get_page
 from .utils import public_host
 from .utils import public_url
@@ -946,11 +949,42 @@ async def test_bad_oauth_get(app, params):
     assert r.status_code == 400
 
 
-async def test_oauth_page_scope_appearance(app):
-    # Test scopes presence
-    # test subscopes presence
-    # test filter presence
-    pass
+async def test_oauth_page_scope_appearance(
+    app, mockservice_url, create_user_with_scopes, create_temp_role
+):
+    service_role = create_temp_role(
+        [
+            'self',
+            'read:users!user=gawain',
+            'read:users:tokens',
+            'read:groups!group=mythos',
+        ]
+    )
+    service = mockservice_url
+    user = create_user_with_scopes("access:services")
+    oauth_client = (
+        app.db.query(orm.OAuthClient)
+        .filter_by(identifier=service.oauth_client_id)
+        .one()
+    )
+    oauth_client.allowed_roles = [service_role]
+    app.db.commit()
+
+    s = AsyncSession()
+    s.cookies = await app.login_user(user.name)
+    url = url_path_join(public_url(app, service) + 'owhoami/?arg=x')
+    r = await s.get(url)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+    scopes_block = soup.find('form')
+    for scope in service_role.scopes:
+        base_scope, _, filter_ = scope.partition('!')
+        scope_def = scopes.scope_definitions[base_scope]
+        assert scope_def['description'] in scopes_block.text
+        if filter_:
+            kind, _, name = filter_.partition('=')
+            assert kind in scopes_block.text
+            assert name in scopes_block.text
 
 
 async def test_token_page(app):

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -372,6 +372,30 @@ async def test_oauth_access_scopes(
     assert r.status_code == 403
 
 
+async def test_oauth_page_memory(app):
+    pass
+    # add service
+    # Login
+    # go to service oauth page
+    # hit auth page
+    # go to service oauth page again
+    # don't hit auth page
+    # clear authorization
+    # go to service oauth page
+    # hit auth page
+
+
+async def test_oauth_page_role_expansion(app):
+    pass
+    # add service
+    # login
+    # go to service oauth page
+    # hit auth page
+    # expand service roles
+    # go to service oauth page
+    # hit auth page again
+
+
 async def test_oauth_cookie_collision(app, mockservice_url, create_user_with_scopes):
     service = mockservice_url
     url = url_path_join(public_url(app, mockservice_url), 'owhoami/')

--- a/share/jupyterhub/templates/oauth.html
+++ b/share/jupyterhub/templates/oauth.html
@@ -5,48 +5,47 @@
 
 {% block main %}
 <div class="container col-md-6 col-md-offset-3">
-  <h1 class="text-center">Authorize access</h1>
+    <h1 class="text-center">Authorize access</h1>
 
-  <h2>
-    A service is attempting to authorize with your
-    JupyterHub account
-  </h2>
+    <h2>
+        An application is requesting authorization to access data associated with your JupyterHub account
+    </h2>
 
-  <p>
-    {{ oauth_client.description }} (oauth URL: {{ oauth_client.redirect_uri }})
-    would like permission to identify you.
-    {% if not role_names %}
-    It will not be able to take actions on
-    your behalf.
-    {% endif %}
-  </p>
+    <p>
+        {{ oauth_client.description }} (oauth URL: {{ oauth_client.redirect_uri }})
+        would like permission to identify you.
+        {% if not role_names %}
+        It will not be able to take actions on
+        your behalf.
+        {% endif %}
+    </p>
 
-  <h3>This will grant the application permission to:</h3>
-  <div>
-    <form method="POST" action="">
-      {# these are the 'real' inputs to the form -#}
-      {% for role_name in role_names %}
-      <input type="hidden" name="scopes" value="{{ role_name }}" />
-      {% endfor %}
+    <h3>This will grant the application permission to:</h3>
+    <div>
+        <form method="POST" action="">
+            {# these are the 'real' inputs to the form -#}
+            {% for role_name in role_names %}
+            <input type="hidden" name="scopes" value="{{ role_name }}"/>
+            {% endfor %}
 
-      {% for scope_info in scope_descriptions %}
-      <div class="checkbox input-group">
-        <label>
-          <input type="checkbox" name="raw-scopes" checked="true" title="This
-          authorization is required" disabled="disabled" {# disabled because
-          it's required #} />
-          <span>
+            {% for scope_info in scope_descriptions %}
+            <div class="checkbox input-group">
+                <label>
+                    <input type="checkbox" name="raw-scopes" checked="true" title="This authorization is required"
+                           disabled="disabled"
+                           {# disabled because it's required #} />
+                    <span>
             {{ scope_info['description'] }}
             {% if scope_info['filter'] %}
             Applies to {{ scope_info['filter'] }}.
             {% endif %}
           </span>
-        </label>
-      </div>
-      {% endfor %}
-      <input type="submit" value="Authorize" class="form-control btn-jupyter" />
-    </form>
-  </div>
+                </label>
+            </div>
+            {% endfor %}
+            <input type="submit" value="Authorize" class="form-control btn-jupyter"/>
+        </form>
+    </div>
 </div>
 
 {% endblock %}

--- a/share/jupyterhub/templates/oauth.html
+++ b/share/jupyterhub/templates/oauth.html
@@ -15,37 +15,38 @@
   <p>
     {{ oauth_client.description }} (oauth URL: {{ oauth_client.redirect_uri }})
     would like permission to identify you.
-    {% if scopes == ["identify"] %}
-    It will not be able to take actions on your behalf.
+    {% if not role_names %}
+    It will not be able to take actions on
+    your behalf.
     {% endif %}
   </p>
 
   <h3>The application will be able to:</h3>
   <div>
     <form method="POST" action="">
-      {% for scope in scopes %}
+      {# these are the 'real' inputs to the form -#}
+      {% for role_name in role_names %}
+      <input type="hidden" name="scopes" value="{{ role_name }}" />
+      {% endfor %}
+
+      {% for scope_info in scope_descriptions %}
       <div class="checkbox input-group">
         <label>
-          <input type="checkbox"
-                 name="scopes"
-                 checked="true"
-                 title="This authorization is required"
-                 disabled="disabled" {# disabled because it's required #}
-                 value="{{ scope }}"
-          />
-          {# disabled checkbox isn't included in form, so this is the real one #}
-          <input type="hidden" name="scopes" value="{{ scope }}"/>
+          <input type="checkbox" name="raw-scopes" checked="true" title="This
+          authorization is required" disabled="disabled" {# disabled because
+          it's required #} />
           <span>
-            {# TODO: use scope description when there's more than one #}
-            See your JupyterHub username and group membership (read-only).
+            {{ scope_info['description'] }}
+            {% if scope_info['filter'] %}
+            For {{ scope_info['filter'] }}.
+            {% endif %}
           </span>
         </label>
       </div>
       {% endfor %}
-      <input type="submit" value="Authorize" class="form-control btn-jupyter"/>
+      <input type="submit" value="Authorize" class="form-control btn-jupyter" />
     </form>
   </div>
 </div>
-
 
 {% endblock %}

--- a/share/jupyterhub/templates/oauth.html
+++ b/share/jupyterhub/templates/oauth.html
@@ -21,7 +21,7 @@
     {% endif %}
   </p>
 
-  <h3>The application will be able to:</h3>
+  <h3>This will grant the application permission to:</h3>
   <div>
     <form method="POST" action="">
       {# these are the 'real' inputs to the form -#}
@@ -38,7 +38,7 @@
           <span>
             {{ scope_info['description'] }}
             {% if scope_info['filter'] %}
-            For {{ scope_info['filter'] }}.
+            Applies to {{ scope_info['filter'] }}.
             {% endif %}
           </span>
         </label>


### PR DESCRIPTION
Continuing from @minrk's [fork](https://github.com/minrk/jupyterhub/tree/authorization-page)

Updates the authorization page for OAuth services to show their required permissions based on their scopes.
Also updates the scope permission descriptions to be usable in both documentations and requesting authorization.