### PR TITLE
exclude dependabot push events from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ name: Release
 # but only publish to PyPI on tags
 on:
   push:
+    branches:
+      - "!dependabot/**"
   pull_request:
 
 jobs:


### PR DESCRIPTION
it's failing in the tag calculation action

maybe the action itself should do something special to avoid dependabot branches?
