### PR TITLE
Add research study participation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 **[License](#license)** |
 **[Help and Resources](#help-and-resources)**
 
+---
+
+Please note that this repository is participating in a study into sustainability
+ of open source projects. Data will be gathered about this repository for
+ approximately the next 12 months, starting from 2021-06-11.
+
+Data collected will include number of contributors, number of PRs, time taken to
+ close/merge these PRs, and issues closed.
+
+For more information, please visit
+[our informational page](https://sustainable-open-science-and-software.github.io/) or download our [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).
+
+---
+
 # [JupyterHub](https://github.com/jupyterhub/jupyterhub)
 
 [![Latest PyPI version](https://img.shields.io/pypi/v/jupyterhub?logo=pypi)](https://pypi.python.org/pypi/jupyterhub)

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 ---
 
 Please note that this repository is participating in a study into sustainability
- of open source projects. Data will be gathered about this repository for
- approximately the next 12 months, starting from 2021-06-11.
+of open source projects. Data will be gathered about this repository for
+approximately the next 12 months, starting from 2021-06-11.
 
 Data collected will include number of contributors, number of PRs, time taken to
- close/merge these PRs, and issues closed.
+close/merge these PRs, and issues closed.
 
 For more information, please visit
 [our informational page](https://sustainable-open-science-and-software.github.io/) or download our [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).


### PR DESCRIPTION
This PR just adds a notice to the readme informing folks that the repo is participating in an open source sustainability study, see https://github.com/jupyterhub/team-compass/issues/417 for reference