### PR TITLE
release docker workflow: 'branchRegex: ^\w[\w-.]*$'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub:"
           defaultTag: "${{ env.REGISTRY }}jupyterhub/jupyterhub:noref"
+          branchRegex: ^\w[\w-.]*$
 
       - name: Build and push jupyterhub
         uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f # associated tag: v2.4.0
@@ -152,6 +153,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub-onbuild:"
           defaultTag: "${{ env.REGISTRY }}jupyterhub/jupyterhub-onbuild:noref"
+          branchRegex: ^\w[\w-.]*$
 
       - name: Build and push jupyterhub-onbuild
         uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f # associated tag: v2.4.0
@@ -172,6 +174,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.REGISTRY }}jupyterhub/jupyterhub-demo:"
           defaultTag: "${{ env.REGISTRY }}jupyterhub/jupyterhub-demo:noref"
+          branchRegex: ^\w[\w-.]*$
 
       - name: Build and push jupyterhub-demo
         uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f # associated tag: v2.4.0


### PR DESCRIPTION
If a branch-name is not a valid docker tag use a default instead. See https://github.com/jupyterhub/jupyterhub/pull/3505

Question: revert #3505 or not?