### PR TITLE
[rbac] ensure managed services work with internal ssl

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2290,7 +2290,7 @@ class JupyterHub(Application):
             if not service.url:
                 continue
             try:
-                await Server.from_orm(service.orm.server).wait_up(timeout=1)
+                await Server.from_orm(service.orm.server).wait_up(timeout=1, http=True)
             except TimeoutError:
                 self.log.warning(
                     "Cannot connect to %s service %s at %s",
@@ -2983,7 +2983,7 @@ class JupyterHub(Application):
             if service.managed:
                 self.log.info("Starting managed service %s", msg)
                 try:
-                    service.start()
+                    await service.start()
                 except Exception as e:
                     self.log.critical(
                         "Failed to start service %s", service_name, exc_info=True
@@ -2996,11 +2996,6 @@ class JupyterHub(Application):
                 tries = 10 if service.managed else 1
                 for i in range(tries):
                     try:
-                        ssl_context = make_ssl_context(
-                            self.internal_ssl_key,
-                            self.internal_ssl_cert,
-                            cafile=self.internal_ssl_ca,
-                        )
                         await Server.from_orm(service.orm.server).wait_up(
                             http=True, timeout=1, ssl_context=ssl_context
                         )

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -29,6 +29,7 @@ import asyncio
 import inspect
 import os
 import sys
+from functools import partial
 from getpass import getuser
 from subprocess import TimeoutExpired
 from unittest import mock
@@ -263,7 +264,7 @@ def _mockservice(request, app, url=False):
         async def start():
             # wait for proxy to be updated before starting the service
             await app.proxy.add_all_services(app._service_map)
-            service.start()
+            await service.start()
 
         io_loop.run_sync(start)
 
@@ -277,7 +278,7 @@ def _mockservice(request, app, url=False):
         with raises(TimeoutExpired):
             service.proc.wait(1)
         if url:
-            io_loop.run_sync(service.server.wait_up)
+            io_loop.run_sync(partial(service.server.wait_up, http=True))
     return service
 
 


### PR DESCRIPTION
- ensure create_certs is called for managed services
- wait for services with http, which checks ssl connections (without http, only tcp was checked, which doesn't verify it works!)