### PR TITLE
[rbac] Revoke tokens for OAuth services if roles expand permissions

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -290,10 +290,14 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
                 return
 
             # resolve roles to scopes for authorization page
-            role_objects = (
-                self.db.query(orm.Role).filter(orm.Role.name.in_(role_names)).all()
-            )
-            raw_scopes = set(itertools.chain(*(role.scopes for role in role_objects)))
+            raw_scopes = set()
+            if role_names:
+                role_objects = (
+                    self.db.query(orm.Role).filter(orm.Role.name.in_(role_names)).all()
+                )
+                raw_scopes = set(
+                    itertools.chain(*(role.scopes for role in role_objects))
+                )
             if not raw_scopes:
                 scope_descriptions = [
                     {

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1985,13 +1985,41 @@ class JupyterHub(Application):
         config_role_names = [r['name'] for r in self.load_roles]
 
         init_roles = default_roles
-        for role_name in config_role_names:
+        roles_with_new_permissions = []
+        for role_spec in self.load_roles:
+            role_name = role_spec['name']
+            # Check for duplicates
             if config_role_names.count(role_name) > 1:
                 raise ValueError(
                     f"Role {role_name} multiply defined. Please check the `load_roles` configuration"
                 )
-        for role_spec in self.load_roles:
             init_roles.append(role_spec)
+            # Check if some roles have obtained new permissions (to avoid 'scope creep')
+            old_role = orm.Role.find(self.db, name=role_name)
+            if old_role:
+                if not set(role_spec['scopes']).issubset(old_role.scopes):
+                    app_log.warning(
+                        "Role %s has obtained extra permissions" % role_name
+                    )
+                    roles_with_new_permissions.append(role_name)
+        if roles_with_new_permissions:
+            unauthorized_oauth_tokens = (
+                self.db.query(orm.APIToken)
+                .filter(
+                    orm.APIToken.roles.any(
+                        orm.Role.name.in_(roles_with_new_permissions)
+                    )
+                )
+                .filter(orm.APIToken.client_id != 'jupyterhub')
+            )
+            for token in unauthorized_oauth_tokens:
+                app_log.warning(
+                    "Deleting OAuth token %s; one of its roles obtained new permissions that were not authorized by user"
+                    % token
+                )
+                self.db.delete(token)
+            self.db.commit()
+
         init_role_names = [r['name'] for r in init_roles]
         if not orm.Role.find(self.db, name='admin'):
             self._rbac_upgrade = True
@@ -2069,11 +2097,12 @@ class JupyterHub(Application):
                             orm_obj.admin = True
                 setattr(predef_role_obj, bearer, orm_role_bearers)
         db.commit()
-        allowed_users = db.query(orm.User).filter(
-            orm.User.name.in_(self.authenticator.allowed_users)
-        )
-        for user in allowed_users:
-            roles.grant_role(db, user, 'user')
+        if self.authenticator.allowed_users:
+            allowed_users = db.query(orm.User).filter(
+                orm.User.name.in_(self.authenticator.allowed_users)
+            )
+            for user in allowed_users:
+                roles.grant_role(db, user, 'user')
         admin_role = orm.Role.find(db, 'admin')
         for bearer in admin_role_objects:
             Class = orm.get_class(bearer)
@@ -2174,6 +2203,8 @@ class JupyterHub(Application):
         # purge expired tokens hourly
         # we don't need to be prompt about this
         # because expired tokens cannot be used anyway
+
+        # purge all OAuth tokens that gained extra permissions due to role definition changes
         pc = PeriodicCallback(
             self.purge_expired_tokens, 1e3 * self.purge_expired_tokens_interval
         )

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2204,7 +2204,6 @@ class JupyterHub(Application):
         # we don't need to be prompt about this
         # because expired tokens cannot be used anyway
 
-        # purge all OAuth tokens that gained extra permissions due to role definition changes
         pc = PeriodicCallback(
             self.purge_expired_tokens, 1e3 * self.purge_expired_tokens_interval
         )

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -848,6 +848,7 @@ async def test_server_role_api_calls(
     app, token_role, api_method, api_endpoint, for_user, response
 ):
     user = add_user(app.db, app, name='test_user')
+    roles.grant_role(app.db, user, 'user')
     if token_role == 'no_role':
         api_token = user.new_api_token(roles=[])
     else:

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -1030,6 +1030,33 @@ async def test_config_role_users():
     assert role not in user.roles
 
 
+async def test_scope_expansion_revokes_tokens(app, mockservice_url):
+    role_name = 'morpheus'
+    roles_to_load = [
+        {
+            'name': role_name,
+            'description': 'wears sunglasses',
+            'scopes': ['users', 'groups'],
+        },
+    ]
+    app.load_roles = roles_to_load
+    await app.init_role_creation()
+    user = add_user(app.db, name='laurence')
+    for _ in range(2):
+        user.new_api_token()
+    red_token, blue_token = user.api_tokens
+    roles.grant_role(app.db, red_token, role_name)
+    service = mockservice_url
+    red_token.client_id = service.oauth_client_id
+    app.db.commit()
+    # Restart hub and see if token is revoked
+    app.load_roles[0]['scopes'].append('proxy')
+    await app.init_role_creation()
+    user = orm.User.find(app.db, name='laurence')
+    assert red_token not in user.api_tokens
+    assert blue_token in user.api_tokens
+
+
 async def test_duplicate_role_users():
     role_name = 'painter'
     user_name = 'benny'
@@ -1249,7 +1276,6 @@ async def test_token_keep_roles_on_restart():
             'scopes': ['read:users'],
         }
     ]
-
     hub = MockHub(load_roles=role_spec)
     hub.init_db()
     hub.authenticator.admin_users = ['ben']

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -416,12 +416,6 @@ async def test_oauth_page_hit(
         assert r.url == url
 
 
-async def test_scope_expansion_revokes_tokens(app):
-    # todo: test when new scopes are added to roles, all api_tokens for services with those roles are deleted
-    # and auth will be hit again
-    pass
-
-
 async def test_oauth_cookie_collision(app, mockservice_url, create_user_with_scopes):
     service = mockservice_url
     url = url_path_join(public_url(app, mockservice_url), 'owhoami/')


### PR DESCRIPTION
Users explicitly opt-in to all permissions of OAuth services. Those are stored as roles on tokens, and upon hub startup, it is possible to change the scope set of a role. To ensure that that does not lead to services having permissions the user does not grant them, this PR ensures all tokens associated with OAuth services are revoked if any of their roles obtain more permissions than originally authorized.

## Minor changes
Improve DB queries and attempt to fix a test