### PR TITLE
[rbac] Docs updates

### DIFF
--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -26,7 +26,7 @@ Roles can be assigned to the following entities:
 An entity can have zero, one, or multiple roles, and there are no restrictions on which roles can be assigned to which entity. Roles can be added to or removed from entities at any time.
 
 **Users** \
-When a new user gets created, they are assigned their default role (`user` or `admin`) based on their admin status. If existing user's admin status changes via API or `jupyterhub_config.py`, their default role will be updated accordingly (after next startup for the latter).
+When a new user gets created, they are assigned their default role `user`. Additionaly, if the user is created with admin privileges (via `c.Authenticator.admin_users` in `jupyterhub_config.py` or `admin: true` via API), they will be also granted `admin` role. If existing user's admin status changes via API or `jupyterhub_config.py`, their default role will be updated accordingly (after next startup for the latter).
 
 **Services** \
 Services do not have a default role. Services without roles have no access to the guarded API end-points, so most services will require assignment of a role in order to function.

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -15,7 +15,7 @@ The `user`, `admin`, and `token` roles by default all preserve the permissions p
 Only the `server` role is changed from pre-2.0, to reduce its permissions to activity-only
 instead of the default of a full access token.
 
-Additional custom roles can also be defined (see {ref}`define_role_target`).
+Additional custom roles can also be defined (see {ref}`define-role-target`).
 Roles can be assigned to the following entities:
 
 - Users
@@ -37,7 +37,7 @@ A group does not require any role, and has no roles by default. If a user is a m
 **Tokens** \
 A token’s permissions are evaluated based on their owning entity. Since a token is always issued for a user or service, it can never have more permissions than its owner. If no specific role is requested for a new token, the token is assigned the `token` role.
 
-(define_role_target)=
+(define-role-target)=
 
 ## Defining Roles
 

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -106,6 +106,10 @@ If no scopes are defined for _new role_, JupyterHub will raise a warning. Provid
 
 In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so. All the role bearers permissions present in the definition will change accordingly.
 
+(removing-roles-target)=
+
+## Removing roles
+
 Only the entities present in the role definition in the `jupyterhub_config.py` remain the role bearers. If a user, service or group is removed from the role definition, they will lose the role on the next startup.
 
 Once a role is loaded, it remains in the database until removing it from the `jupyterhub_config.py` and restarting the Hub. All previously defined role bearers will lose the role and associated permissions. Default roles, even if previously redefined through the config file and removed, will not be deleted from the database.

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -4,9 +4,9 @@ JupyterHub provides four roles that are available by default:
 
 ```{admonition} **Default roles**
 - `user` role provides a {ref}`default user scope <default-user-scope-target>` `self` that grants access to the user's own resources.
-- `admin` role contains all available scopes and grants full rights to all actions similarly to the current admin status. This role **cannot be edited**.
-- `token` role provides a {ref}`default token scope <default-token-scope-target>` `all` that resolves to the same permissions as the token's owner has.
-- `server` role allows for posting activity of "itself" only. The scope is currently under development.
+- `admin` role contains all available scopes and grants full rights to all actions. This role **cannot be edited**.
+- `token` role provides a {ref}`default token scope <default-token-scope-target>` `all` that resolves to the same permissions as the owner of the token has.
+- `server` role allows for posting activity of "itself" only.
 
 **These roles cannot be deleted.**
 ```
@@ -26,7 +26,7 @@ Roles can be assigned to the following entities:
 An entity can have zero, one, or multiple roles, and there are no restrictions on which roles can be assigned to which entity. Roles can be added to or removed from entities at any time.
 
 **Users** \
-When a new user gets created, they are assigned their default role ( `user` or `admin`) if no custom role is requested, currently based on their admin status.
+When a new user gets created, they are assigned their default role (`user` or `admin`) based on their admin status. If existing user's admin status changes via API or `jupyterhub_config.py`, their default role will be updated accordingly (after next startup for the latter).
 
 **Services** \
 Services do not have a default role. Services without roles have no access to the guarded API end-points, so most services will require assignment of a role in order to function.
@@ -43,10 +43,8 @@ A token’s permissions are evaluated based on their owning entity. Since a toke
 
 Roles can be defined or modified in the configuration file as a list of dictionaries. An example:
 
-% TODO: think about loading users/tokens into roles if membership has been changed via API.
+% TODO: think about loading users into roles if membership has been changed via API.
 % What should be the result?
-% What happens if a user is _removed_ from this list?
-% Do they lose their role assignment or keep it?
 
 ```python
 # in jupyterhub_config.py
@@ -59,7 +57,6 @@ c.JupyterHub.load_roles = [
    'users': ['alice', 'bob'],
    'services': ['idle-culler'],
    'groups': ['admin-group'],
-   'tokens': ['foo-6f6e65','bar-74776f']
  }
 ]
 ```
@@ -68,11 +65,10 @@ The role `server-rights` now allows the starting and stopping of servers by any 
 
 - users `alice` and `bob`
 - the service `idle-culler`
-- any member of the `admin-group`
-- requests using the tokens `foo-6f6e65` or `bar-74776f`.
+- any member of the `admin-group`.
 
 ```{attention}
-The `foo-6f6e65` and `bar-74776f` tokens will be assigned the `server-rights` role only if their owner has the corresponding permissions, otherwise JupyterHub throws an error. See {ref}`resolving-roles-scopes-target` for more details on how this is assessed.
+Tokens cannot be assigned roles through role definition but may be assigned specific roles when requested via API (see {ref}`requesting-api-token-target`).
 ```
 
 Another example:
@@ -102,13 +98,14 @@ In a role definition, the `name` field is required, while all other fields are o
 - start with a letter
 - end with letter or number.
 
-If no scopes are defined for new role, JupyterHub will raise a warning. Providing non-existing scopes will result in an error.
-Moreover, `users`, `services`, `groups`, and `tokens` only accept objects that already exist or are defined previously in the file.
+`users`, `services`, and `groups` only accept objects that already exist in the database or are defined previously in the file.
 It is not possible to implicitly add a new user to the database by defining a new role.
 ```
 
-In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so.
-Any previously defined role bearers for this role will remain the role bearers but their permissions will change if the role's permissions are overwritten. The newly defined bearers (in this case `maria` and `joe` and `external`) will be added to the existing ones.
+If no scopes are defined for _new role_, JupyterHub will raise a warning. Providing non-existing scopes will result in an error.
 
-Once a role is loaded, it remains in the database until explicitly deleting it through `delete_role()` function in `roles.py`. Default roles cannot be deleted.
-Omitting the `c.JupyterHub.load_roles` or specifying different roles in the `jupyterhub_config.py` file on the next startup will not erase previously defined roles, nor their bearers.
+In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so. All the role bearers permissions present in the definition will change accordingly.
+
+Only the entities present in the role definition in the `jupyterhub_config.py` remain the role bearers. If a user, service or group is removed from the role definition, they will lose the role on the next startup.
+
+Once a role is loaded, it remains in the database until removing it from the `jupyterhub_config.py` and restarting the Hub. All previously defined role bearers will lose the role and associated permissions. Default roles, even if previously redefined through the config file and removed, will not be deleted from the database.

--- a/docs/source/rbac/scopes.md
+++ b/docs/source/rbac/scopes.md
@@ -68,6 +68,14 @@ Requested resources are filtered based on the filter of the corresponding scope.
 
 In case a user resource is being accessed, any scopes with _group_ filters will be expanded to filters for each _user_ in those groups.
 
+### `!user` filter
+
+The `!user` filter is a special horizontal filter that strictly refers to the **"owner only"** scopes, where _owner_ is a user entity. The filter resolves internally into `!user=<ownerusername>` ensuring that only the owner's resources may be accessed through the associated scopes.
+
+For example, the `server` role assigned by default to server tokens contains `access:servers!user` and `users:activity!user` scopes. This allows the token to access and post activity of only the servers owned by the token owner.
+
+The filter can be applied to any scope.
+
 (vertical-filtering-target)=
 
 ## Vertical filtering

--- a/docs/source/rbac/tech-implementation.md
+++ b/docs/source/rbac/tech-implementation.md
@@ -1,8 +1,22 @@
 # Technical Implementation
 
-Roles are stored in the database, where they are associated with users, services, etc., and can be added or modified as explained in {ref}`define_role_target` section. Users, services, groups, and tokens can gain, change, and lose roles.
-For example, one can change a token's role, and thereby its permissions, without the need to issue a new token (currently through `update_roles()` and `strip_role()` functions in `roles.py`, this will be eventually available through APIs).
-Roles' and scopes' utilities can be found in `roles.py` and `scopes.py` modules.
+Roles are stored in the database, where they are associated with users, services, etc., and can be added or modified as explained in {ref}`define-role-target` section. Users, services, groups, and tokens can gain, change, and lose roles. This is currently achieved via `jupyterhub_config.py` (see {ref}`define-role-target`) and will be made available via API in future. The latter will allow for changing a token's role, and thereby its permissions, without the need to issue a new token.
+
+Roles and scopes utilities can be found in `roles.py` and `scopes.py` modules. Scope variables take on five different formats which is reflected throughout the utilities via specific nomenclature:
+
+```{admonition} **Scope variable nomenclature**
+:class: tip
+- _scopes_ \
+  List of scopes with abbreviations (used in role definitions). E.g., `["users:activity!user"]`.
+- _expanded scopes_ \
+  Set of expanded scopes without abbreviations (i.e., resolved metascopes, filters and subscopes). E.g., `{"users:activity!user=charlie", "read:users:activity!user=charlie"}`.
+- _parsed scopes_ \
+  Dictionary JSON like format of expanded scopes. E.g., `{"users:activity": {"user": ["charlie"]}, "read:users:activity": {"users": ["charlie"]}}`.
+- _intersection_ \
+  Set of expanded scopes as intersection of 2 expanded scope sets.
+- _identify scopes_ \
+  Set of expanded scopes needed for identify (whoami) endpoints.
+```
 
 (resolving-roles-scopes-target)=
 
@@ -10,7 +24,7 @@ Roles' and scopes' utilities can be found in `roles.py` and `scopes.py` modules.
 
 **Resolving roles** refers to determining which roles a user, service, token, or group has, extracting the list of scopes from each role and combining them into a single set of scopes.
 
-**Resolving scopes** involves expanding scopes into all their possible subscopes and, if applicable, comparing two sets of scopes. Both procedures take into account the scope hierarchy, {ref}`vertical <vertical-filtering-target>` and {ref}`horizontal filtering <horizontal-filtering-target>` limiting or elevated permissions (`read:<resource>` or `admin:<resource>`, respectively), and metascopes.
+**Resolving scopes** involves expanding scopes into all their possible subscopes (_expanded scopes_), parsing them into format used for access evaluation (_parsed scopes_) and, if applicable, comparing two sets of scopes (_intersection_). All procedures take into account the scope hierarchy, {ref}`vertical <vertical-filtering-target>` and {ref}`horizontal filtering <horizontal-filtering-target>`, limiting or elevated permissions (`read:<resource>` or `admin:<resource>`, respectively), and metascopes.
 
 Roles and scopes are resolved on several occasions, for example when requesting an API token with specific roles or making an API request. The following sections provide more details.
 
@@ -18,10 +32,7 @@ Roles and scopes are resolved on several occasions, for example when requesting 
 
 ### Requesting API token with specific roles
 
-API tokens grant access to JupyterHub's APIs. The RBAC framework allows for requesting tokens with specific existing roles. To date, it is only possible to add roles to a token in two ways:
-
-1. through the `jupyterhub_config.py` file as described in the {ref}`define_role_target` section
-2. through the _POST /users/:name/tokens_ API where the roles can be specified in the token parameters body (see [](../reference/rest-api.rst)).
+API tokens grant access to JupyterHub's APIs. The RBAC framework allows for requesting tokens with specific existing roles. To date, it is only possible to add roles to a token through the _POST /users/:name/tokens_ API where the roles can be specified in the token parameters body (see [](../reference/rest-api.rst)).
 
 RBAC adds several steps into the token issue flow.
 
@@ -29,7 +40,7 @@ If no roles are requested, the token is issued with the default `token` role (pr
 
 If the token is requested with any roles, the permissions of requesting entity are checked against the requested permissions to ensure the token would not grant its owner additional privileges.
 
-If, due to modifications of roles or entities, at API request time a token has any scopes that its owner does not, those scopes are removed. The API request is resolved without additional errors, but the Hub logs a warning (see {ref}`Figure 2 <api-request-chart>`).
+If, due to modifications of roles or entities, at API request time a token has any scopes that its owner does not, those scopes are removed. The API request is resolved without additional errors using the scopes _intersection_, but the Hub logs a warning (see {ref}`Figure 2 <api-request-chart>`).
 
 Resolving a token's roles (yellow box in {ref}`Figure 1 <token-request-chart>`) corresponds to resolving all the token's owner roles (including the roles associated with their groups) and the token's requested roles into a set of scopes. The two sets are compared (Resolve the scopes box in orange in {ref}`Figure 1 <token-request-chart>`), taking into account the scope hierarchy but, solely for role assignment, omitting any {ref}`horizontal filter <horizontal-filtering-target>` comparison. If the token's scopes are a subset of the token owner's scopes, the token is issued with the requested roles; if not, JupyterHub will raise an error.
 
@@ -42,16 +53,12 @@ Resolving a token's roles (yellow box in {ref}`Figure 1 <token-request-chart>`) 
 Figure 1. Resolving roles and scopes during API token request
 ```
 
-```{note}
-The above check is also performed when roles are requested for existing tokens, e.g., when adding tokens to {ref}`role definitions <define_role_target>` through the `jupyterhub_config.py`.
-```
-
 ### Making an API request
 
 With the RBAC framework each authenticated JupyterHub API request is guarded by a scope decorator that specifies which scopes are required to gain the access to the API.
 
 When an API request is performed, the requesting API token's roles are again resolved (yellow box in {ref}`Figure 2 <api-request-chart>`) to ensure the token does not grant more permissions than its owner has at the request time (e.g., due to changing/losing roles).
-If the owner's roles do not include some scopes of the token's scopes, only the intersection of the token's and owner's scopes will be used. For example, using a token with scope `users` whose owner's role scope is `read:users:name` will results in only the `read:users:name` scope being passed on. In the case of no intersection, an empty set of scopes will be used.
+If the owner's roles do not include some scopes of the token's scopes, only the _intersection_ of the token's and owner's scopes will be used. For example, using a token with scope `users` whose owner's role scope is `read:users:name` will result in only the `read:users:name` scope being passed on. In the case of no _intersection_, an empty set of scopes will be used.
 
 The passed scopes are compared to the scopes required to access the API as follows:
 

--- a/docs/source/rbac/tech-implementation.md
+++ b/docs/source/rbac/tech-implementation.md
@@ -14,6 +14,8 @@ Roles' and scopes' utilities can be found in `roles.py` and `scopes.py` modules.
 
 Roles and scopes are resolved on several occasions, for example when requesting an API token with specific roles or making an API request. The following sections provide more details.
 
+(requesting-api-token-target)=
+
 ### Requesting API token with specific roles
 
 API tokens grant access to JupyterHub's APIs. The RBAC framework allows for requesting tokens with specific existing roles. To date, it is only possible to add roles to a token in two ways:

--- a/docs/source/rbac/upgrade.md
+++ b/docs/source/rbac/upgrade.md
@@ -25,10 +25,10 @@ Once all the {ref}`upgrade steps <rbac-upgrade-steps-target>` above are complete
 
 We recommended the following procedure to start with RBAC:
 
-1. Identify which admin users and services you would like to grant only the permissions they need through the new roles
+1. Identify which admin users and services you would like to grant only the permissions they need through the new roles.
 2. Strip these users and services of their admin status via API or UI. This will change their roles from `admin` to `user`.
    ```{note}
-   Stripping entities of their roles is currently under development and will be available only via API/UI.
+   Stripping entities of their roles is currently available only via `jupyterhub_config.py` (see {ref}`removing-roles-target`).
    ```
 3. Define new roles that you would like to start using with appropriate scopes and assign them to these entities in `jupyterhub_config.py`.
 4. Restart the JupyterHub for the new roles to take effect.

--- a/docs/source/rbac/upgrade.md
+++ b/docs/source/rbac/upgrade.md
@@ -21,7 +21,7 @@ When the JupyterHub is restarted for the first time after the upgrade, all users
 
 ## Changing the permissions after the upgrade
 
-Once all the {ref}`upgrade steps <rbac-upgrade-steps-target>` above are completed, the RBAC framework will be available for utilization. You can define new roles, modify default roles (apart from `admin`) and assign them to entities as described in the {ref}`define_role_target` section.
+Once all the {ref}`upgrade steps <rbac-upgrade-steps-target>` above are completed, the RBAC framework will be available for utilization. You can define new roles, modify default roles (apart from `admin`) and assign them to entities as described in the {ref}`define-role-target` section.
 
 We recommended the following procedure to start with RBAC:
 

--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -297,7 +297,7 @@ You will only get to this stage if the user has the required `access:services!se
 To retrieve the user model for the token, make a request to `GET /hub/api/user` with the token in the Authorization header.
 For example, using flask:
 
-```{literal-include} ../../../examples/service-whoami-flask/whoami-flask.py
+```{literalinclude} ../../../examples/service-whoami-flask/whoami-flask.py
 :language: python
 ```
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -836,8 +836,8 @@ class HubAuthenticated:
       Default values include:
       - 'access:services', 'access:services!service={service_name}' for services
       - 'access:servers', 'access:servers!user={user}',
-        'access:servers!server={user}/{server_name}'
-        for single-user servers
+      'access:servers!server={user}/{server_name}'
+      for single-user servers
 
     If hub_scopes is not used (e.g. JupyterHub 1.x),
     these additional properties can be used:


### PR DESCRIPTION
Ref.: #3438 

Few refinements of RBAC docs to reflect latest changes/additions:

- [x] Role definitions and assignments through `jupyterhub_config.py`
- [x] Scope hierarchy duplicates explanation
- [x] Explanation of the `!user` filter
- [x] Scope variable nomenclature and its meaning