### PR TITLE
add opt-in model for paginated list results

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -2,7 +2,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
+from functools import lru_cache
 from http.client import responses
+from urllib.parse import parse_qs
+from urllib.parse import urlencode
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 from sqlalchemy.exc import SQLAlchemyError
 from tornado import web
@@ -11,6 +16,8 @@ from .. import orm
 from ..handlers import BaseHandler
 from ..utils import isoformat
 from ..utils import url_path_join
+
+PAGINATION_MEDIA_TYPE = "application/jupyterhub-pagination+json"
 
 
 class APIHandler(BaseHandler):
@@ -30,6 +37,16 @@ class APIHandler(BaseHandler):
 
     def get_content_type(self):
         return 'application/json'
+
+    @property
+    @lru_cache()
+    def accepts_pagination(self):
+        """Return whether the client accepts the pagination preview media type"""
+        accept_header = self.request.headers.get("Accept", "")
+        if not accept_header:
+            return False
+        accepts = {s.strip().lower() for s in accept_header.strip().split(",")}
+        return PAGINATION_MEDIA_TYPE in accepts
 
     def check_referer(self):
         """Check Origin for cross-site API requests.
@@ -358,6 +375,44 @@ class APIHandler(BaseHandler):
                 400, "Invalid argument type, offset and limit must be integers"
             )
         return offset, limit
+
+    def paginated_model(self, items, offset, limit, total_count):
+        """Return the paginated form of a collection (list or dict)
+
+        A dict with { items: [], _pagination: {}}
+        instead of a single list (or dict).
+
+        pagination info includes the current offset and limit,
+        the total number of results for the query,
+        and information about how to build the next page request
+        if there is one.
+        """
+        next_offset = offset + limit
+        data = {
+            "items": items,
+            "_pagination": {
+                "offset": offset,
+                "limit": limit,
+                "total": total_count,
+                "next": None,
+            },
+        }
+        if next_offset < total_count:
+            # if there's a next page
+            next_url_parsed = urlparse(self.request.full_url())
+            query = parse_qs(next_url_parsed.query)
+            query['offset'] = [next_offset]
+            query['limit'] = [limit]
+            next_url_parsed = next_url_parsed._replace(
+                query=urlencode(query, doseq=True)
+            )
+            next_url = urlunparse(next_url_parsed)
+            data["_pagination"]["next"] = {
+                "offset": next_offset,
+                "limit": limit,
+                "url": next_url,
+            }
+        return data
 
     def options(self, *args, **kwargs):
         self.finish()

--- a/jupyterhub/apihandlers/proxy.py
+++ b/jupyterhub/apihandlers/proxy.py
@@ -19,13 +19,26 @@ class ProxyAPIHandler(APIHandler):
         """
         offset, limit = self.get_api_pagination()
 
-        routes = await self.proxy.get_all_routes()
+        all_routes = await self.proxy.get_all_routes()
 
-        routes = {
-            key: routes[key]
-            for key in list(routes.keys())[offset:limit]
-            if key in routes
-        }
+        if offset == 0 and len(all_routes) < limit:
+            routes = all_routes
+        else:
+            routes = {}
+            end = offset + limit
+            for i, key in sorted(all_routes.keys()):
+                if i < offset:
+                    continue
+                elif i >= end:
+                    break
+                routes[key] = all_routes[key]
+
+        if self.accepts_pagination:
+            data = self.paginated_model(routes, offset, limit, len(all_routes))
+        else:
+            data = routes
+
+        self.write(json.dumps(data))
 
         self.write(json.dumps(routes))
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -123,14 +123,21 @@ class UserListAPIHandler(APIHandler):
             # no filter, return all users
             query = self.db.query(orm.User)
 
+        full_query = query
         query = query.offset(offset).limit(limit)
 
-        data = []
+        user_list = []
         for u in query:
             if post_filter is None or post_filter(u):
                 user_model = self.user_model(u)
                 if user_model:
-                    data.append(user_model)
+                    user_list.append(user_model)
+
+        if self.accepts_pagination:
+            total_count = full_query.count()
+            data = self.paginated_model(user_list, offset, limit, total_count)
+        else:
+            data = user_list
 
         self.write(json.dumps(data))
 


### PR DESCRIPTION
With a paginated API, we need to return pagination info (next page arguments, whether a next page exists, etc.),
but a simple list response doesn't give a good way to do that. Some APIs use special response headers, but that can be tedious to work with as an API consumer, because you need to keep track of the http response object, not just the response body.

This PR: use `Accept: application/jupyterhub-pagination+json`  to opt-in to a new response format, following what GitHub does for beta changes to their REST API.

We can follow precedents in GitHub, kubernetes, etc. and use a dict with an `items` field for the actual items, and a `_pagination` field for info about pagination, including offset, limit, url for the next request.

So what was:

```python
[ {user1}, {user2}, ... ]
```

becomes

```python
{
  "items": [{user1}, {user2}, ...],
  "_pagination": {
    "offset": 5,
    "limit": 5,
    "total": 501,
    "next": {
      "offset": 10,
      "limit": 5,
      "url": "https://hub.tld/hub/api/users?offset=10&limit=5",
    }
  }
}
```

`next` is null if there is no next page.

An alternative would be to put the new response format at a different URL instead of using the Accept header as a switch.
