### PR TITLE
Release 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ These accounts will be used for authentication in JupyterHub's default configura
 ## Contributing
 
 If you would like to contribute to the project, please read our
-[contributor documentation](http://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html)
+[contributor documentation](https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html)
 and the [`CONTRIBUTING.md`](CONTRIBUTING.md). The `CONTRIBUTING.md` file
 explains how to set up a development installation, how to run the test suite,
 and how to contribute to documentation.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@
 alabaster_jupyterhub
 # Temporary fix of #3021. Revert back to released autodoc-traits when
 # 0.1.0 released.
-https://github.com/jupyterhub/autodoc-traits/archive/75885ee24636efbfebfceed1043459715049cd84.zip
+https://github.com/jupyterhub/autodoc-traits/archive/d22282c1c18c6865436e06d8b329c06fe12a07f8.zip
 pydata-sphinx-theme
 pytablewriter>=0.56
 recommonmark>=0.6

--- a/docs/rest-api.yml
+++ b/docs/rest-api.yml
@@ -873,7 +873,7 @@ definitions:
         description: The user that owns a token (undefined if owned by a service)
       service:
         type: string
-        description: The service that owns the token (undefined of owned by a user)
+        description: The service that owns the token (undefined if owned by a user)
       note:
         type: string
         description: A note about the token, typically describing what it was created for.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -24,6 +24,32 @@ This is now also configurable via `JupyterHub.oauth_token_expires_in`.
 The result is that it should be much less likely for auth tokens stored in cookies
 to expire during the lifetime of a server.
 
+### [1.4.2] 2021-06-15
+
+1.4.2 is a small bugfix release for 1.4.
+
+([full changelog](https://github.com/jupyterhub/jupyterhub/compare/1.4.1...d9860aa98cc537cf685022f81b8f725bfef41304))
+
+#### Bugs fixed
+
+- Fix regression where external services api_token became required [#3531](https://github.com/jupyterhub/jupyterhub/pull/3531) ([@consideRatio](https://github.com/consideRatio))
+- Bug: save_bearer_token (provider.py) passes a float value to the expires_at field (int) [#3484](https://github.com/jupyterhub/jupyterhub/pull/3484) ([@weisdd](https://github.com/weisdd))
+
+#### Maintenance and upkeep improvements
+
+- bump autodoc-traits [#3510](https://github.com/jupyterhub/jupyterhub/pull/3510) ([@minrk](https://github.com/minrk))
+
+#### Documentation improvements
+
+- Fix contributor documentation's link [#3521](https://github.com/jupyterhub/jupyterhub/pull/3521) ([@icankeep](https://github.com/icankeep))
+- Fix typo [#3494](https://github.com/jupyterhub/jupyterhub/pull/3494) ([@davidbrochart](https://github.com/davidbrochart))
+
+#### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/jupyterhub/graphs/contributors?from=2021-05-12&to=2021-07-15&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3AconsideRatio+updated%3A2021-05-12..2021-07-15&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Adavidbrochart+updated%3A2021-05-12..2021-07-15&type=Issues) | [@icankeep](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Aicankeep+updated%3A2021-05-12..2021-07-15&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Aminrk+updated%3A2021-05-12..2021-07-15&type=Issues) | [@weisdd](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Aweisdd+updated%3A2021-05-12..2021-07-15&type=Issues)
+
 ### [1.4.1] 2021-05-12
 
 1.4.1 is a small bugfix release for 1.4.
@@ -53,7 +79,7 @@ to expire during the lifetime of a server.
 
 [@0mar](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3A0mar+updated%3A2021-04-19..2021-05-12&type=Issues) | [@betatim](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Abetatim+updated%3A2021-04-19..2021-05-12&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3AconsideRatio+updated%3A2021-04-19..2021-05-12&type=Issues) | [@danlester](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Adanlester+updated%3A2021-04-19..2021-05-12&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Adavidbrochart+updated%3A2021-04-19..2021-05-12&type=Issues) | [@IvanaH8](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3AIvanaH8+updated%3A2021-04-19..2021-05-12&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Amanics+updated%3A2021-04-19..2021-05-12&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Aminrk+updated%3A2021-04-19..2021-05-12&type=Issues) | [@naatebarber](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Anaatebarber+updated%3A2021-04-19..2021-05-12&type=Issues) | [@OrnithOrtion](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3AOrnithOrtion+updated%3A2021-04-19..2021-05-12&type=Issues) | [@support](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Asupport+updated%3A2021-04-19..2021-05-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyterhub+involves%3Awelcome+updated%3A2021-04-19..2021-05-12&type=Issues)
 
-### 1.4.0 2021-04-19
+### [1.4.0] 2021-04-19
 
 ([full changelog](https://github.com/jupyterhub/jupyterhub/compare/1.3.0...1.4.0))
 
@@ -1072,6 +1098,7 @@ Fix removal of `/login` page in 0.4.0, breaking some OAuth providers.
 First preview release
 
 [unreleased]: https://github.com/jupyterhub/jupyterhub/compare/1.4.1...HEAD
+[1.4.2]: https://github.com/jupyterhub/jupyterhub/compare/1.4.1...1.4.2
 [1.4.1]: https://github.com/jupyterhub/jupyterhub/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/jupyterhub/jupyterhub/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/jupyterhub/jupyterhub/compare/1.2.1...1.3.0

--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -5,7 +5,7 @@
 version_info = (
     1,
     4,
-    1,
+    2,
     "",  # release (b1, rc1, or "" for final or dev)
     # "dev",  # dev or nothing for beta/rc/stable releases
 )

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2042,18 +2042,14 @@ class JupyterHub(Application):
                     raise AttributeError("No such service field: %s" % key)
                 setattr(service, key, value)
 
-            if service.managed:
-                if not service.api_token:
-                    # generate new token
-                    # TODO: revoke old tokens?
-                    service.api_token = service.orm.new_api_token(
-                        note="generated at startup"
-                    )
-                else:
-                    # ensure provided token is registered
-                    self.service_tokens[service.api_token] = service.name
-            else:
+            if service.api_token:
                 self.service_tokens[service.api_token] = service.name
+            elif service.managed:
+                # generate new token
+                # TODO: revoke old tokens?
+                service.api_token = service.orm.new_api_token(
+                    note="generated at startup"
+                )
 
             if service.url:
                 parsed = urlparse(service.url)

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -342,7 +342,7 @@ class JupyterHubRequestValidator(RequestValidator):
         orm_access_token = orm.OAuthAccessToken(
             client=client,
             grant_type=orm.GrantType.authorization_code,
-            expires_at=orm.OAuthAccessToken.now() + token['expires_in'],
+            expires_at=int(orm.OAuthAccessToken.now() + token['expires_in']),
             refresh_token=token['refresh_token'],
             # TODO: save scopes,
             # scopes=scopes,

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -102,3 +102,51 @@ async def test_external_service(app):
         assert len(resp) >= 1
         assert isinstance(resp[0], dict)
         assert 'name' in resp[0]
+
+
+async def test_external_services_without_api_token_set(app):
+    """
+    This test was made to reproduce an error like this:
+
+        ValueError: Tokens must be at least 8 characters, got ''
+
+    The error had the following stack trace in 1.4.1:
+
+        jupyterhub/app.py:2213: in init_api_tokens
+            await self._add_tokens(self.service_tokens, kind='service')
+        jupyterhub/app.py:2182: in _add_tokens
+            obj.new_api_token(
+        jupyterhub/orm.py:424: in new_api_token
+            return APIToken.new(token=token, service=self, **kwargs)
+        jupyterhub/orm.py:699: in new
+            cls.check_token(db, token)
+
+    This test also make _add_tokens receive a token_dict that is buggy:
+
+        {"": "external_2"}
+
+    It turned out that whatever passes token_dict to _add_tokens failed to
+    ignore service's api_tokens that were None, and instead passes them as blank
+    strings.
+
+    It turned out that init_api_tokens was passing self.service_tokens, and that
+    self.service_tokens had been populated with blank string tokens for external
+    services registered with JupyterHub.
+    """
+    name_1 = 'external_1'
+    name_2 = 'external_2'
+    async with external_service(app, name=name_1) as env_1, external_service(
+        app, name=name_2
+    ) as env_2:
+        app.services = [
+            {
+                'name': name_1,
+                'url': "http://irrelevant",
+            },
+            {
+                'name': name_2,
+                'url': "http://irrelevant",
+            },
+        ]
+        await maybe_future(app.init_services())
+        await app.init_api_tokens()


### PR DESCRIPTION
This is a backport release of #3484 #3494 #3510 #3521 #3531 as identified by scanning merged PRs listed via `github-activity` for bug fixes etc.

Two PRs are bug fixes (#3484 #3531), two PRs are fixes to docs (#3494 #3521), and one PR (#3510) is about building the docs for compatibility with a modern version of sphinx.

---

To make this backport PR, I made use of @minrk https://github.com/minrk/ghpro project where I also made some tweaks to make it functional (https://github.com/minrk/ghpro/pull/20)