### PR TITLE
Avoid zombie processes in case of using LocalProcessSpawner

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -722,8 +722,9 @@ class ConfigurableHTTPProxy(Proxy):
         def _check_process():
             status = self.proxy_process.poll()
             if status is not None:
-                e = RuntimeError("Proxy failed to start with exit code %i" % status)
-                raise e from None
+                with self.proxy_process:
+                    e = RuntimeError("Proxy failed to start with exit code %i" % status)
+                    raise e from None
 
         for server in (public_server, api_server):
             for i in range(10):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1542,8 +1542,11 @@ class LocalProcessSpawner(Spawner):
         if self.proc is not None:
             status = self.proc.poll()
             if status is not None:
-                # clear state if the process is done
-                self.clear_state()
+                # handle SIGCHILD to avoid zombie processes
+                # and also close stdout/stderr file descriptors
+                with self.proc:
+                    # clear state if the process is done
+                    self.clear_state()
             return status
 
         # if we resumed from stored state,


### PR DESCRIPTION
Hi.

I've faced with an issue using custom spawner class based on LocalSpawner - after child process has been stopped it become zombie:
```
dolfinus 32746  0.0  0.0      0     0 ?        Z    Jul16   0:00 [ssh] <defunct>
```

This is because child is sending SIGCHILD to the parent process, but it is necessary to call `proc.wait()` method to handle it properly. Otherwise it will become a zombie which cannot be killed.

So I've wrapped the `.poll()` method call using `with` block. In Python 3+ Popen class does have `__exit__` method which is calling `.wait()` along with other useful cleanup stages, like closing `stdout` and `stderr` file descriptors.