### PR TITLE
doc: Mention a list of known proxies available

### DIFF
--- a/docs/source/reference/proxy.md
+++ b/docs/source/reference/proxy.md
@@ -220,3 +220,11 @@ previously required.
 Additionally, configurable attributes for your proxy will
 appear in jupyterhub help output and auto-generated configuration files
 via `jupyterhub --generate-config`.
+
+### Index of proxies
+
+A list of the proxies that are currently available for JupyterHub (that we know about).
+
+1. [`jupyterhub/configurable-http-proxy`](https://github.com/jupyterhub/configurable-http-proxy) The default proxy which uses node-http-proxy
+2. [`jupyterhub/traefik-proxy`](https://github.com/jupyterhub/traefik-proxy) The proxy which configures traefik proxy server for jupyterhub
+3. [`AbdealiJK/configurable-http-proxy`](https://github.com/AbdealiJK/configurable-http-proxy) A pure python implementation of the configurable-http-proxy


### PR DESCRIPTION
Following up on the issue: https://github.com/jupyterhub/jupyterhub/issues/3528
Where we were discussing a pure python implementation of the proxy.
Since then, I have worked on a pure python alternative to configurable-http-proxy - https://pypi.org/project/configurable-http-proxy/
Thought I'd document this in the docs in case others are interested in using it

I tried to keep it similar to https://www.pyfilesystem.org/page/index-of-filesystems/