### PR TITLE
Add expiration date dropdown to Token page

### DIFF
--- a/share/jupyterhub/static/js/token.js
+++ b/share/jupyterhub/static/js/token.js
@@ -20,9 +20,14 @@ require(["jquery", "jhapi", "moment"], function ($, JHAPI, moment) {
     if (!note.length) {
       note = "Requested via token page";
     }
+    var expiration_seconds =
+      parseInt($("#token-expiration-seconds").val()) || null;
     api.request_token(
       user,
-      { note: note },
+      {
+        note: note,
+        expires_in: expiration_seconds,
+      },
       {
         success: function (reply) {
           $("#token-result").text(reply.token);

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -19,6 +19,20 @@
         <small id="note-note" class="form-text text-muted">
           This note will help you keep track of what your tokens are for.
         </small>
+        <br><br>
+        <label for="token-expiration-seconds">Token expires</label>
+        {% block expiration_options %}
+        <select id="token-expiration-seconds"
+                class="form-control">
+          <option value="3600">1 Day</option>
+          <option value="86400">1 Week</option>
+          <option value="604800">1 Month</option>
+          <option value="" selected="selected">Never</option>
+        </select>
+        {% endblock expiration_options %}
+        <small id="note-expires-at" class="form-text text-muted">
+          You can configure when your token will be expired.
+        </small>
       </div>
     </form>
   </div>
@@ -56,6 +70,7 @@
           <td>Note</td>
           <td>Last used</td>
           <td>Created</td>
+          <td>Expires at</td>
         </tr>
       </thead>
       <tbody>
@@ -75,6 +90,13 @@
             {{ token.created.isoformat() + 'Z' }}
             {%- else -%}
             N/A
+            {%- endif -%}
+          </td>
+          <td class="time-col col-sm-3">
+            {%- if token.expires_at -%}
+            {{ token.expires_at.isoformat() + 'Z' }}
+            {%- else -%}
+            Never
             {%- endif -%}
           </td>
           <td class="col-sm-1 text-center">


### PR DESCRIPTION
Hi.

It is possible to pass `expires_in` field into `POST /api/users/me/tokens` request to create token which will be later deleted from the database. But it is not possible to pass that field through Tokens page in the user interface.

I've added added a customization with Token expiration dropdown field and Expires at column in the token table:
![image](https://user-images.githubusercontent.com/4661021/127304002-62571260-64bd-43fc-b5ed-c948c120e752.png)

By default, there are 4 default values op this dropdown field:
* 1 hour
* 1 day
* 1 month
* Never

It is possible to rewrite this block with Jinja templating, so these options could be changed, or field type could be replaced with radiobutton or string input.