### PR TITLE
remove very old backward-compat for LocalProcess subclasses

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1546,16 +1546,6 @@ class LocalProcessSpawner(Spawner):
 
         self.pid = self.proc.pid
 
-        if self.__class__ is not LocalProcessSpawner:
-            # subclasses may not pass through return value of super().start,
-            # relying on deprecated 0.6 way of setting ip, port,
-            # so keep a redundant copy here for now.
-            # A deprecation warning will be shown if the subclass
-            # does not return ip, port.
-            if self.ip:
-                self.server.ip = self.ip
-            self.server.port = self.port
-            self.db.commit()
         return (self.ip or '127.0.0.1', self.port)
 
     async def poll(self):


### PR DESCRIPTION
0.6 introduced start returning connection info instead of relying on db state

this avoids what is almost certainly a redundant db transaction for subclasses