### PR TITLE
remove use of deprecated distutils

### DIFF
--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -46,10 +46,12 @@ def _check_version(hub_version, singleuser_version, log):
 
     # compare minor X.Y versions
     if hub_version != singleuser_version:
-        from distutils.version import LooseVersion as V
+        from packaging.version import parse
 
-        hub_major_minor = V(hub_version).version[:2]
-        singleuser_major_minor = V(singleuser_version).version[:2]
+        hub = parse(hub_version)
+        hub_major_minor = (hub.major, hub.minor)
+        singleuser = parse(singleuser_version)
+        singleuser_major_minor = (singleuser.major, singleuser.minor)
         extra = ""
         do_log = True
         if singleuser_major_minor == hub_major_minor:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ entrypoints
 jinja2>=2.11.0
 jupyter_telemetry>=0.1.0
 oauthlib>=3.0
+packaging
 pamela; sys_platform != 'win32'
 prometheus_client>=0.4.0
 psutil>=5.6.5; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,11 @@ import shutil
 import sys
 from subprocess import check_call
 
+from setuptools import Command
 from setuptools import setup
 from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
 
 
 v = sys.version_info
@@ -130,15 +133,6 @@ setup_args = dict(
         'Tracker': 'https://github.com/jupyterhub/jupyterhub/issues',
     },
 )
-
-# ---------------------------------------------------------------------------
-# custom distutils commands
-# ---------------------------------------------------------------------------
-
-# imports here, so they are after setuptools import if there was one
-from distutils.cmd import Command
-from distutils.command.build_py import build_py
-from distutils.command.sdist import sdist
 
 
 def mtime(path):


### PR DESCRIPTION
distutils is slated for deprecation in the stdlib, in favor of setuptools, etc.

we can use packaging for version parsing and setuptools in setup.py

packaging is technically an extra dependency, but rarely missing because it's so widespread