### PR TITLE
don't omit server model if it's empty

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -243,7 +243,10 @@ class APIHandler(BaseHandler):
                 # (this includes pending events)
                 if spawner.active and scope_filter(spawner, kind='server'):
                     servers[name] = self.server_model(spawner)
-            if not servers:
+            if not servers and 'servers' not in allowed_keys:
+                # omit servers if no access
+                # leave present and empty
+                # if request has access to read servers in general
                 model.pop('servers')
         return model
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -154,11 +154,10 @@ def fill_user(model):
     model.setdefault('roles', [])
     model.setdefault('groups', [])
     model.setdefault('admin', False)
-    model.setdefault('server', None)
     model.setdefault('pending', None)
     model.setdefault('created', TIMESTAMP)
     model.setdefault('last_activity', TIMESTAMP)
-    # model.setdefault('servers', {})
+    model.setdefault('servers', {})
     return model
 
 


### PR DESCRIPTION
if request has access to read servers, leave it present and empty

only omit it if there's no access to read server models.

The `servers` field was meant to be omitted when a request is made that doesn't have access to this field. However, we were removing it any time it's empty, which is true for users not running any servers, even if the request has access to read the field.