### PR TITLE
explicit DB rollback for 500 errors

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -85,12 +85,14 @@ class BaseHandler(RequestHandler):
         self.expanded_scopes = set()
         try:
             await self.get_current_user()
-        except SQLAlchemyError:
-            self.log.exception("Rolling back session due to database error")
-            self.db.rollback()
-        except Exception:
-            self.log.exception("Failed to get current user")
+        except Exception as e:
+            # ensure get_current_user is never called again for this handler,
+            # since it failed
             self._jupyterhub_user = None
+            self.log.exception("Failed to get current user")
+            if isinstance(e, SQLAlchemyError):
+                self.log.error("Rolling back session due to database error")
+                self.db.rollback()
         self._resolve_roles_and_scopes()
         return await maybe_future(super().prepare())
 
@@ -414,12 +416,11 @@ class BaseHandler(RequestHandler):
                 if user and isinstance(user, User):
                     user = await self.refresh_auth(user)
                 self._jupyterhub_user = user
-            except Exception as e:
-                if isinstance(e, SQLAlchemyError):
-                    raise SQLAlchemyError()
+            except Exception:
                 # don't let errors here raise more than once
                 self._jupyterhub_user = None
-                self.log.exception("Error getting current user")
+                # but still raise, which will get handled in .prepare()
+                raise
         return self._jupyterhub_user
 
     def _resolve_roles_and_scopes(self):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -85,6 +85,9 @@ class BaseHandler(RequestHandler):
         self.expanded_scopes = set()
         try:
             await self.get_current_user()
+        except SQLAlchemyError:
+            self.log.exception("Rolling back session due to database error")
+            self.db.rollback()
         except Exception:
             self.log.exception("Failed to get current user")
             self._jupyterhub_user = None
@@ -411,7 +414,9 @@ class BaseHandler(RequestHandler):
                 if user and isinstance(user, User):
                     user = await self.refresh_auth(user)
                 self._jupyterhub_user = user
-            except Exception:
+            except Exception as e:
+                if isinstance(e, SQLAlchemyError):
+                    raise SQLAlchemyError()
                 # don't let errors here raise more than once
                 self._jupyterhub_user = None
                 self.log.exception("Error getting current user")


### PR DESCRIPTION
This PR adds explicit `try`, `except`, and `db.rollback()` when JupyterHub DB is in a bad state. We made these changes in a 'brute force' approach, by searching our logs and adding an explicit `db.rollback()` wherever the error first occurred. It has worked well (no manual restarts required) in our production JupyterHub over the last month, where we are hosted on EKS, using Amazon Aurora PostgreSQL Serverless and JupyterHub version 1.2.1.

Posts related to this issue:
- https://discourse.jupyter.org/t/jupyterhub-500-error-ssl-connection-has-been-closed-unexpectedly-tornado-ioloop/9106/5
- https://github.com/jupyterhub/jupyterhub/issues/1626

Please let us know if there is a better or more standardized approach that we should follow for this. Thanks!