### PR TITLE
Stop injecting statsd parameters into the configurable HTTP proxy

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -683,17 +683,6 @@ class ConfigurableHTTPProxy(Proxy):
             cmd.extend(['--ssl-cert', self.ssl_cert])
         if self.app.internal_ssl:
             cmd.extend(self._get_ssl_options())
-        if self.app.statsd_host:
-            cmd.extend(
-                [
-                    '--statsd-host',
-                    self.app.statsd_host,
-                    '--statsd-port',
-                    str(self.app.statsd_port),
-                    '--statsd-prefix',
-                    self.app.statsd_prefix + '.chp',
-                ]
-            )
         # Warn if SSL is not used
         if ' --ssl' not in ' '.join(cmd):
             self.log.warning(


### PR DESCRIPTION
Addresses https://github.com/jupyterhub/jupyterhub/issues/3567
A more detailed explanation can be found in the body of the issue.

The latest release of the configurable HTTP proxy removed support for statsd. However if the statsd host and port are defined in the Jupyterhub config, they will be added to the command line arguments of the configurable HTTP proxy. Since these arguments are not recognized by the proxy, it fails to start with the following error message:
```
error: unknown option '--statsd-host'
```

This pull request removes the piece of code responsible for adding the statsd command line arguments (host, port and prefix) to the configurable HTTP proxy.
With this change users will be able to define the parameters for their statsd clients in the Jupyterhub config and the configurable HTTP proxy will run normally without failing at the start.