### PR TITLE
Fix wrong name of auth_state_hook in the exception log

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1087,7 +1087,7 @@ class Spawner(LoggingConfigurable):
             try:
                 await maybe_future(self.auth_state_hook(self, auth_state))
             except Exception:
-                self.log.exception("auth_stop_hook failed with exception: %s", self)
+                self.log.exception("auth_state_hook failed with exception: %s", self)
 
     @property
     def _progress_url(self):


### PR DESCRIPTION
Hi.

I found a small issue with handling an exception raised by `Spawner.auth_state_hook` - in the log message it is called `auth_stop_hook`.