### PR TITLE
Validate Content-Type Header for api POST requests

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -61,14 +61,39 @@ class APIHandler(BaseHandler):
             return False
         return True
 
+    def check_post_content_type(self):
+        """Check request content-type, e.g. for cross-site POST requests
+
+        Cross-site POST via form will include content-type
+        """
+        content_type = self.request.headers.get("Content-Type")
+        if not content_type:
+            # not specified, e.g. from a script
+            return True
+
+        # parse content type for application/json
+        fields = content_type.lower().split(";")
+        if not any(f.lstrip().startswith("application/json") for f in fields):
+            self.log.warning(f"Not allowing POST with content-type: {content_type}")
+            return False
+
+        return True
+
     def get_current_user_cookie(self):
-        """Override get_user_cookie to check Referer header"""
+        """Extend get_user_cookie to add checks for CORS"""
         cookie_user = super().get_current_user_cookie()
-        # check referer only if there is a cookie user,
+        # CORS checks for cookie-authentication
+        # check these only if there is a cookie user,
         # avoiding misleading "Blocking Cross Origin" messages
         # when there's no cookie set anyway.
-        if cookie_user and not self.check_referer():
-            return None
+        if cookie_user:
+            if not self.check_referer():
+                return None
+            if (
+                self.request.method.upper() == 'POST'
+                and not self.check_post_content_type()
+            ):
+                return None
         return cookie_user
 
     def get_json_body(self):

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -136,11 +136,6 @@ class UserListAPIHandler(APIHandler):
 
     @needs_scope('admin:users')
     async def post(self):
-
-        content_type = self.request.headers.get("Content-Type")
-        if content_type and not content_type == "application/json":
-            raise web.HTTPError(403, "Must specify content-type as application/json")
-
         data = self.get_json_body()
         if not data or not isinstance(data, dict) or not data.get('usernames'):
             raise web.HTTPError(400, "Must specify at least one user to create")
@@ -220,11 +215,6 @@ class UserAPIHandler(APIHandler):
 
     @needs_scope('admin:users')
     async def post(self, user_name):
-
-        content_type = self.request.headers.get("Content-Type")
-        if content_type and not content_type == "application/json":
-            raise web.HTTPError(403, "Must specify content-type as application/json")
-
         data = self.get_json_body()
         user = self.find_user(user_name)
         if user is not None:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -136,6 +136,11 @@ class UserListAPIHandler(APIHandler):
 
     @needs_scope('admin:users')
     async def post(self):
+
+        content_type = self.request.headers.get("Content-Type")
+        if content_type and not content_type == "application/json":
+            raise web.HTTPError(403, "Must specify content-type as application/json")
+
         data = self.get_json_body()
         if not data or not isinstance(data, dict) or not data.get('usernames'):
             raise web.HTTPError(400, "Must specify at least one user to create")
@@ -215,6 +220,11 @@ class UserAPIHandler(APIHandler):
 
     @needs_scope('admin:users')
     async def post(self, user_name):
+
+        content_type = self.request.headers.get("Content-Type")
+        if content_type and not content_type == "application/json":
+            raise web.HTTPError(403, "Must specify content-type as application/json")
+
         data = self.get_json_body()
         user = self.find_user(user_name)
         if user is not None:

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -409,6 +409,10 @@ async def test_add_multi_user_bad(app):
     assert r.status_code == 400
     r = await api_request(app, 'users', method='post', data='[]')
     assert r.status_code == 400
+    r = await api_request(
+        app, 'users', method='post', data='{}', headers={"Content-Type": "text/plain"}
+    )
+    assert r.status_code == 403
 
 
 @mark.user

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -61,7 +61,7 @@ async def test_auth_api(app):
     assert r.status_code == 403
 
 
-async def test_referer_check(app):
+async def test_cors_checks(app):
     url = ujoin(public_host(app), app.hub.base_url)
     host = urlparse(url).netloc
     # add admin user
@@ -105,6 +105,32 @@ async def test_referer_check(app):
         cookies=cookies,
     )
     assert r.status_code == 200
+
+    r = await api_request(
+        app,
+        'users',
+        method='post',
+        data='{}',
+        headers={
+            "Authorization": "",
+            "Content-Type": "text/plain",
+        },
+        cookies=cookies,
+    )
+    assert r.status_code == 403
+
+    r = await api_request(
+        app,
+        'users',
+        method='post',
+        data='{}',
+        headers={
+            "Authorization": "",
+            "Content-Type": "application/json; charset=UTF-8",
+        },
+        cookies=cookies,
+    )
+    assert r.status_code == 400  # accepted, but invalid
 
 
 # --------------
@@ -409,10 +435,6 @@ async def test_add_multi_user_bad(app):
     assert r.status_code == 400
     r = await api_request(app, 'users', method='post', data='[]')
     assert r.status_code == 400
-    r = await api_request(
-        app, 'users', method='post', data='{}', headers={"Content-Type": "text/plain"}
-    )
-    assert r.status_code == 403
 
 
 @mark.user


### PR DESCRIPTION
The content-type of Hub API requests used for user management, specifically for creating a user
is not validated and so the `text/plain` type is accepted, where it must be `application/json`.
This commit adds validation for `Content-type` header for the /hub/api/users endpoint to only
allow requests with content-type as `application/json`