### PR TITLE
Remove a couple every-request debug statements

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -223,11 +223,6 @@ class APIHandler(BaseHandler):
             'read:roles:users': {'kind', 'name', 'roles', 'admin'},
             'admin:auth_state': {'kind', 'name', 'auth_state'},
         }
-        self.log.debug(
-            "Asking for user model of %s with scopes [%s]",
-            user.name,
-            ", ".join(self.expanded_scopes),
-        )
         allowed_keys = set()
         model = self._filter_model(
             model, access_map, user, kind='user', keys=allowed_keys

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -425,7 +425,6 @@ class BaseHandler(RequestHandler):
 
     def _resolve_roles_and_scopes(self):
         self.expanded_scopes = set()
-        app_log.debug("Loading and parsing scopes")
         if self.current_user:
             orm_token = self.get_token()
             if orm_token:
@@ -433,7 +432,6 @@ class BaseHandler(RequestHandler):
             else:
                 self.expanded_scopes = scopes.get_scopes_for(self.current_user)
         self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
-        app_log.debug("Found scopes [%s]", ",".join(self.expanded_scopes))
 
     @functools.lru_cache()
     def get_scope_filter(self, req_scope):


### PR DESCRIPTION
logging all scopes every request and for every user model retrieval gets noisy

these were useful during RBAC development, but are overkill as we prepare for release