### PR TITLE
Add pyupgrade --py36-plus to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.24.0
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py36-plus
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.6.0
     hooks:


### PR DESCRIPTION
This is PR 3 out of 3 from splitting apart #3583.

Converted to draft because pre-commit.ci applied some auto-fixes to adding this config that is applied manually in #3584 and #3585 and should be merged first.