### PR TITLE
mailto link typo

### DIFF
--- a/docs/source/reference/websecurity.md
+++ b/docs/source/reference/websecurity.md
@@ -131,6 +131,6 @@ A handy website for testing your deployment is
 
 If you believe you’ve found a security vulnerability in JupyterHub, or any
 Jupyter project, please report it to
-[security@ipython.org](mailto:security@iypthon.org). If you prefer to encrypt
+[security@ipython.org](mailto:security@ipython.org). If you prefer to encrypt
 your security reports, you can use [this PGP public
 key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc).


### PR DESCRIPTION
one-character typo in a mailto link