### PR TITLE
server-api example typo: trim space in token file

### DIFF
--- a/examples/server-api/start-stop-server.py
+++ b/examples/server-api/start-stop-server.py
@@ -29,7 +29,7 @@ def get_token():
     token_file = here.joinpath("service-token")
     log.info(f"Loading token from {token_file}")
     with token_file.open("r") as f:
-        token = f.read()
+        token = f.read().strip()
     return token
 
 


### PR DESCRIPTION
avoids invalid newlines in the auth header