### PR TITLE
Fail suspected API requests with 424, not 503

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -369,7 +369,7 @@ class JupyterHub(Application):
         even if your Hub authentication is still valid.
         If your Hub authentication is valid,
         logging in may be a transparent redirect as you refresh the page.
-        
+
         This does not affect JupyterHub API tokens in general,
         which do not expire by default.
         Only tokens issued during the oauth flow
@@ -862,7 +862,7 @@ class JupyterHub(Application):
         "/",
         help="""
         The routing prefix for the Hub itself.
-        
+
         Override to send only a subset of traffic to the Hub.
         Default is to use the Hub as the default route for all requests.
 
@@ -874,7 +874,7 @@ class JupyterHub(Application):
         may want to handle these events themselves,
         in which case they can register their own default target with the proxy
         and set e.g. `hub_routespec = /hub/` to serve only the hub's own pages, or even `/hub/api/` for api-only operation.
-        
+
         Note: hub_routespec must include the base_url, if any.
 
         .. versionadded:: 1.4
@@ -1457,7 +1457,7 @@ class JupyterHub(Application):
         Can be a Unicode string (e.g. '/hub/home') or a callable based on the handler object:
 
         ::
-        
+
             def default_url_fn(handler):
                 user = handler.current_user
                 if user and user.admin:
@@ -1484,6 +1484,25 @@ class JupyterHub(Application):
         current behavior.
         """,
     ).tag(config=True)
+
+    use_legacy_stopped_server_status_code = Bool(
+        False,
+        help="""
+        Return 503 rather than 424 when request comes in for a non-running server.
+
+        Prior to JupyterHub 2.0, we returned a 503 when any request came in for
+        a user server that was currently not running. By default, JupyterHub 2.0
+        will return a 424 - this makes operational metric dashboards more useful.
+
+        JupyterLab < 3.2 expected the 503 to know if the user server is no longer
+        running, and prompted the user to start their server. Set this config to
+        true to retain the old behavior, so JupyterLab < 3.2 can continue to show
+        the appropriate UI when the user server is stopped.
+
+        This option will be removed in a future release.
+        """,
+        config=True,
+    )
 
     def init_handlers(self):
         h = []

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1330,7 +1330,7 @@ class UserUrlHandler(BaseHandler):
 
     **Changed Behavior as of 1.0** This handler no longer triggers a spawn. Instead, it checks if:
 
-    1. server is not active, serve page prompting for spawn (status: 503)
+    1. server is not active, serve page prompting for spawn (status: 424)
     2. server is ready (This shouldn't happen! Proxy isn't updated yet. Wait a bit and redirect.)
     3. server is active, redirect to /hub/spawn-pending to monitor launch progress
        (will redirect back when finished)
@@ -1349,7 +1349,11 @@ class UserUrlHandler(BaseHandler):
         self.log.warning(
             "Failing suspected API request to not-running server: %s", self.request.path
         )
-        self.set_status(404)
+
+        # If we got here, the server is not running. To differentiate
+        # that the *server* itself is not running, rather than just the particular
+        # resource *in* the server is not found, we return a 424 instead of a 404.
+        self.set_status(424)
         self.set_header("Content-Type", "application/json")
 
         spawn_url = urlparse(self.request.full_url())._replace(query="")
@@ -1514,15 +1518,14 @@ class UserUrlHandler(BaseHandler):
             self.redirect(pending_url, status=303)
             return
 
-        # if we got here, the server is not running
-        # serve a page prompting for spawn and 503 error
-        # visiting /user/:name no longer triggers implicit spawn
-        # without explicit user action
+        # If we got here, the server is not running. To differentiate
+        # that the *server* itself is not running, rather than just the particular
+        # page *in* the server is not found, we return a 424 instead of a 404.
         spawn_url = url_concat(
             url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
             {"next": self.request.uri},
         )
-        self.set_status(503)
+        self.set_status(424)
 
         auth_state = await user.get_auth_state()
         html = await self.render_template(

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1353,7 +1353,10 @@ class UserUrlHandler(BaseHandler):
         # If we got here, the server is not running. To differentiate
         # that the *server* itself is not running, rather than just the particular
         # resource *in* the server is not found, we return a 424 instead of a 404.
-        self.set_status(424)
+        # We allow retaining the old behavior to support older JupyterLab versions
+        self.set_status(
+            424 if not self.app.use_legacy_stopped_server_status_code else 503
+        )
         self.set_header("Content-Type", "application/json")
 
         spawn_url = urlparse(self.request.full_url())._replace(query="")
@@ -1521,11 +1524,14 @@ class UserUrlHandler(BaseHandler):
         # If we got here, the server is not running. To differentiate
         # that the *server* itself is not running, rather than just the particular
         # page *in* the server is not found, we return a 424 instead of a 404.
+        # We allow retaining the old behavior to support older JupyterLab versions
         spawn_url = url_concat(
             url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
             {"next": self.request.uri},
         )
-        self.set_status(424)
+        self.set_status(
+            424 if not self.app.use_legacy_stopped_server_status_code else 503
+        )
 
         auth_state = await user.get_auth_state()
         html = await self.render_template(

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1349,7 +1349,7 @@ class UserUrlHandler(BaseHandler):
         self.log.warning(
             "Failing suspected API request to not-running server: %s", self.request.path
         )
-        self.set_status(503)
+        self.set_status(404)
         self.set_header("Content-Type", "application/json")
 
         spawn_url = urlparse(self.request.full_url())._replace(query="")

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1001,11 +1001,18 @@ async def test_token_page(app):
 async def test_server_not_running_api_request(app):
     cookies = await app.login_user("bees")
     r = await get_page("user/bees/api/status", app, hub=False, cookies=cookies)
-    assert r.status_code == 404
+    assert r.status_code == 424
     assert r.headers["content-type"] == "application/json"
     message = r.json()['message']
     assert ujoin(app.base_url, "hub/spawn/bees") in message
     assert " /user/bees" in message
+
+
+async def test_server_not_running_api_request_legacy_status(app):
+    app.use_legacy_stopped_server_status_code = True
+    cookies = await app.login_user("bees")
+    r = await get_page("user/bees/api/status", app, hub=False, cookies=cookies)
+    assert r.status_code == 503
 
 
 async def test_metrics_no_auth(app):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -53,8 +53,8 @@ async def test_root_redirect(app):
     r = await get_page(url, app, cookies=cookies)
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, 'hub/user/%s/test.ipynb' % name)
-    # serve "server not running" page, which has status 503
-    assert r.status_code == 503
+    # serve "server not running" page, which has status 424
+    assert r.status_code == 424
 
 
 async def test_root_default_url_noauth(app):
@@ -169,7 +169,7 @@ async def test_spawn_redirect(app):
     r = await get_page('user/' + name, app, hub=False, cookies=cookies)
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, 'hub/user/%s/' % name)
-    assert r.status_code == 503
+    assert r.status_code == 424
 
 
 async def test_spawn_handler_access(app):
@@ -504,13 +504,13 @@ async def test_user_redirect_deprecated(app, username):
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, 'hub/user/%s/' % name)
-    assert r.status_code == 503
+    assert r.status_code == 424
 
     r = await get_page('/user/baduser/test.ipynb', app, cookies=cookies, hub=False)
     print(urlparse(r.url))
     path = urlparse(r.url).path
     assert path == ujoin(app.base_url, 'hub/user/%s/test.ipynb' % name)
-    assert r.status_code == 503
+    assert r.status_code == 424
 
     r = await get_page('/user/baduser/test.ipynb', app, hub=False)
     r.raise_for_status()

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1001,7 +1001,7 @@ async def test_token_page(app):
 async def test_server_not_running_api_request(app):
     cookies = await app.login_user("bees")
     r = await get_page("user/bees/api/status", app, hub=False, cookies=cookies)
-    assert r.status_code == 503
+    assert r.status_code == 404
     assert r.headers["content-type"] == "application/json"
     message = r.json()['message']
     assert ujoin(app.base_url, "hub/spawn/bees") in message


### PR DESCRIPTION
Non-running user servers making requests is a fairly
common occurance - user servers get culled while their
browser tabs are left open. So we now have a background level
of 503s responses on the hub *all* the time, making it
very difficult to detect *real* 503s, which should ideally
be closely monitored and alerted on.

I *think* 404 is a more appropriate response, as the resource
(API) being requested is no longer present.

Here is a snapshot of 503 responses on a bunch of hubs:

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/30430/135926405-2407f0b1-e439-45a1-acbf-9d3b9208c096.png">

This is theoretically hubs under 'normal' usage, so we can't actually use 503
error rates for any monitoring or alerting.