### PR TITLE
/users/{name}/tokens should pass entire request body to authenticate

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -359,7 +359,7 @@ class UserTokenListAPIHandler(APIHandler):
             # defer to Authenticator for identifying the user
             # can be username+password or an upstream auth token
             try:
-                name = await self.authenticate(body.get('auth'))
+                name = await self.authenticate(body)
                 if isinstance(name, dict):
                     # not a simple string so it has to be a dict
                     name = name.get('name')


### PR DESCRIPTION
 Fixes #3637