### PR TITLE
raise 404 on admin attempt to spawn nonexistent user

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -484,6 +484,11 @@ class UserServerAPIHandler(APIHandler):
     @needs_scope('servers')
     async def post(self, user_name, server_name=''):
         user = self.find_user(user_name)
+        if user is None:
+            # this can be reached if a token has `servers`
+            # permission on *all* users
+            raise web.HTTPError(404)
+
         if server_name:
             if not self.allow_named_servers:
                 raise web.HTTPError(400, "Named servers are not enabled.")

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -972,6 +972,11 @@ async def test_bad_spawn(app, bad_spawn):
     assert app.users.count_active_users()['pending'] == 0
 
 
+async def test_spawn_nosuch_user(app):
+    r = await api_request(app, 'users', "nosuchuser", 'server', method='post')
+    assert r.status_code == 404
+
+
 async def test_slow_bad_spawn(app, no_patience, slow_bad_spawn):
     db = app.db
     name = 'zaphod'


### PR DESCRIPTION
in adding scope permission checks, this (and possibly other?) attempts by admins to do things on behalf of users may have lost the checks for nonexistent target entities, and instead raise 500.