### PR TITLE
use tbump to tag versions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,53 +22,29 @@ For you to follow along according to these instructions, you need:
    git reset --hard $ORIGIN/main
    ```
 
-1. Update [CHANGELOG.md](CHANGELOG.md). Doing this can be made easier with the
-   help of [github-activity](https://github.com/choldgraf/github-activity).
+1. Make sure `docs/source/changelog.md` is up-to-date.
+   [github-activity][] can help with this.
 
-1. Set the `version_info` variable in [\_version.py](jupyterhub/_version.py)
-   appropriately, update `docs/source/_static/rest-api.yml` to match and make a commit.
+1. Update the version with `tbump`.
+   You can see what will happen without making any changes with `tbump --dry-run ${VERSION}`
 
    ```shell
-   git add jupyterhub/_version.py
-   git add docs/source/_static/rest-api.yml
-   VERSION=...  # e.g. 1.2.3
-   git commit -m "release $VERSION"
+   tbump ${VERSION}
    ```
 
-1. Reset the `version_info` variable in
-   [\_version.py](jupyterhub/_version.py) appropriately with an incremented
-   patch version and a `dev` element, then make a commit.
+   This will tag and publish a release,
+   which will be finished on CI.
+
+1. Reset the version back to dev, e.g. `2.1.0.dev` after releasing `2.0.0`
 
    ```shell
-   git add jupyterhub/_version.py
-   git add docs/source/_static/rest-api.yml
-   git commit -m "back to dev"
-   ```
-
-1. Push your two commits to main.
-
-   ```shell
-   # first push commits without a tags to ensure the
-   # commits comes through, because a tag can otherwise
-   # be pushed all alone without company of rejected
-   # commits, and we want have our tagged release coupled
-   # with a specific commit in main
-   git push $ORIGIN main
-   ```
-
-1. Create a git tag for the pushed release commit and push it.
-
-   ```shell
-   git tag -a $VERSION -m $VERSION HEAD~1
-
-   # then verify you tagged the right commit
-   git log
-
-   # then push it
-   git push $ORIGIN $VERSION
+   tbump --no-tag ${NEXT_VERSION}.dev
    ```
 
 1. Following the release to PyPI, an automated PR should arrive to
-   [conda-forge/jupyterhub-feedstock](https://github.com/conda-forge/jupyterhub-feedstock),
+   [conda-forge/jupyterhub-feedstock][],
    check for the tests to succeed on this PR and then merge it to successfully
    update the package for `conda` on the conda-forge channel.
+
+[github-activity]: https://github.com/choldgraf/github-activity
+[conda-forge/jupyterhub-feedstock]: https://github.com/conda-forge/jupyterhub-feedstock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,6 +14,7 @@ pytest>=3.3
 pytest-asyncio
 pytest-cov
 requests-mock
+tbump
 # blacklist urllib3 releases affected by https://github.com/urllib3/urllib3/issues/1683
 # I *think* this should only affect testing, not production
 urllib3!=1.25.4,!=1.25.5

--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -1,15 +1,8 @@
 """JupyterHub version info"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-version_info = (
-    2,
-    0,
-    0,
-    "b3",  # release (b1, rc1, or "" for final or dev)
-    # "dev",  # dev or nothing for beta/rc/stable releases
-    # when updating, make sure to update version in docs/source/_static/rest-api.yml as well
-    # `cd docs; make scopes` will do this
-)
+# version_info updated by running `tbump`
+version_info = (2, 0, 0, "b3", "")
 
 # pep 440 version: no dot before beta/rc, but before .dev
 # 0.1.0rc1
@@ -17,7 +10,9 @@ version_info = (
 # 0.1.0b1.dev
 # 0.1.0.dev
 
-__version__ = ".".join(map(str, version_info[:3])) + ".".join(version_info[3:])
+__version__ = ".".join(map(str, version_info[:3])) + ".".join(version_info[3:]).rstrip(
+    "."
+)
 
 # Singleton flag to only log the major/minor mismatch warning once per mismatch combo.
 _version_mismatch_warning_logged = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,41 @@ target_version = [
     "py37",
     "py38",
 ]
+
+[tool.tbump]
+# Uncomment this if your project is hosted on GitHub:
+github_url = "https://github.com/jupyterhub/jupyterhub"
+
+[tool.tbump.version]
+current = "2.0.0b3"
+
+# Example of a semver regexp.
+# Make sure this matches current_version before
+# using tbump
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (?P<pre>((a|b|rc)\d+)|)
+  \.?
+  (?P<dev>(?<=\.)dev\d*|)
+  '''
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "{new_version}"
+
+# For each file to patch, add a [[tool.tbump.file]] config
+# section containing the path of the file, relative to the
+# pyproject.toml location.
+
+[[tool.tbump.file]]
+src = "jupyterhub/_version.py"
+version_template = '({major}, {minor}, {patch}, "{pre}", "{dev}")'
+search = "version_info = {current_version}"
+
+[[tool.tbump.file]]
+src = "docs/source/_static/rest-api.yml"
+search = "version: {current_version}"


### PR DESCRIPTION
When we have more than one file with a version number in it that needs to match, I think it's time for a tool.

This is really only the last commit, the rest is #3665

draft, while waiting for #3665

After merging this, I'll give it a test making 2.0.0rc1

I went with tbump over bump2version, because it seems a little nicer, especially in terms of feedback and `--dry-run`, etc.


The command I'll use to make 2.0.0rc1  (`tbump --dry-run 2.0.0rc1`):

<img width="601" alt="Screen Shot 2021-10-29 at 15 01 16" src="https://user-images.githubusercontent.com/151929/139439210-150ce716-3242-4657-9fb7-8c9f844a88bc.png">

