### PR TITLE
always use relative paths in data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,9 @@ def get_data_files():
     """Get data files in share/jupyter"""
 
     data_files = []
-    ntrim = len(here + os.path.sep)
-
     for (d, dirs, filenames) in os.walk(share_jupyterhub):
-        data_files.append((d[ntrim:], [pjoin(d, f) for f in filenames]))
+        rel_d = os.path.relpath(d, here)
+        data_files.append((rel_d, [os.path.join(rel_d, f) for f in filenames]))
     return data_files
 
 


### PR DESCRIPTION
instead of absolute paths for sources

seems to have started failing when building from source on Windows

I'm not sure what happened, but it seems at some point setuptools stopped auto-resolving absolute paths within the repo to relative paths, just on Windows.

Can backport to 1.5.1 if needed. I believe only Windows installs from sdist are affected (ref: https://github.com/conda-forge/jupyterhub-feedstock/pull/46)