### PR TITLE
use intersect_scopes utility to check token permissions

### DIFF
--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -417,18 +417,13 @@ def _token_allowed_role(db, token, role):
 
     implicit_permissions = {'inherit', 'read:inherit'}
     explicit_scopes = expanded_scopes - implicit_permissions
-    # ignore horizontal filters
-    no_filter_scopes = {
-        scope.split('!', 1)[0] if '!' in scope else scope for scope in explicit_scopes
-    }
     # find the owner's scopes
     expanded_owner_scopes = expand_roles_to_scopes(owner)
-    # ignore horizontal filters
-    no_filter_owner_scopes = {
-        scope.split('!', 1)[0] if '!' in scope else scope
-        for scope in expanded_owner_scopes
-    }
-    disallowed_scopes = no_filter_scopes.difference(no_filter_owner_scopes)
+    allowed_scopes = scopes._intersect_expanded_scopes(
+        explicit_scopes, expanded_owner_scopes, db
+    )
+    disallowed_scopes = explicit_scopes.difference(allowed_scopes)
+
     if not disallowed_scopes:
         # no scopes requested outside owner's own scopes
         return True

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -665,7 +665,11 @@ async def test_load_roles_user_tokens(tmpdir, request):
         # no role requested - gets default 'token' role
         ({}, None, None, 201),
         # role scopes within the user's default 'user' role
-        ({}, 'self-reader', ['read:users'], 201),
+        ({}, 'self-reader', ['read:users!user'], 201),
+        # role scopes within the user's default 'user' role, but with disjoint filter
+        ({}, 'other-reader', ['read:users!user=other'], 403),
+        # role scopes within the user's default 'user' role, without filter
+        ({}, 'other-reader', ['read:users'], 403),
         # role scopes outside of the user's role but within the group's role scopes of which the user is a member
         ({}, 'groups-reader', ['read:groups'], 201),
         # non-existing role request

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -677,9 +677,14 @@ async def test_resolve_token_permissions(
     intersection_scopes,
 ):
     orm_user = create_user_with_scopes(*user_scopes).orm_user
+    # ensure user has full permissions when token is created
+    # to create tokens with permissions exceeding their owner
+    roles.grant_role(app.db, orm_user, "admin")
     create_temp_role(token_scopes, 'active-posting')
     api_token = orm_user.new_api_token(roles=['active-posting'])
     orm_api_token = orm.APIToken.find(app.db, token=api_token)
+    # drop admin so that filtering can be applied
+    roles.strip_role(app.db, orm_user, "admin")
 
     # get expanded !user filter scopes for check
     user_scopes = roles.expand_roles_to_scopes(orm_user)

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -385,8 +385,8 @@ async def test_oauth_page_hit(
     hits_page,
 ):
     test_roles = {
-        'reader': create_temp_role(['read:users'], role_name='reader'),
-        'writer': create_temp_role(['users:activity'], role_name='writer'),
+        'reader': create_temp_role(['read:users!user'], role_name='reader'),
+        'writer': create_temp_role(['users:activity!user'], role_name='writer'),
     }
     service = mockservice_url
     user = create_user_with_scopes("access:services", "self")


### PR DESCRIPTION
we didn't have this function when we started checking token scopes at creation time, so we can simplify the check by reusing the function used elsewhere.

The token-scopes check is a refusal to issue tokens that wouldn't actually have the requested permissions after intersecting them with the owner's permissions, which would be confusing, though not a security issue.