### PR TITLE
Grant role after user creation during config load

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1993,7 +1993,7 @@ class JupyterHub(Application):
             self.log.info(f"Creating user {username}")
             user = orm.User(name=username)
             self.db.add(user)
-            roles.grant_role(self.db, user, 'user')
+            roles.assign_default_roles(self.db, entity=user)
             self.db.commit()
         return user
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2128,6 +2128,7 @@ class JupyterHub(Application):
                             if kind == 'users':
                                 orm_obj = await self._get_or_create_user(bname)
                                 orm_role_bearers.append(orm_obj)
+                                roles.grant_role(db, orm_obj, 'user')
                             elif kind == 'groups':
                                 group = orm.Group(name=bname)
                                 db.add(group)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1993,6 +1993,7 @@ class JupyterHub(Application):
             self.log.info(f"Creating user {username}")
             user = orm.User(name=username)
             self.db.add(user)
+            roles.grant_role(self.db, user, 'user')
             self.db.commit()
         return user
 
@@ -2128,7 +2129,6 @@ class JupyterHub(Application):
                             if kind == 'users':
                                 orm_obj = await self._get_or_create_user(bname)
                                 orm_role_bearers.append(orm_obj)
-                                roles.grant_role(db, orm_obj, 'user')
                             elif kind == 'groups':
                                 group = orm.Group(name=bname)
                                 db.add(group)

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -247,6 +247,7 @@ async def test_load_groups(tmpdir, request):
         kwargs['internal_certs_location'] = str(tmpdir)
     hub = MockHub(**kwargs)
     hub.init_db()
+    await hub.init_role_creation()
     await hub.init_users()
     await hub.init_groups()
     db = hub.db

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -1203,6 +1203,27 @@ async def test_user_config_respects_memberships():
         assert user in user_role.users
 
 
+async def test_user_config_creates_default_role():
+    role_spec = [
+        {
+            'name': 'new-role',
+            'scopes': ['read:users'],
+            'users': ['not-yet-created-user'],
+        }
+    ]
+    user_names = []
+    hub = MockHub(load_roles=role_spec)
+    hub.init_db()
+    hub.authenticator.allowed_users = user_names
+    await hub.init_role_creation()
+    await hub.init_users()
+    await hub.init_role_assignment()
+    user_role = orm.Role.find(hub.db, 'user')
+    new_role = orm.Role.find(hub.db, 'new-role')
+    assert orm.User.find(hub.db, 'not-yet-created-user') in new_role.users
+    assert orm.User.find(hub.db, 'not-yet-created-user') in user_role.users
+
+
 async def test_admin_role_respects_config():
     role_spec = [
         {


### PR DESCRIPTION
I faced role related issue for my jupyterhub deployment:
- Using Zero To JupyterHub with Kubernetes
- Using GenericOAuthenticator
  - ```python
      from oauthenticator.generic import GenericOAuthenticator
      c.JupyterHub.authenticator_class = GenericOAuthenticator
      c.GenericOAuthenticator.oauth_callback_url = "http://<my-jupyter-hub-domain>/hub/oauth_callback"
      c.GenericOAuthenticator.client_id = "<client-id>"
      c.GenericOAuthenticator.client_secret = "<client-secret>"
      c.GenericOAuthenticator.login_service = "<my-service>"
      c.GenericOAuthenticator.authorize_url = "http://<my-oauth-provider-domain>/oauth/authorize"
      c.GenericOAuthenticator.userdata_url = "http://<my-oauth-provider-domain>/api/v1/me"
      c.GenericOAuthenticator.token_url = "http://<my-oauth-provider-domain>/oauth/token"
      c.GenericOAuthenticator.username_key = "email"
    ```
 - Loading Roles Like
   - ```
      c.JupyterHub.load_roles = [
        {
          "name": "role-for-rtc",
          "scopes": ["servers", "read:users", "access:servers"],
          "users": ["<rtc-privileged-user>@<my-domain>"]
        }
      ]
     ```
Under this condition:
  - User `<rtc-privileged-user>@<my-domain>` is not yet been created (signed in)

-> User `<rtc-privileged-user>@<my-domain>` cannot access to its own server.
- ```
  [W 2021-12-13 02:44:18.992 JupyterHub roles:436] Token requesting role server with scopes not held by owner <rtc-privileged-user>@<my-domain>: {<List of scopes which change depending on the scopes listed in load_roles>'}
  ```
- (I removed some part for my security)
![image](https://user-images.githubusercontent.com/4434752/145815166-c3594a12-1e64-4668-8726-eebd3024d346.png)

Under the other condition:
  - User `<rtc-privileged-user>@<my-domain>` is already created.
    - To reset everything, I deleted the user first.
    - I deleted my `load_roles` lines, too.
    - Then, I created the user by logging in.
    - Finally, I added my `load_roles` in my config, and restarted the hub.

-> Everything works fine.


In conclusion, I suggest these changes to fix this issue.
  - At app.py#L2131, `orm_obj` is always created as an new user. So it's fine to grant default role here.
  - In the cases mentioned above, this user is not granted for their default `user` role.
  - Without `roles.grant_role(db, orm_obj, 'user')`, default user role is not granted to the user, because it is not listed in `self.authenticator.allowed_users`