### PR TITLE
Fix error message about Authenticator.pre_spawn_start

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -308,10 +308,13 @@ class SpawnHandler(BaseHandler):
         # otherwise it may cause a redirect loop
         if f.done() and f.exception():
             exc = f.exception()
+            self.log.exception(f"Error starting server {spawner._log_name}: {exc}")
+            if isinstance(exc, web.HTTPError):
+                # allow custom HTTPErrors to pass through
+                raise exc
             raise web.HTTPError(
                 500,
-                "Error in Authenticator.pre_spawn_start: %s %s"
-                % (type(exc).__name__, str(exc)),
+                f"Unhandled error starting server {spawner._log_name}",
             )
         return self.redirect(pending_url)
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1129,7 +1129,7 @@ async def test_health_check_request(app):
 
 
 async def test_pre_spawn_start_exc_no_form(app):
-    exc = "pre_spawn_start error"
+    exc = "Unhandled error starting server"
 
     # throw exception from pre_spawn_start
     async def mock_pre_spawn_start(user, spawner):


### PR DESCRIPTION
This isn't the only or even main thing likely to raise here, so don't blame it, which is confusing, especially in a message shown to users.

Has come up during spawn failures, e.g. #3703

Log the full exception, and show a more opaque message to the user to avoid confusion.
