### PR TITLE
always assign default roles on login

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -771,8 +771,9 @@ class BaseHandler(RequestHandler):
         # Only set `admin` if the authenticator returned an explicit value.
         if admin is not None and admin != user.admin:
             user.admin = admin
-            roles.assign_default_roles(self.db, entity=user)
-            self.db.commit()
+        # always ensure default roles ('user', 'admin' if admin) are assigned
+        # after a successful login
+        roles.assign_default_roles(self.db, entity=user)
         # always set auth_state and commit,
         # because there could be key-rotation or clearing of previous values
         # going on.

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -1365,7 +1365,8 @@ async def test_login_default_role(app, username):
     user.roles = []
     app.db.commit()
 
-    # login *again*; user exists, shouldn't trigger change in roles
+    # login *again*; user exists,
+    # login should always trigger "user" role assignment
     cookies = await app.login_user(username)
     user = app.users[username]
-    assert user.roles == []
+    assert [role.name for role in user.roles] == ["user"]


### PR DESCRIPTION
successful authentication of a user always grants 'user' role

rather than only on first user creation in db

I think this results in more consistent, expected behavior


related to #3721