### PR TITLE
Use URL from authenticator on default login form

### DIFF
--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -20,7 +20,7 @@
   </a>
 </div>
 {% else %}
-<form action="{{login_url}}?next={{next}}" method="post" role="form">
+<form action="{{authenticator_login_url}}" method="post" role="form">
   <div class="auth-form-header">
     Sign in
   </div>


### PR DESCRIPTION
This patch is related to the implementation of the MultiAuthenticator in jupyterhub/oauthenticator#459

The issue will be triggered when using more than one local provider or mixing with oauth providers. With multiple providers the template generates a set of buttons to choose from to continue the login process.

For OAuth, the user will be sent to the provider login page and the redirect at the end will continue nicely the process.

Now for the tricky part, using a local provider (e.g. PAM), the user will be redirected to the "same page" thus the same template will be rendered but this time to show the username/password dialog.

This will trip the workflow because of the action URL coming from the settings and not from the authenticator. Therefore when the button is clicked, the user will come back to the original multiple choice page rather than continue the login.