### PR TITLE
update service-whoami example

### DIFF
--- a/examples/service-whoami/README.md
+++ b/examples/service-whoami/README.md
@@ -8,58 +8,71 @@ There is an implementation each of api-token-based `HubAuthenticated` and OAuth-
 
 1.  Launch JupyterHub and the `whoami` services with
 
-        jupyterhub --ip=127.0.0.1
+        jupyterhub
 
 2.  Visit http://127.0.0.1:8000/services/whoami-oauth
 
-After logging in with your local-system credentials, you should see a JSON dump of your user info:
+After logging in with any username and password, you should see a JSON dump of your user info:
 
 ```json
 {
   "admin": false,
-  "last_activity": "2016-05-27T14:05:18.016372",
+  "groups": [],
+  "kind": "user",
   "name": "queequeg",
-  "pending": null,
-  "server": "/user/queequeg"
+  "scopes": ["access:services!service=whoami-oauth"],
+  "session_id": "5a2164273a7346728873bcc2e3c26415"
 }
 ```
 
+What is contained in the model will depend on the permissions
+requested in the `oauth_roles` configuration of the service `whoami-oauth` service.
+The default is the minimum required for identification and access to the service,
+which will provide the username and current scopes.
+
 The `whoami-api` service powered by the base `HubAuthenticated` class only supports token-authenticated API requests,
-not browser visits, because it does not implement OAuth. Visit it by requesting an api token from the tokens page,
+not browser visits, because it does not implement OAuth. Visit it by requesting an api token from the tokens page (`/hub/token`),
 and making a direct request:
 
 ```bash
-$ curl -H "Authorization: token 8630bbd8ef064c48b22c7f122f0cd8ad" http://127.0.0.1:8000/services/whoami-api/ | jq .
+token="d584cbc5bba2430fb153aadb305029b4"
+curl -H "Authorization: token $token" http://127.0.0.1:8000/services/whoami-api/ | jq .
+```
+
+```json
 {
   "admin": false,
-  "created": "2021-05-21T09:47:41.299400Z",
+  "created": "2021-12-20T09:49:37.258427Z",
   "groups": [],
   "kind": "user",
-  "last_activity": "2021-05-21T09:49:08.290745Z",
-  "name": "test",
+  "last_activity": "2021-12-20T10:07:31.298056Z",
+  "name": "queequeg",
   "pending": null,
-  "roles": [
-    "user"
-  ],
+  "roles": ["user"],
   "scopes": [
+    "access:servers!user=queequeg",
     "access:services",
-    "access:servers!user=test",
-    "read:users!user=test",
-    "read:users:activity!user=test",
-    "read:users:groups!user=test",
-    "read:users:name!user=test",
-    "read:servers!user=test",
-    "read:tokens!user=test",
-    "users!user=test",
-    "users:activity!user=test",
-    "users:groups!user=test",
-    "users:name!user=test",
-    "servers!user=test",
-    "tokens!user=test"
+    "delete:servers!user=queequeg",
+    "read:servers!user=queequeg",
+    "read:tokens!user=queequeg",
+    "read:users!user=queequeg",
+    "read:users:activity!user=queequeg",
+    "read:users:groups!user=queequeg",
+    "read:users:name!user=queequeg",
+    "servers!user=queequeg",
+    "tokens!user=queequeg",
+    "users:activity!user=queequeg"
   ],
-  "server": null
+  "server": null,
+  "servers": {},
+  "session_id": null
 }
 ```
+
+The above is a more complete user model than the `whoami-oauth` example, because
+the token was issued with the default `token` role,
+which has the `inherit` metascope,
+meaning the token has access to everything the tokens owner has access to.
 
 This relies on the Hub starting the whoami services, via config (see [jupyterhub_config.py](./jupyterhub_config.py)).
 

--- a/examples/service-whoami/jupyterhub_config.py
+++ b/examples/service-whoami/jupyterhub_config.py
@@ -10,7 +10,15 @@ c.JupyterHub.services = [
         'name': 'whoami-oauth',
         'url': 'http://127.0.0.1:10102',
         'command': [sys.executable, './whoami-oauth.py'],
-        'oauth_roles': ['user'],
+        # the default oauth roles is minimal,
+        # only requesting access to the service,
+        # and identification by name,
+        # nothing more.
+        # Specifying 'oauth_roles' as a list of role names
+        # allows requesting more information about users,
+        # or the ability to take actions on users' behalf, as required.
+        # The default 'token' role has the full permissions of its owner:
+        # 'oauth_roles': ['token'],
     },
 ]
 


### PR DESCRIPTION
- update models with 2.0.0
- different scopes for oauth, api shows model depends on permissions
- update text with more details about scopes


inconsistency reported on gitter by @rcthomas 