### PR TITLE
initialize new admin users with default roles

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1903,6 +1903,7 @@ class JupyterHub(Application):
             user = orm.User.find(db, name)
             if user is None:
                 user = orm.User(name=name, admin=True)
+                roles.assign_default_roles(self.db, entity=user)
                 new_users.append(user)
                 db.add(user)
             else:

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -188,6 +188,8 @@ def normalize_user(user):
     """
     for key in ('created', 'last_activity'):
         user[key] = normalize_timestamp(user[key])
+    if 'roles' in user:
+        user['roles'] = sorted(user['roles'])
     if 'servers' in user:
         for server in user['servers'].values():
             for key in ('started', 'last_activity'):
@@ -240,7 +242,12 @@ async def test_get_users(app):
     }
     assert users == [
         fill_user(
-            {'name': 'admin', 'admin': True, 'roles': ['admin'], 'auth_state': None}
+            {
+                'name': 'admin',
+                'admin': True,
+                'roles': ['admin', 'user'],
+                'auth_state': None,
+            }
         ),
         fill_user(user_model),
     ]


### PR DESCRIPTION
#3720 updated the expected roles of admins to include 'user', but the tests were passing without being updated because it was only after concurrent PR #3714 or #3708 that the default admin user in the test setup actually got this role assigned.

it was also still possible for a user in `admin_users` to not get the `user` role if they were not present in the db.

closes #3734 
