### PR TITLE
DOC: Add note about allowed_users not being set

### DIFF
--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -16,6 +16,10 @@ c.Authenticator.allowed_users = {'mal', 'zoe', 'inara', 'kaylee'}
 Users in the `allowed_users` set are added to the Hub database when the Hub is
 started.
 
+```{warning}
+If this configuration value is not set, then **all users will be allowed into your hub**.
+```
+
 ## Configure admins (`admin_users`)
 
 ```{note}

--- a/docs/source/getting-started/authenticators-users-basics.md
+++ b/docs/source/getting-started/authenticators-users-basics.md
@@ -17,7 +17,7 @@ Users in the `allowed_users` set are added to the Hub database when the Hub is
 started.
 
 ```{warning}
-If this configuration value is not set, then **all users will be allowed into your hub**.
+If this configuration value is not set, then **all authenticated users will be allowed into your hub**.
 ```
 
 ## Configure admins (`admin_users`)


### PR DESCRIPTION
This adds a warning to the `allowed_users` section to clarify that any user will be able to log on if this configuration isn't set.

Correct me if this is wrong, but we ran into an issue with this on a 2i2c hub and I wanted to make sure we didn't forget to note this in the docs if it is indeed true.