### PR TITLE
DOCS: Update theme configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -130,6 +130,23 @@ html_static_path = ['_static']
 
 htmlhelp_basename = 'JupyterHubdoc'
 
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/jupyterhub/jupyterhub",
+            "icon": "fab fa-github-square",
+        },
+        {
+            "name": "Discourse",
+            "url": "https://discourse.jupyter.org/c/jupyterhub/10",
+            "icon": "fab fa-discourse",
+        },
+    ],
+  "use_edit_page_button": True,
+  "navbar_align": "left",
+}
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,8 +143,8 @@ html_theme_options = {
             "icon": "fab fa-discourse",
         },
     ],
-  "use_edit_page_button": True,
-  "navbar_align": "left",
+    "use_edit_page_button": True,
+    "navbar_align": "left",
 }
 
 # -- Options for LaTeX output ---------------------------------------------


### PR DESCRIPTION
This adds a bit of theme configuration for our documentation, it does these things:

- Aligns the navbar items to the left to create a bit more space
- Adds github and discourse icons
- Adds an "edit on github" link to the right