### PR TITLE
use outermost proxied entry when looking up browser protocol

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -16,6 +16,7 @@ from tornado import web
 from .. import orm
 from .. import roles
 from .. import scopes
+from ..utils import get_browser_protocol
 from ..utils import token_authenticated
 from .base import APIHandler
 from .base import BaseHandler
@@ -115,7 +116,10 @@ class OAuthHandler:
         # make absolute local redirects full URLs
         # to satisfy oauthlib's absolute URI requirement
         redirect_uri = (
-            self.request.protocol + "://" + self.request.headers['Host'] + redirect_uri
+            get_browser_protocol(self.request)
+            + "://"
+            + self.request.host
+            + redirect_uri
         )
         parsed_url = urlparse(uri)
         query_list = parse_qsl(parsed_url.query, keep_blank_values=True)

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -14,6 +14,7 @@ from tornado import web
 
 from .. import orm
 from ..handlers import BaseHandler
+from ..utils import get_browser_protocol
 from ..utils import isoformat
 from ..utils import url_path_join
 
@@ -60,6 +61,8 @@ class APIHandler(BaseHandler):
         """
         host_header = self.app.forwarded_host_header or "Host"
         host = self.request.headers.get(host_header)
+        if host and "," in host:
+            host = host.split(",", 1)[0].strip()
         referer = self.request.headers.get("Referer")
 
         # If no header is provided, assume it comes from a script/curl.
@@ -71,7 +74,8 @@ class APIHandler(BaseHandler):
             self.log.warning("Blocking API request with no referer")
             return False
 
-        proto = self.request.protocol
+        proto = get_browser_protocol(self.request)
+
         full_host = f"{proto}://{host}{self.hub.base_url}"
         host_url = urlparse(full_host)
         referer_url = urlparse(referer)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -49,6 +49,7 @@ from ..spawner import LocalProcessSpawner
 from ..user import User
 from ..utils import AnyTimeoutError
 from ..utils import get_accepted_mimetype
+from ..utils import get_browser_protocol
 from ..utils import maybe_future
 from ..utils import url_path_join
 
@@ -632,12 +633,10 @@ class BaseHandler(RequestHandler):
         next_url = self.get_argument('next', default='')
         # protect against some browsers' buggy handling of backslash as slash
         next_url = next_url.replace('\\', '%5C')
-        if (next_url + '/').startswith(
-            (
-                f'{self.request.protocol}://{self.request.host}/',
-                f'//{self.request.host}/',
-            )
-        ) or (
+        proto = get_browser_protocol(self.request)
+        host = self.request.host
+
+        if (next_url + '/').startswith((f'{proto}://{host}/', f'//{host}/',)) or (
             self.subdomain_host
             and urlparse(next_url).netloc
             and ("." + urlparse(next_url).netloc).endswith(

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -53,6 +53,7 @@ from traitlets import validate
 from traitlets.config import SingletonConfigurable
 
 from ..scopes import _intersect_expanded_scopes
+from ..utils import get_browser_protocol
 from ..utils import url_path_join
 
 
@@ -772,7 +773,7 @@ class HubOAuth(HubAuth):
             # OAuth that doesn't complete shouldn't linger too long.
             'max_age': 600,
         }
-        if handler.request.protocol == 'https':
+        if get_browser_protocol(handler.request) == 'https':
             kwargs['secure'] = True
         # load user cookie overrides
         kwargs.update(self.cookie_options)
@@ -812,7 +813,7 @@ class HubOAuth(HubAuth):
     def set_cookie(self, handler, access_token):
         """Set a cookie recording OAuth result"""
         kwargs = {'path': self.base_url, 'httponly': True}
-        if handler.request.protocol == 'https':
+        if get_browser_protocol(handler.request) == 'https':
             kwargs['secure'] = True
         # load user cookie overrides
         kwargs.update(self.cookie_options)

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -683,3 +683,44 @@ def catch_db_error(f):
             return r
 
     return catching
+
+
+def get_browser_protocol(request):
+    """Get the _protocol_ seen by the browser
+
+    Like tornado's _apply_xheaders,
+    but in the case of multiple proxy hops,
+    use the outermost value (what the browser likely sees)
+    instead of the innermost value,
+    which is the most trustworthy.
+
+    We care about what the browser sees,
+    not where the request actually came from,
+    so trusting possible spoofs is the right thing to do.
+    """
+    headers = request.headers
+    # first choice: Forwarded header
+    forwarded_header = headers.get("Forwarded")
+    if forwarded_header:
+        first_forwarded = forwarded_header.split(",", 1)[0].strip()
+        fields = {}
+        forwarded_dict = {}
+        for field in first_forwarded.split(";"):
+            key, _, value = field.partition("=")
+            fields[key.strip().lower()] = value.strip()
+        if "proto" in fields and fields["proto"].lower() in {"http", "https"}:
+            return fields["proto"].lower()
+        else:
+            app_log.warning(
+                f"Forwarded header present without protocol: {forwarded_header}"
+            )
+
+    # second choice: X-Scheme or X-Forwarded-Proto
+    proto_header = headers.get("X-Scheme", headers.get("X-Forwarded-Proto", None))
+    if proto_header:
+        proto_header = proto_header.split(",")[0].strip().lower()
+        if proto_header in {"http", "https"}:
+            return proto_header
+
+    # no forwarded headers
+    return request.protocol


### PR DESCRIPTION
In some cases (e.g. CORS and setting cookies) we care about what the _browser_ sees, so trust the outermost entry instead of the innermost, which is the most strictly trustworthy value used by tornado (see https://github.com/tornadoweb/tornado/pull/2162).

Using the outermost entry is not secure _in general_, in that these values can be spoofed by additional proxies we don't control, but for CORS and cookie purposes, we only care about what the browser sees, however many hops there may be, whoever they may be controlled by.

A malicious proxy in the chain here setting fake host/proto fields isn't a concern for these cases because what matters is the immediate hop from the _browser_, not the immediate hop from the _server_. It would not be appropriate, for instance, to trust the outermost _ip_ field for logging/abuse purposes. A bad proxy can _break_ stuff with invalid fields, but not compromise things in the way it's used here (e.g. for header comparison, they can just as easily change _both_ headers being compared).

This adds the failing case noted in #3746 which works now. It failed because CHP adds its own X-Forwarded-Proto, so the value was `https, http` - exactly the two-hop failure mentioned in #3737 that is handled as intended now.

I believe this closes #3737

xref [this comment on tornado](https://github.com/tornadoweb/tornado/pull/2162#discussion_r150203117) where I said I'd do this in 2017.

related issues: #1477, https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1700
