### PR TITLE
remove unused macro with missing references

### DIFF
--- a/share/jupyterhub/templates/admin.html
+++ b/share/jupyterhub/templates/admin.html
@@ -1,20 +1,5 @@
 {% extends "page.html" %}
 
-{% macro th(label, key='', colspan=1) %}
-<th data-sort="{{key}}" colspan="{{colspan}}">{{label}}
-  {% if key %}
-  <a href="#"><i class="fa {% if sort.get(key) == 'asc' -%}
-                               fa-sort-asc
-                           {%- elif sort.get(key) == 'desc' -%}
-                               fa-sort-desc
-                           {%- else -%}
-                               fa-sort
-                           {%- endif %} sort-icon">
-  </i></a>
-  {% endif %}
-</th>
-{% endmacro %}
-
 {% block main %}
 <div id="react-admin-hook">
   <script id="jupyterhub-admin-config">


### PR DESCRIPTION
The th macro is unused and doesn't work because it references `sort` template variable, which has been removed