### PR TITLE
Add the capability to inform a connection to Alembic Migration Script

### DIFF
--- a/jupyterhub/alembic/env.py
+++ b/jupyterhub/alembic/env.py
@@ -55,9 +55,14 @@ def run_migrations_offline():
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
-
+    connectable = config.attributes.get('connection', None)
+    
+    if connectable is None:
+        url = config.get_main_option("sqlalchemy.url")
+        context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    else:
+        context.configure(connection=connectable, target_metadata=target_metadata, literal_binds=True)
+        
     with context.begin_transaction():
         context.run_migrations()
 
@@ -69,11 +74,14 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix='sqlalchemy.',
-        poolclass=pool.NullPool,
-    )
+    connectable = config.attributes.get('connection', None)
+    
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section),
+            prefix='sqlalchemy.',
+            poolclass=pool.NullPool,
+        )
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/jupyterhub/alembic/env.py
+++ b/jupyterhub/alembic/env.py
@@ -56,13 +56,15 @@ def run_migrations_offline():
 
     """
     connectable = config.attributes.get('connection', None)
-    
+
     if connectable is None:
         url = config.get_main_option("sqlalchemy.url")
         context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
     else:
-        context.configure(connection=connectable, target_metadata=target_metadata, literal_binds=True)
-        
+        context.configure(
+            connection=connectable, target_metadata=target_metadata, literal_binds=True
+        )
+
     with context.begin_transaction():
         context.run_migrations()
 
@@ -75,7 +77,7 @@ def run_migrations_online():
 
     """
     connectable = config.attributes.get('connection', None)
-    
+
     if connectable is None:
         connectable = engine_from_config(
             config.get_section(config.config_ini_section),


### PR DESCRIPTION
Hi guys,

In this PR, I'm adding the capability to pass a connection in the config variable used by Alembic Migration Scripts.

The way that I did it uses the same approach that we can see in [Cookbook — Alembic 1.7.5 documentation](https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-connection-with-a-series-of-migration-commands-and-environments)

This approach allows us to reuse an established connection in SQLAlchemy. Very useful in my use case that I replaced the default approach that uses the URL by IAM Role connection.