### PR TITLE
Improve documentation about spawner exception handling

### DIFF
--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -108,6 +108,16 @@ class MySpawner(Spawner):
         return url
 ```
 
+#### Exception handling
+
+When `Spawner.start` raises an Exception, a message can be passed on to the user via the exception via a `.jupyterhub_html_message` or `.jupyterhub_message` attribute.
+
+When the Exception has a `.jupyterhub_html_message` attribute, it will be rendered as HTML to the user.
+
+Alternatively `.jupyterhub_message` is rendered as unformatted text.
+
+If both attributes are not present, the Exception will be shown to the user as unformatted text.
+
 ### Spawner.poll
 
 `Spawner.poll` should check if the spawner is still running.


### PR DESCRIPTION
This PR further improves upon #3764.

`.jupyter_message` is only documented in the Changelog at the moment. I've added documentation on the place where I was looking for it.
