### PR TITLE
DOCS: Add github metadata for edit button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,6 +147,13 @@ html_theme_options = {
     "navbar_align": "left",
 }
 
+html_context = {
+    "github_user": "jupyterhub",
+    "github_repo": "jupyterhub",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {


### PR DESCRIPTION
after #3754 local builds don't work when this is True due to missing GitHub metadata. So make it true only on RTD.