### PR TITLE
Log proxy's public_url only when started by JupyterHub

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3150,7 +3150,8 @@ class JupyterHub(Application):
             self.last_activity_callback = pc
             pc.start()
 
-        self.log.info("JupyterHub is now running at %s", self.proxy.public_url)
+        if self.proxy.should_start:
+            self.log.info("JupyterHub is now running at %s", self.proxy.public_url)
         # Use atexit for Windows, it doesn't have signal handling support
         if _mswindows:
             atexit.register(self.atexit)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3152,6 +3152,8 @@ class JupyterHub(Application):
 
         if self.proxy.should_start:
             self.log.info("JupyterHub is now running at %s", self.proxy.public_url)
+        else:
+            self.log.info("JupyterHub is now running, internal Hub API at %s", self.hub.url)
         # Use atexit for Windows, it doesn't have signal handling support
         if _mswindows:
             atexit.register(self.atexit)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3153,7 +3153,9 @@ class JupyterHub(Application):
         if self.proxy.should_start:
             self.log.info("JupyterHub is now running at %s", self.proxy.public_url)
         else:
-            self.log.info("JupyterHub is now running, internal Hub API at %s", self.hub.url)
+            self.log.info(
+                "JupyterHub is now running, internal Hub API at %s", self.hub.url
+            )
         # Use atexit for Windows, it doesn't have signal handling support
         if _mswindows:
             atexit.register(self.atexit)


### PR DESCRIPTION
When we run the proxy separately,  defaults of `hub.bind_url` may be different from proxy's public url. Actually, the hub has no ways to know about which address the proxy is serving at if we do not configure its `bind_url` explicitly.