### PR TITLE
Stop opening PAM sessions by default

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -975,16 +975,24 @@ class PAMAuthenticator(LocalAuthenticator):
     ).tag(config=True)
 
     open_sessions = Bool(
-        True,
+        False,
         help="""
         Whether to open a new PAM session when spawners are started.
 
-        This may trigger things like mounting shared filsystems,
-        loading credentials, etc. depending on system configuration,
-        but it does not always work.
+        This may trigger things like mounting shared filesystems,
+        loading credentials, etc. depending on system configuration.
+
+        The lifecycle of PAM sessions is not correct,
+        so many PAM session configurations will not work.
 
         If any errors are encountered when opening/closing PAM sessions,
         this is automatically set to False.
+
+        .. versionchanged:: 2.2
+
+            Due to longstanding problems in the session lifecycle,
+            this is now disabled by default.
+            You may opt-in to opening sessions by setting this to True.
         """,
     ).tag(config=True)
 


### PR DESCRIPTION
We don't do it correctly, so don't try by default

It does work _sometimes_, but most of the times that it does work, it's because it's a no-op. Turning it off by default makes it more likely folks will see the caveat that it may not work.

xref #2973