### PR TITLE
Enable options_from_form(spawner, form_data) from configuration file

### DIFF
--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -255,7 +255,7 @@ class SpawnHandler(BaseHandler):
             self.log.debug(
                 "Triggering spawn with supplied form options for %s", spawner._log_name
             )
-            options = await maybe_future(spawner.options_from_form(form_options))
+            options = await maybe_future(spawner.run_options_from_form(form_options))
             pending_url = self._get_pending_url(user, server_name)
             return await self._wrap_spawn_single_user(
                 user, server_name, spawner, pending_url, options

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -11,6 +11,7 @@ import shutil
 import signal
 import sys
 import warnings
+from inspect import signature
 from subprocess import Popen
 from tempfile import mkdtemp
 from urllib.parse import urlparse
@@ -423,6 +424,13 @@ class Spawner(LoggingConfigurable):
 
     def _default_options_from_form(self, form_data):
         return form_data
+
+    def run_options_from_form(self, form_data):
+        sig = signature(self.options_from_form)
+        if 'spawner' in sig.parameters:
+            return self.options_from_form(form_data, spawner=self)
+        else:
+            return self.options_from_form(form_data)
 
     def options_from_query(self, query_data):
         """Interpret query arguments passed to /spawn

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -459,3 +459,25 @@ async def test_spawner_oauth_roles_bad(app, user):
     # raises ValueError if we try to assign a role that doesn't exist
     with pytest.raises(ValueError):
         await spawner.user.spawn()
+
+
+async def test_spawner_options_from_form(db):
+    def options_from_form(form_data):
+        return form_data
+    spawner = new_spawner(db, options_from_form=options_from_form)
+    form_data = {"key": ["value"]}
+    result = spawner.run_options_from_form(form_data)
+    for key, value in form_data.items():
+        assert key in result
+        assert result[key] == value
+
+
+async def test_spawner_options_from_form_with_spawner(db):
+    def options_from_form(form_data, spawner):
+        return form_data
+    spawner = new_spawner(db, options_from_form=options_from_form)
+    form_data = {"key": ["value"]}
+    result = spawner.run_options_from_form(form_data)
+    for key, value in form_data.items():
+        assert key in result
+        assert result[key] == value

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -464,6 +464,7 @@ async def test_spawner_oauth_roles_bad(app, user):
 async def test_spawner_options_from_form(db):
     def options_from_form(form_data):
         return form_data
+
     spawner = new_spawner(db, options_from_form=options_from_form)
     form_data = {"key": ["value"]}
     result = spawner.run_options_from_form(form_data)
@@ -475,6 +476,7 @@ async def test_spawner_options_from_form(db):
 async def test_spawner_options_from_form_with_spawner(db):
     def options_from_form(form_data, spawner):
         return form_data
+
     spawner = new_spawner(db, options_from_form=options_from_form)
     form_data = {"key": ["value"]}
     result = spawner.run_options_from_form(form_data)


### PR DESCRIPTION
In #3789 it was noted that attempting to customize `c.Spawner.options_from_form` would result in a syntax error if the callable signature was like `my_options_from_form(spawner, form_data)`.  Since the default `options_from_form` and subclass `options_from_form` implementations can take the spawner object and the form data as arguments, it appears to be a bug.

The question is how best to handle both cases, and here I document one that seems to work in my case and at least passes existing tests (though a new test with a configured `options_from_form` setting may make sense).  There might be a nicer way to do this than to check whether `options_from_form` is being a function (as opposed to a bound method).  If there are better ideas I'm happy to try them. 