### PR TITLE
show insecure-login-warning for all authenticators

### DIFF
--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -15,6 +15,11 @@
 {{ custom_html | safe }}
 {% elif login_service %}
 <div class="service-login">
+  <p id='insecure-login-warning' class='hidden'>
+  Warning: JupyterHub seems to be served over an unsecured HTTP connection.
+  We strongly recommend enabling HTTPS for JupyterHub.
+  </p>
+
   <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
     Sign in with {{login_service}}
   </a>


### PR DESCRIPTION
the insecure login warning over http only appears when form-based authentication is in use. for example a github authenticator does not show this warning.

there is probably a more generic version of this change outside of the if-else construct.