### PR TITLE
Replace failed spawners when starting new launch

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -515,7 +515,7 @@ class UserServerAPIHandler(APIHandler):
                             user_name, self.named_server_limit_per_user
                         ),
                     )
-        spawner = user.spawners[server_name]
+        spawner = user.get_spawner(server_name, replace_failed=True)
         pending = spawner.pending
         if pending == 'spawn':
             self.set_header('Content-Type', 'text/plain')


### PR DESCRIPTION
Avoids leaving stale state when re-using a spawner that failed the last time it started (closes #3592)

we keep failed spawners around to track their errors, but we don't want to re-use them when it comes time to start a new launch.

adds `User.get_spawner(server_name, replace_failed=True)` to always get a non-failed Spawner.

The alternative approach  is to change how we 'keep' failures around, e.g. in a separate failed-launches dict, so that `user.spawners['name']` never returns failed spawners. I suspect that would be _more_ complicated, though, not less.