### PR TITLE
idle-culler example config missing closing bracket

### DIFF
--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -83,6 +83,7 @@ c.JupyterHub.load_roles = [
             # 'admin:users' # needed if culling idle users as well
         ]
     }
+]
 
 c.JupyterHub.services = [
     {


### PR DESCRIPTION
I was looking through the example config and noticed that the provided config is missing a closing square bracket.