### PR TITLE
Apache: set X-Forwarded-Proto header

### DIFF
--- a/docs/source/reference/config-proxy.md
+++ b/docs/source/reference/config-proxy.md
@@ -208,6 +208,7 @@ Listen 443
     # proxy to JupyterHub
     ProxyPass         http://127.0.0.1:8000/
     ProxyPassReverse  http://127.0.0.1:8000/
+    RequestHeader     set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
   </Location>
 </VirtualHost>
 ```


### PR DESCRIPTION
This should ensure JupyterHub correctly compares the protocol used for the request (e.g. https) with the protocol from the referrer when checking for cross-site requests in the admin pages.

Closes https://github.com/jupyterhub/jupyterhub/issues/3780

@rzo1 @tobi45 would you mind checking this matches your configuration?

Preview of the rendered docs is at https://jupyterhub--3808.org.readthedocs.build/en/3808/reference/config-proxy.html#apache