### PR TITLE
Update example to not reference an undefined scope

### DIFF
--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -113,7 +113,6 @@ c.JupyterHub.load_roles = [
         "scopes": [
             # specify the permissions the token should have
             "admin:users",
-            "admin:services",
         ],
         "services": [
             # assign the service the above permissions


### PR DESCRIPTION
Fixes #3811

Removes the non-existent scope from the documentation example. I am not sure if some scopes should be added to the example so it is equivalent to the JupyterHub 1.x admin services:

```
c.JupyterHub.services = [
    {
        "name": "service-admin",
        "api_token": "secret-token",
         "admin": True,
    },
]
```