### PR TITLE
allow Spawner.server to be mocked without underlying orm_spawner

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -195,8 +195,7 @@ class Spawner(LoggingConfigurable):
         # always check that we're in sync with orm_spawner
         if not self.orm_spawner:
             # no ORM spawner, nothing to check
-            self._server = None
-            return None
+            return self._server
 
         orm_server = self.orm_spawner.server
 
@@ -227,6 +226,10 @@ class Spawner(LoggingConfigurable):
                 if server.orm_server is None:
                     self.log.warning(f"No ORM server for {self._log_name}")
                 self.orm_spawner.server = server.orm_server
+        elif server is not None:
+            self.log.warning(
+                "Setting Spawner.server for {self._log_name} with no underlying orm_spawner"
+            )
 
     @property
     def name(self):

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -529,3 +529,10 @@ def test_spawner_server(db):
     spawner.server = None
     db.commit()
     assert spawner.orm_spawner.server is None
+
+    # test with no underlying orm.Spawner
+    # (only relevant for mocking, never true for actual Spawners)
+    spawner = Spawner()
+    spawner.server = Server.from_url("http://1.2.3.4")
+    assert spawner.server is not None
+    assert spawner.server.ip == "1.2.3.4"


### PR DESCRIPTION
This can't happen in reality, but can happen in tests (https://github.com/jupyterhub/kubespawner/issues/582).

Instead of being strict about always reflecting underlying orm_spawner, allow setting Spawner.server to persist if Spawner.orm_spawner is never defined.