### PR TITLE
Tokens have scopes instead of roles

### DIFF
--- a/ci/init-db.sh
+++ b/ci/init-db.sh
@@ -20,7 +20,7 @@ fi
 
 # Configure a set of databases in the database server for upgrade tests
 set -x
-for SUFFIX in '' _upgrade_100 _upgrade_122 _upgrade_130; do
+for SUFFIX in '' _upgrade_100 _upgrade_122 _upgrade_130 _upgrade_150 _upgrade_211; do
     $SQL_CLIENT "DROP DATABASE jupyterhub${SUFFIX};" 2>/dev/null || true
     $SQL_CLIENT "CREATE DATABASE jupyterhub${SUFFIX} ${EXTRA_CREATE_DATABASE_ARGS:-};"
 done

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -560,7 +560,19 @@ paths:
                   description: A note attached to the token for future bookkeeping
                 roles:
                   type: array
-                  description: A list of role names that the token should have
+                  description: |
+                    A list of role names from which to derive scopes.
+                    This is a shortcut for assigning collections of scopes;
+                    Tokens do not retain role assignment.
+                    (Changed in 2.3: roles are immediately resolved to scopes
+                    instead of stored on roles.)
+                  items:
+                    type: string
+                scopes:
+                  type: array
+                  description: |
+                    A list of scopes that the token should have.
+                    (new in JupyterHub 2.3).
                   items:
                     type: string
         required: false
@@ -1314,7 +1326,15 @@ components:
           description: The service that owns the token (undefined of owned by a user)
         roles:
           type: array
-          description: The names of roles this token has
+          description: Deprecated in JupyterHub 2.3, always an empty list.
+            Tokens have 'scopes' starting from JupyterHub 2.3.
+          items:
+            type: string
+        scopes:
+          type: array
+          description: List of scopes this token has been assigned.
+            New in JupyterHub 2.3. In JupyterHub 2.0-2.2,
+            tokens were assigned 'roles' insead of scopes.
           items:
             type: string
         note:

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1326,15 +1326,16 @@ components:
           description: The service that owns the token (undefined of owned by a user)
         roles:
           type: array
-          description: Deprecated in JupyterHub 2.3, always an empty list.
-            Tokens have 'scopes' starting from JupyterHub 2.3.
+          description:
+            Deprecated in JupyterHub 2.3, always an empty list. Tokens
+            have 'scopes' starting from JupyterHub 2.3.
           items:
             type: string
         scopes:
           type: array
-          description: List of scopes this token has been assigned.
-            New in JupyterHub 2.3. In JupyterHub 2.0-2.2,
-            tokens were assigned 'roles' insead of scopes.
+          description:
+            List of scopes this token has been assigned. New in JupyterHub
+            2.3. In JupyterHub 2.0-2.2, tokens were assigned 'roles' insead of scopes.
           items:
             type: string
         note:

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -41,7 +41,7 @@ Services do not have a default role. Services without roles have no access to th
 A group does not require any role, and has no roles by default. If a user is a member of a group, they automatically inherit any of the group's permissions (see {ref}`resolving-roles-scopes-target` for more details). This is useful for assigning a set of common permissions to several users.
 
 **Tokens** \
-A token’s permissions are evaluated based on their owning entity. Since a token is always issued for a user or service, it can never have more permissions than its owner. If no specific role is requested for a new token, the token is assigned the `token` role.
+A token’s permissions are evaluated based on their owning entity. Since a token is always issued for a user or service, it can never have more permissions than its owner. If no specific scopes are requested for a new token, the token is assigned the `token` role.
 
 (define-role-target)=
 

--- a/jupyterhub/alembic/env.py
+++ b/jupyterhub/alembic/env.py
@@ -65,8 +65,9 @@ def run_migrations_offline():
 
     """
     connectable = config.attributes.get('connection', None)
-    config_opts = dict(literal_binds=True)
+    config_opts = {}
     config_opts.update(common_config_opts)
+    config_opts["literal_binds"] = True
 
     if connectable is None:
         config_opts["url"] = config.get_main_option("sqlalchemy.url")

--- a/jupyterhub/alembic/versions/651f5419b74d_api_token_scopes.py
+++ b/jupyterhub/alembic/versions/651f5419b74d_api_token_scopes.py
@@ -1,0 +1,82 @@
+"""api_token_scopes
+
+Revision ID: 651f5419b74d
+Revises: 833da8570507
+Create Date: 2022-02-28 12:42:55.149046
+
+"""
+# revision identifiers, used by Alembic.
+revision = '651f5419b74d'
+down_revision = '833da8570507'
+branch_labels = None
+depends_on = None
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import Table
+from sqlalchemy import Unicode
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm.session import Session
+
+from jupyterhub import orm
+from jupyterhub import roles
+
+
+def upgrade():
+    c = op.get_bind()
+
+    tables = sa.inspect(c.engine).get_table_names()
+
+    # oauth codes are short lived, no need to upgrade them
+    if 'oauth_code_role_map' in tables:
+        op.drop_table('oauth_code_role_map')
+
+    if 'oauth_codes' in tables:
+        op.add_column('oauth_codes', sa.Column('scopes', orm.JSONList(), nullable=True))
+
+    if 'api_tokens' not in tables:
+        # e.g. upgrade from 1.x, token table dropped
+        # no migration to do
+        return
+
+    # define new scopes column on API tokens
+    op.add_column('api_tokens', sa.Column('scopes', orm.JSONList(), nullable=True))
+
+    if 'api_token_role_map' in tables:
+        # redefine the to-be-removed api_token->role relationship
+        # so we can run a query on it for the migration
+        token_role_map = Table(
+            "api_token_role_map",
+            orm.Base.metadata,
+            Column(
+                'api_token_id',
+                ForeignKey('api_tokens.id', ondelete='CASCADE'),
+                primary_key=True,
+            ),
+            Column(
+                'role_id',
+                ForeignKey('roles.id', ondelete='CASCADE'),
+                primary_key=True,
+            ),
+            extend_existing=True,
+        )
+        orm.APIToken.roles = relationship('Role', secondary='api_token_role_map')
+
+        # tokens have roles, evaluate to scopes
+        db = Session(bind=c)
+        for token in db.query(orm.APIToken):
+            token.scopes = list(roles.roles_to_scopes(token.roles))
+        db.commit()
+        # drop token-role relationship
+        op.drop_table('api_token_role_map')
+
+
+def downgrade():
+    # cannot map permissions from scopes back to roles
+    # drop whole api token table (revokes all tokens), which will be recreated on hub start
+    op.drop_table('api_tokens')
+    op.drop_table('oauth_codes')

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -14,6 +14,7 @@ from tornado import web
 
 from .. import orm
 from ..handlers import BaseHandler
+from ..scopes import get_scopes_for
 from ..utils import get_browser_protocol
 from ..utils import isoformat
 from ..utils import url_path_join
@@ -224,7 +225,9 @@ class APIHandler(BaseHandler):
             owner_key: owner,
             'id': token.api_id,
             'kind': 'api_token',
-            'roles': [r.name for r in token.roles],
+            # deprecated field, but leave it present.
+            'roles': [],
+            'scopes': list(get_scopes_for(token)),
             'created': isoformat(token.created),
             'last_activity': isoformat(token.last_activity),
             'expires_at': isoformat(token.expires_at),

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -406,21 +406,18 @@ class UserTokenListAPIHandler(APIHandler):
             if requester is not user:
                 note += f" by {kind} {requester.name}"
 
-        token_roles = body.get('roles')
+        token_roles = body.get("roles")
+        token_scopes = body.get("scopes")
+
         try:
             api_token = user.new_api_token(
                 note=note,
                 expires_in=body.get('expires_in', None),
                 roles=token_roles,
+                scopes=token_scopes,
             )
-        except KeyError:
-            raise web.HTTPError(404, "Requested roles %r not found" % token_roles)
-        except ValueError:
-            raise web.HTTPError(
-                403,
-                "Requested roles %r cannot have higher permissions than the token owner"
-                % token_roles,
-            )
+        except ValueError as e:
+            raise web.HTTPError(400, str(e))
         if requester is not user:
             self.log.info(
                 "%s %s requested API token for %s",

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -55,7 +55,6 @@ from traitlets import (
     Bool,
     Any,
     Tuple,
-    Type,
     Set,
     Instance,
     Bytes,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2079,23 +2079,6 @@ class JupyterHub(Application):
 
         # make sure we load any default roles not overridden
         init_roles = list(default_roles_dict.values()) + init_roles
-        if roles_with_new_permissions:
-            unauthorized_oauth_tokens = (
-                self.db.query(orm.APIToken)
-                .filter(
-                    orm.APIToken.roles.any(
-                        orm.Role.name.in_(roles_with_new_permissions)
-                    )
-                )
-                .filter(orm.APIToken.client_id != 'jupyterhub')
-            )
-            for token in unauthorized_oauth_tokens:
-                self.log.warning(
-                    "Deleting OAuth token %s; one of its roles obtained new permissions that were not authorized by user"
-                    % token
-                )
-                self.db.delete(token)
-            self.db.commit()
 
         init_role_names = [r['name'] for r in init_roles]
         if (
@@ -2230,9 +2213,6 @@ class JupyterHub(Application):
             )
             for kind in kinds:
                 roles.check_for_default_roles(db, kind)
-
-            # check tokens for default roles
-            roles.check_for_default_roles(db, bearer='tokens')
 
     async def _add_tokens(self, token_dict, kind):
         """Add tokens for users or services to the database"""

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -3,7 +3,6 @@
 # Distributed under the terms of the Modified BSD License.
 import enum
 import json
-import warnings
 from base64 import decodebytes
 from base64 import encodebytes
 from datetime import datetime
@@ -40,10 +39,7 @@ from sqlalchemy.types import Text
 from sqlalchemy.types import TypeDecorator
 from tornado.log import app_log
 
-from .roles import assign_default_roles
-from .roles import create_role
-from .roles import get_default_roles
-from .roles import update_roles
+from .roles import roles_to_scopes
 from .utils import compare_token
 from .utils import hash_token
 from .utils import new_token
@@ -110,7 +106,9 @@ class JSONList(JSONDict):
         return value
 
     def process_result_value(self, value, dialect):
-        if value is not None:
+        if value is None:
+            return []
+        else:
             value = json.loads(value)
         return value
 
@@ -157,9 +155,7 @@ for has_role in (
     'user',
     'group',
     'service',
-    'api_token',
     'oauth_client',
-    'oauth_code',
 ):
     role_map = Table(
         f'{has_role}_role_map',
@@ -185,10 +181,9 @@ class Role(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(Unicode(255), unique=True)
     description = Column(Unicode(1023))
-    scopes = Column(JSONList)
+    scopes = Column(JSONList, default=[])
     users = relationship('User', secondary='user_role_map', backref='roles')
     services = relationship('Service', secondary='service_role_map', backref='roles')
-    tokens = relationship('APIToken', secondary='api_token_role_map', backref='roles')
     groups = relationship('Group', secondary='group_role_map', backref='roles')
 
     def __repr__(self):
@@ -597,6 +592,10 @@ class APIToken(Hashed, Base):
     def api_id(self):
         return 'a%i' % self.id
 
+    @property
+    def owner(self):
+        return self.user or self.service
+
     # added in 2.0
     client_id = Column(
         Unicode(255),
@@ -624,6 +623,7 @@ class APIToken(Hashed, Base):
     expires_at = Column(DateTime, default=None, nullable=True)
     last_activity = Column(DateTime)
     note = Column(Unicode(1023))
+    scopes = Column(JSONList, default=[])
 
     def __repr__(self):
         if self.user is not None:
@@ -676,9 +676,11 @@ class APIToken(Hashed, Base):
     def new(
         cls,
         token=None,
+        *,
         user=None,
         service=None,
         roles=None,
+        scopes=None,
         note='',
         generated=True,
         session_id=None,
@@ -697,6 +699,42 @@ class APIToken(Hashed, Base):
             generated = True
         else:
             cls.check_token(db, token)
+
+        if scopes is not None and roles is not None:
+            raise ValueError(
+                "Can only assign one of scopes or roles when creating tokens."
+            )
+
+        elif scopes is None and roles is None:
+            # this is the default branch
+            # use the default 'token' role to specify default permissions for API tokens
+            default_token_role = Role.find(db, 'token')
+            if not default_token_role:
+                scopes = ["inherit"]
+            else:
+                scopes = roles_to_scopes([default_token_role])
+        elif roles is not None:
+            # evaluate roles to scopes immediately
+            # TODO: should this be deprecated, or not?
+            # warnings.warn(
+            #     "Setting roles on tokens is deprecated in JupyterHub 2.2. Use scopes.",
+            #     DeprecationWarning,
+            #     stacklevel=3,
+            # )
+            orm_roles = []
+            for rolename in roles:
+                role = Role.find(db, name=rolename)
+                if role is None:
+                    raise ValueError(f"No such role: {rolename}")
+                orm_roles.append(role)
+            scopes = roles_to_scopes(orm_roles)
+
+        # avoid circular import
+        from .scopes import _check_scopes_exist, _check_token_scopes
+
+        _check_scopes_exist(scopes, who_for="token")
+        _check_token_scopes(scopes, owner=user or service)
+
         # two stages to ensure orm_token.generated has been set
         # before token setter is called
         orm_token = cls(
@@ -704,6 +742,7 @@ class APIToken(Hashed, Base):
             note=note or '',
             client_id=client_id,
             session_id=session_id,
+            scopes=list(scopes),
         )
         orm_token.token = token
         if user:
@@ -716,20 +755,16 @@ class APIToken(Hashed, Base):
             orm_token.expires_at = cls.now() + timedelta(seconds=expires_in)
 
         db.add(orm_token)
-        if not Role.find(db, 'token'):
-            raise RuntimeError("Default token role has not been created")
-        try:
-            if roles is not None:
-                update_roles(db, entity=orm_token, roles=roles)
-            else:
-                assign_default_roles(db, entity=orm_token)
-        except Exception:
-            db.delete(orm_token)
-            db.commit()
-            raise
-
         db.commit()
         return token
+
+    def update_scopes(self, new_scopes):
+        """Set new scopes, checking that they are allowed"""
+        from .scopes import _check_scopes_exist, _check_token_scopes
+
+        _check_scopes_exist(new_scopes, who_for="token")
+        _check_token_scopes(new_scopes, owner=self.owner)
+        self.scopes = new_scopes
 
 
 class OAuthCode(Expiring, Base):
@@ -746,7 +781,7 @@ class OAuthCode(Expiring, Base):
     # state = Column(Unicode(1023))
     user_id = Column(Integer, ForeignKey('users.id', ondelete='CASCADE'))
 
-    roles = relationship('Role', secondary='oauth_code_role_map')
+    scopes = Column(JSONList, default=[])
 
     @staticmethod
     def now():

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -424,9 +424,11 @@ def _expand_scope(scope):
             f"{scope_name}!{filter_}" for scope_name in expanded_scope_names
         }
         # special handling of server filter
-        # any access via server filter includes permission to read the user's name
+        # any read access via server filter includes permission to read the user's name
         resource, _, value = filter_.partition('=')
-        if resource == 'server':
+        if resource == 'server' and any(
+            scope_name.startswith("read:") for scope_name in expanded_scope_names
+        ):
             username, _, server = value.partition('/')
             expanded_scopes.add(f'read:users:name!user={username}')
     else:

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -319,11 +319,11 @@ def get_scopes_for(orm_object):
         if orm_object.client_id != "jupyterhub":
             # oauth tokens can be used to access the service issuing the token,
             # assuming the owner itself still has permission to do so
-            access = access_scopes(orm_object.oauth_client)
-            token_scopes.update(access)
+            token_scopes.update(access_scopes(orm_object.oauth_client))
 
         # reduce to collapse multiple filters on the same scope
         # to avoid spurious logs about discarded scopes
+        token_scopes.update(identify_scopes(owner))
         token_scopes = reduce_scopes(token_scopes)
 
         intersection = _intersect_expanded_scopes(
@@ -346,6 +346,8 @@ def get_scopes_for(orm_object):
                 token_scopes,
             )
         expanded_scopes = intersection
+        # always include identify scopes
+        expanded_scopes
     else:
         expanded_scopes = roles.roles_to_expanded_scopes(
             roles.get_roles_for(orm_object),
@@ -354,9 +356,6 @@ def get_scopes_for(orm_object):
         if isinstance(orm_object, (orm.User, orm.Service)):
             owner = orm_object
 
-    # always include identify scopes
-    if owner:
-        expanded_scopes.update(identify_scopes(owner))
     return expanded_scopes
 
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -303,7 +303,6 @@ def _mockservice(request, app, url=False):
         assert name in app._service_map
         service = app._service_map[name]
         token = service.orm.api_tokens[0]
-        update_roles(app.db, token, roles=['token'])
 
         async def start():
             # wait for proxy to be updated before starting the service

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -68,7 +68,7 @@ class WhoAmIHandler(HubAuthenticated, web.RequestHandler):
 
     @web.authenticated
     def get(self):
-        self.write(self.get_current_user())
+        self.write(json.dumps(self.get_current_user()))
 
 
 class OWhoAmIHandler(HubOAuthenticated, web.RequestHandler):
@@ -86,7 +86,7 @@ class OWhoAmIHandler(HubOAuthenticated, web.RequestHandler):
 
     @web.authenticated
     def get(self):
-        self.write(self.get_current_user())
+        self.write(json.dumps(self.get_current_user()))
 
 
 def main():

--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -8,10 +8,10 @@ import pytest
 from pytest import raises
 from traitlets.config import Config
 
-from ..app import JupyterHub
+from .. import orm
 from ..app import NewToken
 from ..app import UpgradeDB
-
+from ..scopes import _check_scopes_exist
 
 here = os.path.abspath(os.path.dirname(__file__))
 populate_db = os.path.join(here, 'populate_db.py')
@@ -36,7 +36,7 @@ def generate_old_db(env_dir, hub_version, db_url):
     check_call([env_py, populate_db, db_url])
 
 
-@pytest.mark.parametrize('hub_version', ['1.0.0', "1.2.2", "1.3.0"])
+@pytest.mark.parametrize('hub_version', ['1.0.0', "1.2.2", "1.3.0", "1.5.0", "2.1.1"])
 async def test_upgrade(tmpdir, hub_version):
     db_url = os.getenv('JUPYTERHUB_TEST_DB_URL')
     if db_url:
@@ -75,3 +75,10 @@ async def test_upgrade(tmpdir, hub_version):
 
     # run tokenapp again, it should work
     tokenapp.start()
+
+    db = orm.new_session_factory(db_url)()
+    query = db.query(orm.APIToken)
+    assert query.count() >= 1
+    for token in query:
+        assert token.scopes, f"Upgraded token {token} has no scopes"
+        _check_scopes_exist(token.scopes)

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -10,6 +10,7 @@ from tornado.log import app_log
 
 from .. import orm
 from .. import roles
+from ..scopes import _expand_self_scope
 from ..scopes import get_scopes_for
 from ..scopes import scope_definitions
 from ..utils import utcnow
@@ -76,24 +77,17 @@ def test_orm_roles(db):
     # assigns it the default 'token' role
     token = user.new_api_token()
     user_token = orm.APIToken.find(db, token=token)
-    assert user_token in token_role.tokens
-    assert token_role in user_token.roles
+    assert set(user_token.scopes) == set(token_role.scopes)
 
     # check creating token with a specific role
     token = service.new_api_token(roles=['service'])
     service_token = orm.APIToken.find(db, token=token)
-    assert service_token in service_role.tokens
-    assert service_role in service_token.roles
+    assert set(service_token.scopes) == set(service_role.scopes)
 
-    # check deleting user removes the user and the token from roles
+    # check deleting user removes the user from roles
     db.delete(user)
     db.commit()
     assert user_role.users == []
-    assert user_token not in token_role.tokens
-    # check deleting the service token removes it from 'service' role
-    db.delete(service_token)
-    db.commit()
-    assert service_token not in service_role.tokens
     # check deleting the service_role removes it from service.roles
     db.delete(service_role)
     db.commit()
@@ -174,7 +168,7 @@ def test_orm_roles_delete_cascade(db):
 
 @mark.role
 @mark.parametrize(
-    "scopes, subscopes",
+    "scopes, expected_scopes",
     [
         (
             ['admin:users'],
@@ -246,12 +240,12 @@ def test_orm_roles_delete_cascade(db):
         ),
     ],
 )
-def test_get_subscopes(db, scopes, subscopes):
-    """Test role scopes expansion into their subscopes"""
+def test_get_expanded_scopes(db, scopes, expected_scopes):
+    """Test role scopes expansion into their fully expanded scopes"""
     roles.create_role(db, {'name': 'testing_scopes', 'scopes': scopes})
     role = orm.Role.find(db, name='testing_scopes')
-    response = roles._get_subscopes(role)
-    assert response == subscopes
+    expanded_scopes = roles.roles_to_expanded_scopes([role], owner=None)
+    assert expanded_scopes == expected_scopes
     db.delete(role)
 
 
@@ -659,9 +653,9 @@ async def test_load_roles_user_tokens(tmpdir, request):
     # test if all other tokens have default 'user' role
     token_role = orm.Role.find(db, 'token')
     secret_token = orm.APIToken.find(db, 'secret-token')
-    assert token_role in secret_token.roles
+    assert set(secret_token.scopes) == set(token_role.scopes)
     secrety_token = orm.APIToken.find(db, 'secrety-token')
-    assert token_role in secrety_token.roles
+    assert set(secrety_token.scopes) == set(token_role.scopes)
 
     # delete the test tokens
     for token in db.query(orm.APIToken):
@@ -682,15 +676,15 @@ async def test_load_roles_user_tokens(tmpdir, request):
         # role scopes within the user's default 'user' role
         ({}, 'self-reader', ['read:users!user'], 201),
         # role scopes within the user's default 'user' role, but with disjoint filter
-        ({}, 'other-reader', ['read:users!user=other'], 403),
+        ({}, 'other-reader', ['read:users!user=other'], 400),
         # role scopes within the user's default 'user' role, without filter
-        ({}, 'other-reader', ['read:users'], 403),
+        ({}, 'other-reader', ['read:users'], 400),
         # role scopes outside of the user's role but within the group's role scopes of which the user is a member
         ({}, 'groups-reader', ['read:groups'], 201),
         # non-existing role request
-        ({}, 'non-existing', [], 404),
+        ({}, 'non-existing', [], 400),
         # role scopes outside of both user's role and group's role scopes
-        ({}, 'users-creator', ['admin:users'], 403),
+        ({}, 'users-creator', ['admin:users'], 400),
     ],
 )
 async def test_get_new_token_via_api(app, headers, rolename, scopes, status):
@@ -756,7 +750,7 @@ async def test_self_expansion(app, kind, has_user_scopes):
     test_role = orm.Role(name='test_role', scopes=['self'])
     orm_obj.roles.append(test_role)
     # test expansion of user/service scopes
-    scopes = roles.expand_roles_to_scopes(orm_obj)
+    scopes = get_scopes_for(orm_obj)
     assert bool(scopes) == has_user_scopes
     if kind == 'users':
         for scope in scopes:
@@ -797,9 +791,9 @@ async def test_user_filter_expansion(app, scope_list, kind, test_for_token):
     if test_for_token:
         token = orm_obj.new_api_token(roles=['test_role'])
         orm_token = orm.APIToken.find(app.db, token)
-        expanded_scopes = roles.expand_roles_to_scopes(orm_token)
+        expanded_scopes = get_scopes_for(orm_token)
     else:
-        expanded_scopes = roles.expand_roles_to_scopes(orm_obj)
+        expanded_scopes = get_scopes_for(orm_obj)
 
     for scope in scope_list:
         base, _, filter = scope.partition('!')
@@ -817,7 +811,7 @@ async def test_user_filter_expansion(app, scope_list, kind, test_for_token):
 
 
 async def test_large_filter_expansion(app, create_temp_role, create_user_with_scopes):
-    scope_list = roles.expand_self_scope('==')
+    scope_list = _expand_self_scope('==')
     # Mimic the role 'self' based on '!user' filter for tokens
     scope_list = [scope.rstrip("=") for scope in scope_list]
     filtered_role = create_temp_role(scope_list)
@@ -864,9 +858,7 @@ async def test_server_token_role(app):
     assert orm_server_token
 
     server_role = orm.Role.find(app.db, 'server')
-    token_role = orm.Role.find(app.db, 'token')
-    assert server_role in orm_server_token.roles
-    assert token_role not in orm_server_token.roles
+    assert set(server_role.scopes) == set(orm_server_token.scopes)
 
     assert orm_server_token.user.name == user.name
     assert user.api_tokens == [orm_server_token]
@@ -891,7 +883,7 @@ async def test_server_role_api_calls(
     user = add_user(app.db, app, name='test_user')
     roles.grant_role(app.db, user, 'user')
     app_log.debug(user.roles)
-    app_log.debug(roles.expand_roles_to_scopes(user.orm_user))
+    app_log.debug(get_scopes_for(user.orm_user))
     if token_role == 'no_role':
         api_token = user.new_api_token(roles=[])
     else:
@@ -963,7 +955,7 @@ async def test_user_group_roles(app, create_temp_role):
     # regression test for #3472
     roles_before = list(user.roles)
     for i in range(3):
-        roles.expand_roles_to_scopes(user.orm_user)
+        get_scopes_for(user.orm_user)
         user_roles = list(user.roles)
         assert user_roles == roles_before
 
@@ -1063,33 +1055,6 @@ async def test_config_role_users():
     user = orm.User.find(hub.db, name=user_name)
     role = orm.Role.find(hub.db, name=role_name)
     assert role not in user.roles
-
-
-async def test_scope_expansion_revokes_tokens(app, mockservice_url):
-    role_name = 'morpheus'
-    roles_to_load = [
-        {
-            'name': role_name,
-            'description': 'wears sunglasses',
-            'scopes': ['users', 'groups'],
-        },
-    ]
-    app.load_roles = roles_to_load
-    await app.init_role_creation()
-    user = add_user(app.db, name='laurence')
-    for _ in range(2):
-        user.new_api_token()
-    red_token, blue_token = user.api_tokens
-    roles.grant_role(app.db, red_token, role_name)
-    service = mockservice_url
-    red_token.client_id = service.oauth_client_id
-    app.db.commit()
-    # Restart hub and see if token is revoked
-    app.load_roles[0]['scopes'].append('proxy')
-    await app.init_role_creation()
-    user = orm.User.find(app.db, name='laurence')
-    assert red_token not in user.api_tokens
-    assert blue_token in user.api_tokens
 
 
 async def test_duplicate_role_users():
@@ -1352,7 +1317,7 @@ async def test_hub_upgrade_detection(tmpdir):
     for name in user_names:
         user = orm.User.find(hub.db, name)
         assert user_role in user.roles
-        assert token_role in user.api_tokens[0].roles
+        assert set(user.api_tokens[0].scopes) == set(token_role.scopes)
     # Strip all roles and see if it sticks
     user_role.users = []
     token_role.tokens = []
@@ -1371,48 +1336,8 @@ async def test_hub_upgrade_detection(tmpdir):
     allowed_user = orm.User.find(hub.db, 'patricia')
     rem_user = orm.User.find(hub.db, 'quentin')
     assert user_role in allowed_user.roles
-    assert token_role not in allowed_user.api_tokens[0].roles
     assert user_role not in rem_user.roles
     assert token_role not in rem_user.roles
-
-
-async def test_token_keep_roles_on_restart():
-    role_spec = [
-        {
-            'name': 'bloop',
-            'scopes': ['read:users'],
-        }
-    ]
-    hub = MockHub(load_roles=role_spec)
-    hub.init_db()
-    hub.authenticator.admin_users = ['ben']
-    await hub.init_role_creation()
-    await hub.init_users()
-    await hub.init_role_assignment()
-    user = orm.User.find(hub.db, name='ben')
-    for _ in range(3):
-        user.new_api_token()
-    happy_token, content_token, sad_token = user.api_tokens
-    roles.grant_role(hub.db, happy_token, 'bloop')
-    roles.strip_role(hub.db, sad_token, 'token')
-    assert len(happy_token.roles) == 2
-    assert len(content_token.roles) == 1
-    assert len(sad_token.roles) == 0
-    # Restart hub and see if roles are as expected
-    hub.load_roles = []
-    await hub.init_role_creation()
-    await hub.init_users()
-    await hub.init_api_tokens()
-    await hub.init_role_assignment()
-    user = orm.User.find(hub.db, name='ben')
-    happy_token, content_token, sad_token = user.api_tokens
-    assert len(happy_token.roles) == 1
-    assert len(content_token.roles) == 1
-    print(sad_token.roles)
-    assert len(sad_token.roles) == 0
-    for token in user.api_tokens:
-        hub.db.delete(token)
-    hub.db.commit()
 
 
 async def test_login_default_role(app, username):

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -10,7 +10,6 @@ from tornado.log import app_log
 
 from .. import orm
 from .. import roles
-from ..scopes import _expand_self_scope
 from ..scopes import get_scopes_for
 from ..scopes import scope_definitions
 from ..utils import utcnow
@@ -808,19 +807,6 @@ async def test_user_filter_expansion(app, scope_list, kind, test_for_token):
 
     app.db.delete(orm_obj)
     app.db.delete(test_role)
-
-
-async def test_large_filter_expansion(app, create_temp_role, create_user_with_scopes):
-    scope_list = _expand_self_scope('==')
-    # Mimic the role 'self' based on '!user' filter for tokens
-    scope_list = [scope.rstrip("=") for scope in scope_list]
-    filtered_role = create_temp_role(scope_list)
-    user = create_user_with_scopes('self')
-    user.new_api_token(roles=[filtered_role.name])
-    user.new_api_token(roles=['token'])
-    manual_scope_set = get_scopes_for(user.api_tokens[0])
-    auto_scope_set = get_scopes_for(user.api_tokens[1])
-    assert manual_scope_set == auto_scope_set
 
 
 @mark.role

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -1,5 +1,4 @@
 """Tests for services"""
-import asyncio
 import os
 import sys
 from binascii import hexlify
@@ -99,7 +98,6 @@ async def test_external_service(app):
         assert service.oauth_client is not None
         assert service.oauth_client.allowed_roles == [orm.Role.find(app.db, "user")]
         api_token = service.orm.api_tokens[0]
-        update_roles(app.db, api_token, roles=['token'])
         url = public_url(app, service) + '/api/users'
         r = await async_requests.get(url, allow_redirects=False)
         r.raise_for_status()

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -12,6 +12,7 @@ import pytest
 from bs4 import BeautifulSoup
 from pytest import raises
 from tornado.httputil import url_concat
+from tornado.log import app_log
 
 from .. import orm
 from .. import roles
@@ -206,32 +207,50 @@ async def test_hubauth_service_token(request, app, mockservice_url, scopes, allo
 
 
 @pytest.mark.parametrize(
-    "client_allowed_roles, request_roles, expected_roles",
+    "client_allowed_roles, request_scopes, expected_scopes",
     [
-        # allow empty roles
+        # allow empty permissions
         ([], [], []),
         # allow original 'identify' scope to map to no role
         ([], ["identify"], []),
         # requesting roles outside client list doesn't work
         ([], ["admin"], None),
-        ([], ["token"], None),
-        # requesting nonexistent roles fails in the same way (no server error)
-        ([], ["nosuchrole"], None),
-        # requesting exactly client allow list works
+        ([], ["read:users"], None),
+        # requesting nonexistent roles or scopes fails in the same way (no server error)
+        ([], ["nosuchscope"], None),
+        ([], ["admin:invalid!no=bo!"], None),
+        # requesting role exactly client allow list works
         (["user"], ["user"], ["user"]),
+        # Request individual scope, held by user, not listed in allowed role
         # no explicit request, defaults to all
         (["token", "user"], [], ["token", "user"]),
-        # explicit 'identify' maps to none
-        (["token", "user"], ["identify"], []),
+        # explicit 'identify' maps to read:users:name!user
+        (["token", "user"], ["identify"], ["read:users:name!user=$user"]),
         # any item outside the list isn't allowed
         (["token", "user"], ["token", "server"], None),
+        (["read-only"], ["access:services"], None),
         # requesting subset
         (["admin", "user"], ["user"], ["user"]),
         (["user", "token", "server"], ["token", "user"], ["token", "user"]),
         (["admin", "user", "read-only"], ["read-only"], ["read-only"]),
+        # Request individual scopes, listed in allowed role
+        (["read-only"], ["access:servers"], ["access:servers"]),
         # requesting valid subset, some not held by user
-        (["admin", "user"], ["admin", "user"], ["user"]),
-        (["admin", "user"], ["admin"], []),
+        (
+            ["admin", "user"],
+            ["admin:users", "access:servers", "self"],
+            ["access:servers", "user"],
+        ),
+        (["other"], ["other"], []),
+        # custom scopes
+        (["user"], ["custom:jupyter_server:read:*"], None),
+        (
+            ["read-only"],
+            ["custom:jupyter_server:read:*"],
+            ["custom:jupyter_server:read:*"],
+        ),
+        # this one _should_ work, but doesn't until we implement expanded_scope filtering
+        # (["read-only"], ["custom:jupyter_server:read:*!user=$user"], ["custom:jupyter_server:read:*!user=$user"]),
     ],
 )
 async def test_oauth_service_roles(
@@ -239,8 +258,8 @@ async def test_oauth_service_roles(
     mockservice_url,
     create_user_with_scopes,
     client_allowed_roles,
-    request_roles,
-    expected_roles,
+    request_scopes,
+    expected_scopes,
     preserve_scopes,
 ):
     service = mockservice_url
@@ -267,13 +286,24 @@ async def test_oauth_service_roles(
             ],
         },
     )
+
+    roles.create_role(
+        app.db,
+        {
+            "name": "other",
+            "description": "A role not held by our test user",
+            "scopes": [
+                "admin:users",
+            ],
+        },
+    )
     oauth_client.allowed_roles = [
         orm.Role.find(app.db, role_name) for role_name in client_allowed_roles
     ]
     app.db.commit()
     url = url_path_join(public_url(app, mockservice_url) + 'owhoami/?arg=x')
-    if request_roles:
-        url = url_concat(url, {"request-scope": " ".join(request_roles)})
+    if request_scopes:
+        url = url_concat(url, {"request-scope": " ".join(request_scopes)})
     # first request is only going to login and get us to the oauth form page
     s = AsyncSession()
     user = create_user_with_scopes("access:services")
@@ -283,7 +313,7 @@ async def test_oauth_service_roles(
     s.cookies = await app.login_user(name)
 
     r = await s.get(url)
-    if expected_roles is None:
+    if expected_scopes is None:
         # expected failed auth, stop here
         # verify expected 'invalid scope' error, not server error
         dest_url, _, query = r.url.partition("?")
@@ -291,6 +321,7 @@ async def test_oauth_service_roles(
         assert parse_qs(query).get("error") == ["invalid_scope"]
         assert r.status_code == 400
         return
+
     r.raise_for_status()
     # we should be looking at the oauth confirmation page
     assert urlparse(r.url).path == app.base_url + 'hub/api/oauth2/authorize'
@@ -300,7 +331,7 @@ async def test_oauth_service_roles(
     page = BeautifulSoup(r.text, "html.parser")
     scope_inputs = page.find_all("input", {"name": "scopes"})
     scope_values = [input["value"] for input in scope_inputs]
-    print("Submitting request with scope values", scope_values)
+    app_log.info(f"Submitting request with scope values {scope_values}")
     # submit the oauth form to complete authorization
     data = {}
     if scope_values:
@@ -317,9 +348,34 @@ async def test_oauth_service_roles(
     r = await s.get(url, allow_redirects=False)
     r.raise_for_status()
     assert r.status_code == 200
+    assert len(r.history) == 0
     reply = r.json()
     sub_reply = {key: reply.get(key, 'missing') for key in ('kind', 'name')}
     assert sub_reply == {'name': user.name, 'kind': 'user'}
+
+    expected_scopes = {s.replace("$user", user.name) for s in expected_scopes}
+
+    # expand roles to scopes (shortcut)
+    for scope in list(expected_scopes):
+        role = orm.Role.find(app.db, scope)
+        if role:
+            expected_scopes.discard(role.name)
+            expected_scopes.update(
+                roles.roles_to_expanded_scopes([role], owner=user.orm_user)
+            )
+
+    if 'inherit' in expected_scopes:
+        expected_scopes = scopes.get_scopes_for(user.orm_user)
+
+    # always expect identify/access scopes
+    # on successful authentication
+    expected_scopes.update(scopes.identify_scopes(user.orm_user))
+    expected_scopes.update(scopes.access_scopes(oauth_client))
+    expected_scopes = scopes.reduce_scopes(expected_scopes)
+    have_scopes = scopes.reduce_scopes(set(reply['scopes']))
+    # pytest is better at reporting list differences
+    # than set differences, especially with `-vv`
+    assert sorted(have_scopes) == sorted(expected_scopes)
 
     # token-authenticated request to HubOAuth
     token = app.users[name].new_api_token()
@@ -428,18 +484,23 @@ async def test_oauth_page_hit(
     user = create_user_with_scopes("access:services", "self")
     for role in test_roles.values():
         roles.grant_role(app.db, user, role)
-    token_scopes = roles.roles_to_scopes([test_roles[t] for t in token_roles])
-    user.new_api_token(scopes=token_scopes)
-    token = user.api_tokens[0]
 
+    # Create a token with the prior authorization
     oauth_client = (
         app.db.query(orm.OAuthClient)
         .filter_by(identifier=service.oauth_client_id)
         .one()
     )
     oauth_client.allowed_roles = list(test_roles.values())
+
+    authorized_scopes = roles.roles_to_scopes([test_roles[t] for t in token_roles])
+    authorized_scopes.update(scopes.identify_scopes())
+    authorized_scopes.update(scopes.access_scopes(oauth_client))
+    user.new_api_token(scopes=authorized_scopes)
+    token = user.api_tokens[0]
     token.client_id = service.oauth_client_id
     app.db.commit()
+
     s = AsyncSession()
     s.cookies = await app.login_user(user.name)
     url = url_path_join(public_url(app, service) + 'owhoami/?arg=x')

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -428,9 +428,9 @@ async def test_oauth_page_hit(
     user = create_user_with_scopes("access:services", "self")
     for role in test_roles.values():
         roles.grant_role(app.db, user, role)
-    user.new_api_token()
+    token_scopes = roles.roles_to_scopes([test_roles[t] for t in token_roles])
+    user.new_api_token(scopes=token_scopes)
     token = user.api_tokens[0]
-    token.roles = [test_roles[t] for t in token_roles]
 
     oauth_client = (
         app.db.query(orm.OAuthClient)

--- a/share/jupyterhub/templates/oauth.html
+++ b/share/jupyterhub/templates/oauth.html
@@ -14,7 +14,7 @@
     <p>
         {{ oauth_client.description }} (oauth URL: {{ oauth_client.redirect_uri }})
         would like permission to identify you.
-        {% if not role_names %}
+        {% if scope_descriptions | length == 1 and not scope_descriptions[0].scope %}
         It will not be able to take actions on
         your behalf.
         {% endif %}
@@ -24,8 +24,8 @@
     <div>
         <form method="POST" action="">
             {# these are the 'real' inputs to the form -#}
-            {% for role_name in role_names %}
-            <input type="hidden" name="scopes" value="{{ role_name }}"/>
+            {% for scope in allowed_scopes %}
+            <input type="hidden" name="scopes" value="{{ scope }}"/>
             {% endfor %}
 
             {% for scope_info in scope_descriptions %}


### PR DESCRIPTION
Following #3713 (included here, will rebase after merge), it's proven to be a problem that API tokens can only be assigned _roles_ instead of permissions.

Among other things, this means that intersections of requested scopes and user-owned scopes cannot be assigned to tokens, making granular permissions difficult to manage.

The main change here is resolving roles to scopes when tokens are issued, rather than storing role relationships

- [x] merge #3713
- [x] Tokens have scopes, not roles
- [x] Creating tokens with roles still works, but scopes are resolved immediately when the token is issued instead of lazily, at each authorized request
- [x] On db upgrade, role assignments are turned into scopes before dropping token roles (needed some tweaks to migration config to ensure the detection of the 2.0 api_tokens drop would work)
- [x] Small reorganization of scope/role utilities to make it easier to work with scopes at the relevant levels here
- [x] handle migration of roles->scopes in oauth `?scope` parameter. Currently backward-compatible just by allowing both.
- [x] no longer need to check for permission-changes on tokens at startup, as we did with roles, because scopes are now fixed.
- [x] expand some test coverage for new branches
