### PR TITLE
remove lingering reference to distutils

### DIFF
--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -15,7 +15,6 @@ from unittest.mock import patch
 
 import pytest
 import traitlets
-from distutils.version import LooseVersion as V
 from traitlets.config import Config
 
 from .. import orm
@@ -33,7 +32,7 @@ def test_help_all():
     assert '--JupyterHub.ip' in out
 
 
-@pytest.mark.skipif(V(traitlets.__version__) < V('5'), reason="requires traitlets 5")
+@pytest.mark.skipif(traitlets.version_info < (5,), reason="requires traitlets 5")
 def test_show_config(tmpdir):
     tmpdir.chdir()
     p = Popen(


### PR DESCRIPTION
traitlets, like most Jupyter projects (and Python itself), has a `.version_info` tuple to avoid needing to parse versions