### PR TITLE
adopt pytest-asyncio asyncio_mode='auto'

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,8 @@ jupyterlab >=3
 mock
 pre-commit
 pytest>=3.3
-pytest-asyncio
+pytest-asyncio; python_version < "3.7"
+pytest-asyncio>=0.17; python_version >= "3.7"
 pytest-cov
 requests-mock
 tbump

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -59,17 +59,26 @@ from .utils import add_user
 _db = None
 
 
-def pytest_collection_modifyitems(items):
+def _pytest_collection_modifyitems(items):
     """This function is automatically run by pytest passing all collected test
     functions.
 
     We use it to add asyncio marker to all async tests and assert we don't use
     test functions that are async generators which wouldn't make sense.
+
+    It is no longer required with pytest-asyncio >= 0.17
     """
     for item in items:
         if inspect.iscoroutinefunction(item.obj):
             item.add_marker('asyncio')
         assert not inspect.isasyncgenfunction(item.obj)
+
+
+if sys.version_info < (3, 7):
+    # apply pytest-asyncio's 'auto' mode on Python 3.6.
+    # 'auto' mode is new in pytest-asyncio 0.17,
+    # which requires Python 3.7.
+    pytest_collection_modifyitems = _pytest_collection_modifyitems
 
 
 @fixture(scope='module')

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,9 @@
 # so we have to disable this until pytest 3.11
 # minversion = 3.3
 
+# automatically run coroutine tests with asyncio
+asyncio_mode = auto
+
 # jupyter_server plugin is incompatible with notebook imports
 addopts = -p no:jupyter_server
 


### PR DESCRIPTION
removes need for our own implementation of the same behavior in conftest