### PR TITLE
Fix xsrf_cookie_kwargs ValueError

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -522,7 +522,7 @@ class BaseHandler(RequestHandler):
         # clear_cookie only accepts a subset of set_cookie's kwargs
         clear_xsrf_cookie_kwargs = {
             key: value
-            for key, value in self.settings.get('xsrf_cookie_kwargs', {})
+            for key, value in self.settings.get('xsrf_cookie_kwargs', {}).items()
             if key in {"path", "domain"}
         }
 


### PR DESCRIPTION
Fixes 

`ValueError: too many values to unpack (expected 2)`

Related to code added as a fix for https://github.com/jupyterhub/jupyterhub/issues/3821