### PR TITLE
Do not store Spawner.ip/port on spawner.server during get_env

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -873,9 +873,6 @@ class Spawner(LoggingConfigurable):
 
         if self.server:
             base_url = self.server.base_url
-            if self.ip or self.port:
-                self.server.ip = self.ip
-                self.server.port = self.port
             env['JUPYTERHUB_SERVICE_PREFIX'] = self.server.base_url
         else:
             # this should only occur in mock/testing scenarios


### PR DESCRIPTION
we shouldn't mutate db state when getting the environment.

IIRC, this was part of an attempt to get the url via `self.server.bind_url` that didn't end up getting used in #3381. So this doesn't really have any positive effects, but it _can_ have negative effects if `get_env` is called in unusual circumstances (jupyterhub/batchspawner#236)


closes jupyterhub/batchspawner#236