### PR TITLE
Deprecate Authenticator.db, Spawner.db

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1129,7 +1129,7 @@ class JupyterHub(Application):
 
     @default('authenticator')
     def _authenticator_default(self):
-        return self.authenticator_class(parent=self, db=self.db)
+        return self.authenticator_class(parent=self, _deprecated_db_session=self.db)
 
     implicit_spawn_seconds = Float(
         0,

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen
+from textwrap import dedent
 
 try:
     import pamela
@@ -30,6 +31,23 @@ class Authenticator(LoggingConfigurable):
     """Base class for implementing an authentication provider for JupyterHub"""
 
     db = Any()
+
+    @default("db")
+    def _deprecated_db(self):
+        self.log.warning(
+            dedent(
+                """
+                The shared database session at Authenticator.db is deprecated, and will be removed.
+                Please manage your own database and connections.
+
+                Contact JupyterHub at https://github.com/jupyterhub/jupyterhub/issues/3700
+                if you have questions or ideas about direct database needs for your Authenticator.
+                """
+            ),
+        )
+        return self._deprecated_db_session
+
+    _deprecated_db_session = Any()
 
     enable_auth_state = Bool(
         False,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -14,6 +14,7 @@ import warnings
 from inspect import signature
 from subprocess import Popen
 from tempfile import mkdtemp
+from textwrap import dedent
 from urllib.parse import urlparse
 
 from async_generator import aclosing
@@ -157,8 +158,26 @@ class Spawner(LoggingConfigurable):
     authenticator = Any()
     hub = Any()
     orm_spawner = Any()
-    db = Any()
     cookie_options = Dict()
+
+    db = Any()
+
+    @default("db")
+    def _deprecated_db(self):
+        self.log.warning(
+            dedent(
+                """
+                The shared database session at Spawner.db is deprecated, and will be removed.
+                Please manage your own database and connections.
+
+                Contact JupyterHub at https://github.com/jupyterhub/jupyterhub/issues/3700
+                if you have questions or ideas about direct database needs for your Spawner.
+                """
+            ),
+        )
+        return self._deprecated_db_session
+
+    _deprecated_db_session = Any()
 
     @observe('orm_spawner')
     def _orm_spawner_changed(self, change):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -411,7 +411,7 @@ class User:
             authenticator=self.authenticator,
             config=self.settings.get('config'),
             proxy_spec=url_path_join(self.proxy_spec, server_name, '/'),
-            db=self.db,
+            _deprecated_db_session=self.db,
             oauth_client_id=client_id,
             cookie_options=self.settings.get('cookie_options', {}),
             trusted_alt_names=trusted_alt_names,


### PR DESCRIPTION
These objects (and indeed, all extension points) should not access the shared db session; add a warning pointing to Issue about their removal if it is accessed.

Doesn't break anything, but warns on access and solicits feedback for https://github.com/jupyterhub/jupyterhub/issues/3700 .
