### PR TITLE
`admin_access` no longer works as it is overridden by RBAC scopes

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1317,11 +1317,14 @@ class JupyterHub(Application):
 
     admin_access = Bool(
         False,
-        help="""Grant admin users permission to access single-user servers.
+        help="""DEPRECATED since version 2.0.0.
 
-        Users should be properly informed if this is enabled.
+        The default admin role has full permissions, use custom RBAC scopes instead to
+        create restricted administrator roles.
+        https://jupyterhub.readthedocs.io/en/stable/rbac/index.html
         """,
     ).tag(config=True)
+
     admin_users = Set(
         help="""DEPRECATED since version 0.7.2, use Authenticator.admin_users instead."""
     ).tag(config=True)


### PR DESCRIPTION
`admin_access` no longer has any effect, see https://github.com/jupyterhub/jupyterhub/issues/3745#issuecomment-1038789932

The `admin_access` variable is still referenced elsewhere and I considered removing it, but I couldn't work out exactly how/if it's used so this is just a docs change for now.

Closes https://github.com/jupyterhub/jupyterhub/issues/3897
Closes https://github.com/jupyterhub/jupyterhub/issues/3045