### PR TITLE
`jupyter troubleshooting` ➡️  `jupyter troubleshoot`

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -371,7 +371,7 @@ a JupyterHub deployment. The commands are:
 - System and deployment information
 
 ```bash
-jupyter troubleshooting
+jupyter troubleshoot
 ```
 
 - Kernel information


### PR DESCRIPTION
Looks like there's a long-standing typo:
Closes https://github.com/jupyterhub/jupyterhub/issues/3119