### PR TITLE
Escape named server name

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -12,7 +12,7 @@ from tornado import web
 from .. import orm
 from ..handlers import BaseHandler
 from ..scopes import get_scopes_for
-from ..utils import get_browser_protocol, isoformat, url_path_join
+from ..utils import get_browser_protocol, isoformat, url_escape_path, url_path_join
 
 PAGINATION_MEDIA_TYPE = "application/jupyterhub-pagination+json"
 
@@ -196,7 +196,7 @@ class APIHandler(BaseHandler):
             'started': isoformat(spawner.orm_spawner.started),
             'pending': spawner.pending,
             'ready': spawner.ready,
-            'url': url_path_join(spawner.user.url, spawner.name, '/'),
+            'url': url_path_join(spawner.user.url, url_escape_path(spawner.name), '/'),
             'user_options': spawner.user_options,
             'progress_url': spawner._progress_url,
         }

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -15,7 +15,13 @@ from .. import orm, scopes
 from ..roles import assign_default_roles
 from ..scopes import needs_scope
 from ..user import User
-from ..utils import isoformat, iterate_until, maybe_future, url_path_join
+from ..utils import (
+    isoformat,
+    iterate_until,
+    maybe_future,
+    url_escape_path,
+    url_path_join,
+)
 from .base import APIHandler
 
 
@@ -685,7 +691,7 @@ class SpawnProgressAPIHandler(APIHandler):
         # - spawner not running at all
         # - spawner failed
         # - spawner pending start (what we expect)
-        url = url_path_join(user.url, server_name, '/')
+        url = url_path_join(user.url, url_escape_path(server_name), '/')
         ready_event = {
             'progress': 100,
             'ready': True,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -856,7 +856,9 @@ class BaseHandler(RequestHandler):
 
         if server_name:
             if '/' in server_name:
-                error_message = f"Invalid server_name (may not contain '/'): {server_name}"
+                error_message = (
+                    f"Invalid server_name (may not contain '/'): {server_name}"
+                )
                 self.log.error(error_message)
                 raise web.HTTPError(400, error_message)
             user_server_name = f'{user.name}:{server_name}'

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -44,6 +44,7 @@ from ..utils import (
     get_accepted_mimetype,
     get_browser_protocol,
     maybe_future,
+    url_escape_path,
     url_path_join,
 )
 
@@ -1519,6 +1520,7 @@ class UserUrlHandler(BaseHandler):
                 server_name = ''
         else:
             server_name = ''
+        escaped_server_name = url_escape_path(server_name)
         spawner = user.spawners[server_name]
 
         if spawner.ready:
@@ -1537,7 +1539,10 @@ class UserUrlHandler(BaseHandler):
 
         pending_url = url_concat(
             url_path_join(
-                self.hub.base_url, 'spawn-pending', user.escaped_name, server_name
+                self.hub.base_url,
+                'spawn-pending',
+                user.escaped_name,
+                escaped_server_name,
             ),
             {'next': self.request.uri},
         )
@@ -1551,7 +1556,9 @@ class UserUrlHandler(BaseHandler):
         # page *in* the server is not found, we return a 424 instead of a 404.
         # We allow retaining the old behavior to support older JupyterLab versions
         spawn_url = url_concat(
-            url_path_join(self.hub.base_url, "spawn", user.escaped_name, server_name),
+            url_path_join(
+                self.hub.base_url, "spawn", user.escaped_name, escaped_server_name
+            ),
             {"next": self.request.uri},
         )
         self.set_status(

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -856,7 +856,7 @@ class BaseHandler(RequestHandler):
 
         if server_name:
             if '/' in server_name:
-                error_message = f"Invalid server_name: {server_name}"
+                error_message = f"Invalid server_name (may not contain '/'): {server_name}"
                 self.log.error(error_message)
                 raise web.HTTPError(400, error_message)
             user_server_name = f'{user.name}:{server_name}'

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -855,6 +855,10 @@ class BaseHandler(RequestHandler):
         user_server_name = user.name
 
         if server_name:
+            if '/' in server_name:
+                error_message = f"Invalid server_name: {server_name}"
+                self.log.error(error_message)
+                raise web.HTTPError(400, error_message)
             user_server_name = f'{user.name}:{server_name}'
 
         if server_name in user.spawners and user.spawners[server_name].pending:

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -118,9 +118,6 @@ class SpawnHandler(BaseHandler):
 
     @needs_scope("servers")
     async def _get(self, user_name, server_name):
-        if '/' in server_name:
-            raise web.HTTPError(400, f"Invalid server_name: {server_name}")
-
         for_user = user_name
 
         user = current_user = self.current_user

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -118,6 +118,9 @@ class SpawnHandler(BaseHandler):
 
     @needs_scope("servers")
     async def _get(self, user_name, server_name):
+        if '/' in server_name:
+            raise web.HTTPError(400, f"Invalid server_name: {server_name}")
+
         for_user = user_name
 
         user = current_user = self.current_user

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -36,7 +36,7 @@ from jupyterhub.traitlets import Command
 from . import utils
 from .metrics import CHECK_ROUTES_DURATION_SECONDS, PROXY_POLL_DURATION_SECONDS
 from .objects import Server
-from .utils import AnyTimeoutError, exponential_backoff, url_path_join
+from .utils import AnyTimeoutError, exponential_backoff, url_escape_path, url_path_join
 
 
 def _one_at_a_time(method):
@@ -295,7 +295,9 @@ class Proxy(LoggingConfigurable):
         """Remove a user's server from the proxy table."""
         routespec = user.proxy_spec
         if server_name:
-            routespec = url_path_join(user.proxy_spec, server_name, '/')
+            routespec = url_path_join(
+                user.proxy_spec, url_escape_path(server_name), '/'
+            )
         self.log.info("Removing user %s from proxy (%s)", user.name, routespec)
         await self.delete_route(routespec)
 

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -288,7 +288,7 @@ class Proxy(LoggingConfigurable):
         await self.add_route(
             spawner.proxy_spec,
             spawner.server.host,
-            {'user': user.name, 'server_name': server_name},
+            {'user': user.name, 'server_name': url_escape_path(server_name)},
         )
 
     async def delete_user(self, user, server_name=''):

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -288,7 +288,7 @@ class Proxy(LoggingConfigurable):
         await self.add_route(
             spawner.proxy_spec,
             spawner.server.host,
-            {'user': user.name, 'server_name': url_escape_path(server_name)},
+            {'user': user.name, 'server_name': server_name},
         )
 
     async def delete_user(self, user, server_name=''):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -43,6 +43,7 @@ from .utils import (
     exponential_backoff,
     maybe_future,
     random_port,
+    url_escape_path,
     url_path_join,
 )
 
@@ -871,7 +872,7 @@ class Spawner(LoggingConfigurable):
             env['JUPYTERHUB_COOKIE_OPTIONS'] = json.dumps(self.cookie_options)
         env['JUPYTERHUB_HOST'] = self.hub.public_host
         env['JUPYTERHUB_OAUTH_CALLBACK_URL'] = url_path_join(
-            self.user.url, self.name, 'oauth_callback'
+            self.user.url, url_escape_path(self.name), 'oauth_callback'
         )
 
         env['JUPYTERHUB_OAUTH_SCOPES'] = json.dumps(self.oauth_scopes)

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -144,7 +144,7 @@ async def test_create_named_server(
                     'name': name,
                     'started': TIMESTAMP,
                     'last_activity': TIMESTAMP,
-                    'url': url_path_join(user.url, name, '/'),
+                    'url': url_path_join(user.url, escapedname, '/'),
                     'pending': None,
                     'ready': True,
                     'progress_url': 'PREFIX/hub/api/users/{}/servers/{}/progress'.format(

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -175,7 +175,7 @@ async def test_create_invalid_named_server(app, named_servers):
         r.raise_for_status()
     assert exc.value.response.json() == {
         'status': 400,
-        'message': 'Invalid server_name: a$/b',
+        'message': "Invalid server_name (may not contain '/'): a$/b",
     }
 
 

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -91,6 +91,7 @@ async def test_default_server(app, named_servers):
         ('trevor', 'trevor', False),
         ('$p~c|a! ch@rs', '%24p~c%7Ca%21%20ch@rs', False),
         ('$p~c|a! ch@rs', '%24p~c%7Ca%21%20ch@rs', True),
+        ('hash#?question', 'hash%23%3Fquestion', True),
     ],
 )
 async def test_create_named_server(
@@ -111,7 +112,7 @@ async def test_create_named_server(
     assert r.status_code == 201
     assert r.text == ''
 
-    url = url_path_join(public_url(app, user), servername, 'env')
+    url = url_path_join(public_url(app, user), request_servername, 'env')
     expected_url = url_path_join(public_url(app, user), escapedname, 'env')
     r = await async_requests.get(url, cookies=cookies)
     r.raise_for_status()

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -2,7 +2,7 @@
 import asyncio
 import json
 from unittest import mock
-from urllib.parse import urlencode, urlparse
+from urllib.parse import unquote, urlencode, urlparse
 
 import pytest
 from tornado.httputil import url_concat
@@ -83,25 +83,35 @@ async def test_default_server(app, named_servers):
     )
 
 
-async def test_create_named_server(app, named_servers):
+@pytest.mark.parametrize(
+    'servername,escapedname',
+    [
+        ('trevor', 'trevor'),
+        ('$p~c|a! ch@rs', '%24p~c%7Ca%21%20ch@rs'),
+    ],
+)
+async def test_create_named_server(app, named_servers, servername, escapedname):
     username = 'walnut'
     user = add_user(app.db, app, name=username)
     # assert user.allow_named_servers == True
     cookies = await app.login_user(username)
-    servername = 'trevor'
     r = await api_request(app, 'users', username, 'servers', servername, method='post')
     r.raise_for_status()
     assert r.status_code == 201
     assert r.text == ''
 
     url = url_path_join(public_url(app, user), servername, 'env')
+    expected_url = url_path_join(public_url(app, user), escapedname, 'env')
     r = await async_requests.get(url, cookies=cookies)
     r.raise_for_status()
-    assert r.url == url
+    # requests doesn't fully encode the servername: "$p~c%7Ca!%20ch@rs".
+    # Since this is the internal requests representation and not the JupyterHub
+    # representation it just needs to be equivalent.
+    assert unquote(r.url) == unquote(expected_url)
     env = r.json()
     prefix = env.get('JUPYTERHUB_SERVICE_PREFIX')
     assert prefix == user.spawners[servername].server.base_url
-    assert prefix.endswith(f'/user/{username}/{servername}/')
+    assert prefix.endswith(f'/user/{username}/{escapedname}/')
 
     r = await api_request(app, 'users', username)
     r.raise_for_status()
@@ -121,7 +131,7 @@ async def test_create_named_server(app, named_servers):
                     'pending': None,
                     'ready': True,
                     'progress_url': 'PREFIX/hub/api/users/{}/servers/{}/progress'.format(
-                        username, servername
+                        username, escapedname
                     ),
                     'state': {'pid': 0},
                     'user_options': {},

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -89,7 +89,6 @@ async def test_default_server(app, named_servers):
         ('trevor', 'trevor', False),
         ('$p~c|a! ch@rs', '%24p~c%7Ca%21%20ch@rs', False),
         ('$p~c|a! ch@rs', '%24p~c%7Ca%21%20ch@rs', True),
-        ('must/be/escaped', 'must%2Fbe%2Fescaped', True),
     ],
 )
 async def test_create_named_server(

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -687,7 +687,6 @@ class User:
                 client_id,
                 api_token,
                 url_path_join(self.url, url_escape_path(server_name), 'oauth_callback'),
-                # url_path_join(self.url, server_name, 'oauth_callback'),
                 allowed_roles=allowed_roles,
                 description="Server at %s"
                 % (url_path_join(self.base_url, server_name) + '/'),

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -19,6 +19,7 @@ from binascii import b2a_hex
 from datetime import datetime, timezone
 from hmac import compare_digest
 from operator import itemgetter
+from urllib.parse import quote
 
 from async_generator import aclosing
 from sqlalchemy.exc import SQLAlchemyError
@@ -369,6 +370,11 @@ def compare_token(compare, token):
     if compare_digest(compare, hashed):
         return True
     return False
+
+
+def url_escape_path(value):
+    """Escape a value to be used in URLs, cookies, etc."""
+    return quote(value, safe='@~')
 
 
 def url_path_join(*pieces):


### PR DESCRIPTION
This escapes the server name when used in paths, but keeps the original server name in the database.

Closes https://github.com/jupyterhub/jupyterhub/issues/3144

An alternative to this implementation is to require that server names are url-safe and error if they're not, i.e. the client UI would be responsible for converting the name submitted by a server to it's URL safe form before POSTing it to JupyterHub. However this leads to more complications since if the client encodes the name before submission (e.g. in javascript), then it'll be encoded a second time when it's sent in the URL request, and the JupyterHub database will always store an encoded name instead of the original.

- [x] This works in manual testing, ~but needs an automated test~ I've added some tests, though I couldn't work out how to trigger the `'/' in server_name` error in a test. I can trigger it in the browser, but if I add to the existing test it's accepted- is there a Mock getting in the way somewhere?