### PR TITLE
Force add existing certificates

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1702,7 +1702,9 @@ class JupyterHub(Application):
             for authority, files in self.internal_ssl_authorities.items():
                 if files:
                     self.log.info("Adding CA for %s", authority)
-                    certipy.store.add_record(authority, is_ca=True, files=files, overwrite=True)
+                    certipy.store.add_record(
+                        authority, is_ca=True, files=files, overwrite=True
+                    )
 
             self.internal_trust_bundles = certipy.trust_from_graph(
                 self.internal_ssl_components_trust

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1702,7 +1702,7 @@ class JupyterHub(Application):
             for authority, files in self.internal_ssl_authorities.items():
                 if files:
                     self.log.info("Adding CA for %s", authority)
-                    certipy.store.add_record(authority, is_ca=True, files=files)
+                    certipy.store.add_record(authority, is_ca=True, files=files, overwrite=True)
 
             self.internal_trust_bundles = certipy.trust_from_graph(
                 self.internal_ssl_components_trust


### PR DESCRIPTION
When persisting certificates in e.g. a PV hub restarts throw a `certipy.certipy.CertExistsError` complaining the certificate exists already, instead of overwriting it and using the "old" one.

I think related issues have been around for a while (see e.g. https://discourse.jupyter.org/t/unable-to-combine-recreate-internal-ssl-false-with-external-ssl-authorities/10897)

