### PR TITLE
use equality to filter token prefixes

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -528,9 +528,7 @@ class Hashed(Expiring):
         prefix = token[: cls.prefix_length]
         # since we can't filter on hashed values, filter on prefix
         # so we aren't comparing with all tokens
-        prefix_match = db.query(cls).filter(
-            bindparam('prefix', prefix).startswith(cls.prefix)
-        )
+        prefix_match = db.query(cls).filter_by(prefix=prefix)
         prefix_match = prefix_match.filter(
             or_(cls.expires_at == None, cls.expires_at >= cls.now())
         )


### PR DESCRIPTION
otherwise, index isn't used (closes #3070)

note: this means changing the token prefix size requires revoking all tokens, where before only _increasing_ the token prefix size required doing that.

I ran a test with `sqlite:///:memory:` showing clear performance consequences:

![visualization](https://user-images.githubusercontent.com/151929/170279598-4dd8a0f3-0d44-4c7c-84f4-af0d76637439.png)

where using the index, lookup stays around 150µs, it rapidly increased beyond 1ms per token lookup with the current scheme if you have at least ~10k tokens.