### PR TITLE
Fixes #3913 db uri parsing issue

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1798,7 +1798,7 @@ class JupyterHub(Application):
             self.log.error("Failed to connect to db: %s", db_log_url)
             self.log.debug("Database error was:", exc_info=True)
             if self.db_url.startswith('sqlite:///'):
-                self._check_db_path(self.db_url.split(':///', 1)[1])
+                self._check_db_path(self.db_url.split('://', 1)[1])
             self.log.critical(
                 '\n'.join(
                     [


### PR DESCRIPTION
Fixes jupyterhub/jupyterhub#3913

This change updates the parsing of sqlite URIs so that the root does not get parsed out.