### PR TITLE
FreeBSD, missing -n for pw useradd

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -832,7 +832,7 @@ class LocalAuthenticator(Authenticator):
             raise ValueError("I don't know how to create users on OS X")
         elif which('pw'):
             # Probably BSD
-            return ['pw', 'useradd', '-m']
+            return ['pw', 'useradd', '-m', '-n']
         else:
             # This appears to be the Linux non-interactive adduser command:
             return ['adduser', '-q', '--gecos', '""', '--disabled-password']


### PR DESCRIPTION
I was playing with jupyterhub for a workshop in a FreeBSD jail and noticed:

```
[I 2022-06-15 16:46:21.352 JupyterHub app:3156] JupyterHub is now running at http://:8000                                                     
[I 2022-06-15 16:46:58.270 JupyterHub roles:366] Adding role user for User: foo                                                                                                                                                                                                             
[I 2022-06-15 16:46:58.282 JupyterHub auth:945] Creating user: pw useradd -m foo                                                              
[E 2022-06-15 16:46:58.288 JupyterHub users:223] Failed to create user: foo                                                                   
    Traceback (most recent call last):                                                                                                        
      File "/usr/local/www/jupyterhub/jup/lib/python3.8/site-packages/jupyterhub/apihandlers/users.py", line 221, in post                                                                                                                                                                   
        await maybe_future(self.authenticator.add_user(user))                                                                                                                                                                                                                               
      File "/usr/local/www/jupyterhub/jup/lib/python3.8/site-packages/jupyterhub/auth.py", line 884, in add_user                              
        await maybe_future(self.add_system_user(user))                                                                                                                                                                                                                                      
      File "/usr/local/www/jupyterhub/jup/lib/python3.8/site-packages/jupyterhub/auth.py", line 950, in add_system_user                                                                                                                                                                     
        raise RuntimeError(f"Failed to create system user {name}: {err}")                                                                                                                                                                                                                   
    RuntimeError: Failed to create system user foo: pw: user name or id required                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
[W 2022-06-15 16:46:58.316 JupyterHub web:1787] 400 POST /hub/api/users (10.209.1.43): Failed to create user foo: Failed to create system user foo: pw: user name or id required
```

this is because a -n is missing when pw useradd is executed                                                                                                      