### PR TITLE
validate proxy.extra_routes

### DIFF
--- a/examples/server-api/jupyterhub_config.py
+++ b/examples/server-api/jupyterhub_config.py
@@ -2,6 +2,8 @@
 # 1. start/stop servers, and
 # 2. access the server API
 
+c = get_config()  # noqa
+
 c.JupyterHub.load_roles = [
     {
         "name": "launcher",

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -711,11 +711,14 @@ class JupyterHub(Application):
         """,
     ).tag(config=True)
 
-    def _subdomain_host_changed(self, name, old, new):
+    @validate("subdomain_host")
+    def _validate_subdomain_host(self, proposal):
+        new = proposal.value
         if new and '://' not in new:
             # host should include '://'
             # if not specified, assume https: You have to be really explicit about HTTP!
-            self.subdomain_host = 'https://' + new
+            new = 'https://' + new
+        return new
 
     domain = Unicode(help="domain name, e.g. 'example.com' (excludes protocol, port)")
 


### PR DESCRIPTION
- add trailing slash if missing, and warn (as we do with url prefixes elsewhere), since this one is unambiguous
- raise if leading slash is wrong (must not be present with host routing, must be present otherwise). Raises rather than fixing automatically like trailing slash because it is ambiguous whether the intention is host-based routing or prefix routing.
- Lightweight check for probably-urls (don't need to be strict here, just catch likely errors, such as omitting host/protocol entirely)

Came up in https://discourse.jupyter.org/t/oauth-flow-in-jupyterhub-on-z2jh/14779/8