### PR TITLE
pin nbclassic in dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,11 @@ cryptography
 html5lib  # needed for beautifulsoup
 jupyterlab >=3
 mock
-nbclassic  # ensures /tree/ handler is present as assumed by tests
+# nbclassic provides the '/tree/' handler, which we use in tests
+# it is a transitive dependency via jupyterlab,
+# but depend on it directly
+# 0.4 introduces some installation/loading problems (check again after 0.4.3)
+nbclassic<0.4
 pre-commit
 pytest>=3.3
 pytest-asyncio; python_version < "3.7"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ cryptography
 html5lib  # needed for beautifulsoup
 jupyterlab >=3
 mock
+nbclassic
 pre-commit
 pytest>=3.3
 pytest-asyncio; python_version < "3.7"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ cryptography
 html5lib  # needed for beautifulsoup
 jupyterlab >=3
 mock
-nbclassic
+nbclassic  # ensures /tree/ handler is present as assumed by tests
 pre-commit
 pytest>=3.3
 pytest-asyncio; python_version < "3.7"


### PR DESCRIPTION
ensures `/tree/` handler is present.

There are no longer any authenticated non-API URLs served by both `notebook` and bare `jupyter-server + jupyterlab`. This is causing 404s in tests when no handler is registered for `/tree/`