### PR TITLE
Fix disabling of individual page template announcements

### DIFF
--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_home is defined %}
+{% if announcement_home is string %}
   {% set announcement = announcement_home %}
 {% endif %}
 

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_home %}
+{% if announcement_home is defined %}
   {% set announcement = announcement_home %}
 {% endif %}
 

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_login %}
+{% if announcement_login is defined %}
   {% set announcement = announcement_login %}
 {% endif %}
 

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_login is defined %}
+{% if announcement_login is string %}
   {% set announcement = announcement_login %}
 {% endif %}
 

--- a/share/jupyterhub/templates/logout.html
+++ b/share/jupyterhub/templates/logout.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_logout %}
+{% if announcement_logout is defined %}
   {% set announcement = announcement_logout %}
 {% endif %}
 

--- a/share/jupyterhub/templates/logout.html
+++ b/share/jupyterhub/templates/logout.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_logout is defined %}
+{% if announcement_logout is string %}
   {% set announcement = announcement_logout %}
 {% endif %}
 

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_spawn %}
+{% if announcement_spawn is defined %}
   {% set announcement = announcement_spawn %}
 {% endif %}
 

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% if announcement_spawn is defined %}
+{% if announcement_spawn is string %}
   {% set announcement = announcement_spawn %}
 {% endif %}
 


### PR DESCRIPTION
Closes #3965.

This could be written as `is not none` as well, but I figured there is no default value for `announcement_<page name>` in template_vars, this made sense as well, allowing people to declare a None value as well as a blank string, and not just a blank string, to disable an individual announcement.

## Final behavior

Setting template variables like:

```python
c.JupyterHub.template_vars = {
    "announcement": "something",
    "announcement_spawn": "something else",
    "announcement_login": "",
    # Setting a specific page's announcement variable to None doesn't do anything, but
    # it can be useful if merging template_vars dictionaries to unset a value.
    "announcement_home": None,
}
```

will cause the announcement `something` show up on all pages expect on the spawn page where it sais `something else` and on the login page where no announcement it shown.

## Related unchanged logic

https://github.com/jupyterhub/jupyterhub/blob/ab776e3989bffe9e1a9d0744c96c5f8e8d876988/share/jupyterhub/templates/page.html#L168-L174