### PR TITLE
nbclassic extension name has been renamed

### DIFF
--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -749,10 +749,12 @@ class SingleUserNotebookAppMixin(Configurable):
         if 'jinja2_env' in settings:
             # default jinja env (should we do this on jupyter-server, or only notebook?)
             jinja_envs.append(settings['jinja2_env'])
-        if 'notebook_jinja2_env' in settings:
-            # when running with jupyter-server, classic notebook (nbclassic server extension)
-            # gets its own jinja env, which needs the same patch
-            jinja_envs.append(settings['notebook_jinja2_env'])
+        for ext_name in ("notebook", "nbclassic"):
+            env_name = f"{ext_name}_jinja2_env"
+            if env_name in settings:
+                # when running with jupyter-server, classic notebook (nbclassic server extension or notebook v7)
+                # gets its own jinja env, which needs the same patch
+                jinja_envs.append(settings['notebook_jinja2_env'])
 
         # patch jinja env loading to get modified template, only for base page.html
         def get_page(name):


### PR DESCRIPTION
ref: https://github.com/jupyter/nbclassic/pull/96/files#diff-baf53b9a1d8f038c7de824e4928d10356271b26bacf19ffccba98454e685438eL109-R110

our patches to the jinja env need updating to find the new env. Until then, nbclassic 0.4.x will not get the template patches (the 'control panel' link)