### PR TITLE
Avoid deprecated 'IOLoop.current' method

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3292,16 +3292,19 @@ class JupyterHub(Application):
     def launch_instance(cls, argv=None):
         self = cls.instance()
         self._init_asyncio_patch()
-        loop = IOLoop.current()
-        task = asyncio.ensure_future(self.launch_instance_async(argv))
+        loop = IOLoop(make_current=False)
+
+        try:
+            loop.run_sync(self.launch_instance_async, argv)
+        except Exception:
+            loop.close()
+            raise
+
         try:
             loop.start()
         except KeyboardInterrupt:
             print("\nInterrupted")
         finally:
-            if task.done():
-                # re-raise exceptions in launch_instance_async
-                task.result()
             loop.stop()
             loop.close()
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -132,16 +132,13 @@ def event_loop(request):
 
 
 @fixture(scope='module')
-def io_loop(event_loop, request):
+async def io_loop(event_loop, request):
     """Same as pytest-tornado.io_loop, but re-scoped to module-level"""
-    ioloop.IOLoop.configure(AsyncIOMainLoop)
     io_loop = AsyncIOMainLoop()
-    io_loop.make_current()
     assert asyncio.get_event_loop() is event_loop
     assert io_loop.asyncio_loop is event_loop
 
     def _close():
-        io_loop.clear_current()
         io_loop.close(all_fds=True)
 
     request.addfinalizer(_close)


### PR DESCRIPTION
Deprecated in tornado 6.2, matching asyncio's deprecation of get_current_loop (i.e. there is no longer any such thing as a 'current' loop that isn't running). Instead, only access running loop from inside coroutines.