### PR TITLE
Require Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,17 +76,18 @@ jobs:
             oldest_dependencies: oldest_dependencies
             legacy_notebook: legacy_notebook
           - python: "3.8"
-            subdomain: subdomain
+            legacy_notebook: legacy_notebook
           - python: "3.9"
             db: mysql
           - python: "3.10"
-            ssl: ssl
-          - python: "3.10"
             db: postgres
           - python: "3.10"
-            legacy_notebook: legacy_notebook
+            subdomain: subdomain
+          - python: "3.10"
+            ssl: ssl
           # can't test 3.11.0-beta.4 until a greenlet release
           # greenlet is a dependency of sqlalchemy on linux
+          # see https://github.com/gevent/gevent/issues/1867
           # - python: "3.11.0-beta.4"
           - python: "3.10"
             main_dependencies: main_dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,20 +72,20 @@ jobs:
         #       GitHub UI when the workflow run, we avoid using true/false as
         #       values by instead duplicating the name to signal true.
         include:
-          - python: "3.6"
+          - python: "3.7"
             oldest_dependencies: oldest_dependencies
-          - python: "3.6"
             legacy_notebook: legacy_notebook
+          - python: "3.8"
             subdomain: subdomain
-          - python: "3.7"
-            db: mysql
-          - python: "3.7"
-            ssl: ssl
-          - python: "3.8"
-            db: postgres
-          - python: "3.8"
-            legacy_notebook: legacy_notebook
           - python: "3.9"
+            db: mysql
+          - python: "3.10"
+            ssl: ssl
+          - python: "3.10"
+            db: postgres
+          - python: "3.10"
+            legacy_notebook: legacy_notebook
+          - python: "3.11.0-beta.4"
             main_dependencies: main_dependencies
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,9 @@ jobs:
         #   Tests everything when JupyterHub works against a dedicated mysql or
         #   postgresql server.
         #
-        # nbclassic:
+        # legacy_notebook:
         #   Tests everything when the user instances are started with
-        #   notebook instead of jupyter_server.
+        #   the legacy notebook server instead of jupyter_server.
         #
         # ssl:
         #   Tests everything using internal SSL connections instead of
@@ -74,8 +74,8 @@ jobs:
         include:
           - python: "3.6"
             oldest_dependencies: oldest_dependencies
-            nbclassic: nbclassic
           - python: "3.6"
+            legacy_notebook: legacy_notebook
             subdomain: subdomain
           - python: "3.7"
             db: mysql
@@ -84,7 +84,7 @@ jobs:
           - python: "3.8"
             db: postgres
           - python: "3.8"
-            nbclassic: nbclassic
+            legacy_notebook: legacy_notebook
           - python: "3.9"
             main_dependencies: main_dependencies
 
@@ -148,9 +148,9 @@ jobs:
           if [ "${{ matrix.main_dependencies }}" != "" ]; then
               pip install git+https://github.com/ipython/traitlets#egg=traitlets --force
           fi
-          if [ "${{ matrix.nbclassic }}" != "" ]; then
+          if [ "${{ matrix.legacy_notebook }}" != "" ]; then
               pip uninstall jupyter_server --yes
-              pip install notebook
+              pip install 'notebook<7'
           fi
           if [ "${{ matrix.db }}" == "mysql" ]; then
               pip install mysql-connector-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,10 @@ jobs:
             db: postgres
           - python: "3.10"
             legacy_notebook: legacy_notebook
-          - python: "3.11.0-beta.4"
+          # can't test 3.11.0-beta.4 until a greenlet release
+          # greenlet is a dependency of sqlalchemy on linux
+          # - python: "3.11.0-beta.4"
+          - python: "3.10"
             main_dependencies: main_dependencies
 
     steps:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,8 +16,7 @@ mock
 nbclassic<0.4
 pre-commit
 pytest>=3.3
-pytest-asyncio; python_version < "3.7"
-pytest-asyncio>=0.17; python_version >= "3.7"
+pytest-asyncio>=0.17
 pytest-cov
 requests-mock
 tbump

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -11,6 +11,7 @@ import re
 import secrets
 import signal
 import socket
+import ssl
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -3047,7 +3048,7 @@ class JupyterHub(Application):
             self.internal_ssl_key,
             self.internal_ssl_cert,
             cafile=self.internal_ssl_ca,
-            check_hostname=False,
+            purpose=ssl.Purpose.CLIENT_AUTH,
         )
 
         # start the webserver

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -23,15 +23,6 @@ from urllib.parse import unquote, urlparse, urlunparse
 if sys.version_info[:2] < (3, 3):
     raise ValueError("Python < 3.3 not supported: %s" % sys.version)
 
-# For compatibility with python versions 3.6 or earlier.
-# asyncio.Task.all_tasks() is fully moved to asyncio.all_tasks() starting with 3.9. Also applies to current_task.
-try:
-    asyncio_all_tasks = asyncio.all_tasks
-    asyncio_current_task = asyncio.current_task
-except AttributeError as e:
-    asyncio_all_tasks = asyncio.Task.all_tasks
-    asyncio_current_task = asyncio.Task.current_task
-
 import tornado.httpserver
 import tornado.options
 from dateutil.parser import parse as parse_date
@@ -3248,7 +3239,7 @@ class JupyterHub(Application):
 
         await self.cleanup()
 
-        tasks = [t for t in asyncio_all_tasks() if t is not asyncio_current_task()]
+        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
 
         if tasks:
             self.log.debug("Cancelling pending tasks")
@@ -3261,7 +3252,7 @@ class JupyterHub(Application):
             except StopAsyncIteration as e:
                 self.log.error("Caught StopAsyncIteration Exception", exc_info=True)
 
-            tasks = [t for t in asyncio_all_tasks()]
+            tasks = [t for t in asyncio.all_tasks()]
             for t in tasks:
                 self.log.debug("Task status: %s", t)
         asyncio.get_event_loop().stop()

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -14,6 +14,7 @@ import logging
 import os
 import random
 import secrets
+import ssl
 import sys
 import warnings
 from datetime import timezone

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -54,28 +54,6 @@ from .utils import add_user
 _db = None
 
 
-def _pytest_collection_modifyitems(items):
-    """This function is automatically run by pytest passing all collected test
-    functions.
-
-    We use it to add asyncio marker to all async tests and assert we don't use
-    test functions that are async generators which wouldn't make sense.
-
-    It is no longer required with pytest-asyncio >= 0.17
-    """
-    for item in items:
-        if inspect.iscoroutinefunction(item.obj):
-            item.add_marker('asyncio')
-        assert not inspect.isasyncgenfunction(item.obj)
-
-
-if sys.version_info < (3, 7):
-    # apply pytest-asyncio's 'auto' mode on Python 3.6.
-    # 'auto' mode is new in pytest-asyncio 0.17,
-    # which requires Python 3.7.
-    pytest_collection_modifyitems = _pytest_collection_modifyitems
-
-
 @fixture(scope='module')
 def ssl_tmpdir(tmpdir_factory):
     return tmpdir_factory.mktemp('ssl')

--- a/jupyterhub/tests/mockservice.py
+++ b/jupyterhub/tests/mockservice.py
@@ -15,6 +15,7 @@ Handlers and their purpose include:
 import json
 import os
 import pprint
+import ssl
 import sys
 from urllib.parse import urlparse
 
@@ -111,7 +112,9 @@ def main():
         ca = os.environ.get('JUPYTERHUB_SSL_CLIENT_CA') or ''
 
         if key and cert and ca:
-            ssl_context = make_ssl_context(key, cert, cafile=ca, check_hostname=False)
+            ssl_context = make_ssl_context(
+                key, cert, cafile=ca, purpose=ssl.Purpose.CLIENT_AUTH
+            )
 
         server = httpserver.HTTPServer(app, ssl_options=ssl_context)
         server.listen(url.port, url.hostname)

--- a/jupyterhub/tests/mocksu.py
+++ b/jupyterhub/tests/mocksu.py
@@ -47,7 +47,11 @@ def main():
     ca = os.environ.get('JUPYTERHUB_SSL_CLIENT_CA') or ''
 
     if key and cert and ca:
-        ssl_context = make_ssl_context(key, cert, cafile=ca, check_hostname=False)
+        import ssl
+
+        ssl_context = make_ssl_context(
+            key, cert, cafile=ca, purpose=ssl.Purpose.CLIENT_AUTH
+        )
         assert url.scheme == "https"
 
     server = httpserver.HTTPServer(app, ssl_options=ssl_context)

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -1,7 +1,7 @@
 """Tests for jupyterhub.singleuser"""
 import os
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from subprocess import CalledProcessError, check_output
 from unittest import mock
 from urllib.parse import urlencode, urlparse
@@ -15,12 +15,6 @@ from .. import orm
 from ..utils import url_path_join
 from .mocking import StubSingleUserSpawner, public_url
 from .utils import AsyncSession, async_requests, get_page
-
-
-@contextmanager
-def nullcontext():
-    """Python 3.7+ contextlib.nullcontext, backport for 3.6"""
-    yield
 
 
 @pytest.mark.parametrize(

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -117,7 +117,7 @@ def make_ssl_context(
         purpose = ssl.Purpose.SERVER_AUTH if verify else ssl.Purpose.CLIENT_AUTH
         warnings.warn(
             f"make_ssl_context(verify={verify}) is deprecated in jupyterhub 2.4."
-            f" Use make_ssl_context(purpose={purpose}).",
+            f" Use make_ssl_context(purpose={purpose!s}).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -125,7 +125,7 @@ def make_ssl_context(
         purpose = ssl.Purpose.SERVER_AUTH if check_hostname else ssl.Purpose.CLIENT_AUTH
         warnings.warn(
             f"make_ssl_context(check_hostname={check_hostname}) is deprecated in jupyterhub 2.4."
-            f" Use make_ssl_context(purpose={purpose}).",
+            f" Use make_ssl_context(purpose={purpose!s}).",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -27,14 +27,26 @@ from tornado import gen, ioloop, web
 from tornado.httpclient import AsyncHTTPClient, HTTPError
 from tornado.log import app_log
 
-# For compatibility with python versions 3.6 or earlier.
-# asyncio.Task.all_tasks() is fully moved to asyncio.all_tasks() starting with 3.9. Also applies to current_task.
-try:
-    asyncio_all_tasks = asyncio.all_tasks
-    asyncio_current_task = asyncio.current_task
-except AttributeError as e:
-    asyncio_all_tasks = asyncio.Task.all_tasks
-    asyncio_current_task = asyncio.Task.current_task
+
+# Deprecated aliases: no longer needed now that we require 3.7
+def asyncio_all_tasks(loop=None):
+    warnings.warn(
+        "jupyterhub.utils.asyncio_all_tasks is deprecated in JupyterHub 2.4."
+        " Use asyncio.all_tasks().",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return asyncio.all_tasks(loop=loop)
+
+
+def asyncio_current_task(loop=None):
+    warnings.warn(
+        "jupyterhub.utils.asyncio_current_task is deprecated in JupyterHub 2.4."
+        " Use asyncio.current_task().",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return asyncio.current_task(loop=loop)
 
 
 def random_port():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ skip-string-normalization = true
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
 target_version = [
-    "py36",
     "py37",
     "py38",
     "py39",

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup_args = dict(
     license="BSD",
     platforms="Linux, Mac OS X",
     keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={
         'jupyterhub.authenticators': [
             'default = jupyterhub.auth:PAMAuthenticator',

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,6 @@ from setuptools.command.bdist_egg import bdist_egg
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
 
-v = sys.version_info
-if v[:2] < (3, 6):
-    error = "ERROR: JupyterHub requires Python version 3.6 or above."
-    print(error, file=sys.stderr)
-    sys.exit(1)
-
 shell = False
 if os.name in ('nt', 'dos'):
     shell = True


### PR DESCRIPTION
- Bumps CI Python versions to include 3.10 and 3.11 (closes #3972)
- Removes some special handling for 3.6
