### PR TITLE
Avoid IOLoop.current in singleuser mixins

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3228,11 +3228,7 @@ class JupyterHub(Application):
         self._atexit_ran = True
         self._init_asyncio_patch()
         # run the cleanup step (in a new loop, because the interrupted one is unclean)
-        asyncio.set_event_loop(asyncio.new_event_loop())
-        IOLoop.clear_current()
-        loop = IOLoop()
-        loop.make_current()
-        loop.run_sync(self.cleanup)
+        asyncio.run(self.cleanup())
 
     async def shutdown_cancel_tasks(self, sig=None):
         """Cancel all other tasks of the event loop and initiate cleanup"""

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -656,14 +656,13 @@ class SingleUserNotebookAppMixin(Configurable):
                 # running, use IOLoop.current
                 self.io_loop = ioloop.IOLoop.current()
 
-        for cls in self.__class__.mro():
-            if cls.__module__.startswith("notebook."):
-                # notebookapp unconditionally calls `self.io_loop = IOLoop.current()` in start.
-                # To avoid problems, we must make sure our event loop is current.
-                # this is not required for jupyter-server.
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    self.io_loop.make_current()
+        # Make our event loop the 'current' event loop.
+        # FIXME: this shouldn't be necessary, but it is.
+        # notebookapp (<=6.4, at least), and
+        # jupyter-server (<=1.17.0, at least) still need the 'current' event loop to be defined
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.io_loop.make_current()
 
     def init_httpserver(self):
         self.io_loop.run_sync(super().init_httpserver)

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -636,14 +636,43 @@ class SingleUserNotebookAppMixin(Configurable):
         if default_url:
             self.config[self.__class__.__name__].default_url = default_url
         self._log_app_versions()
+        # call our init_ioloop very early
+        # jupyter-server calls it too late, notebook doesn't define it yet
+        # only called in jupyter-server >= 1.9
+        self.init_ioloop()
         super().initialize(argv)
         self.patch_templates()
+
+    def init_ioloop(self):
+        """init_ioloop added in jupyter-server 1.9"""
+        # avoid deprecated access to current event loop
+        if getattr(self, "io_loop", None) is None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                # not running, make our own loop
+                self.io_loop = ioloop.IOLoop(make_current=False)
+            else:
+                # running, use IOLoop.current
+                self.io_loop = ioloop.IOLoop.current()
+
+        for cls in self.__class__.mro():
+            if cls.__module__.startswith("notebook."):
+                # notebookapp unconditionally calls `self.io_loop = IOLoop.current()` in start.
+                # To avoid problems, we must make sure our event loop is current.
+                # this is not required for jupyter-server.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    self.io_loop.make_current()
+
+    def init_httpserver(self):
+        self.io_loop.run_sync(super().init_httpserver)
 
     def start(self):
         self.log.info("Starting jupyterhub-singleuser server version %s", __version__)
         # start by hitting Hub to check version
-        ioloop.IOLoop.current().run_sync(self.check_hub_version)
-        ioloop.IOLoop.current().add_callback(self.keep_activity_updated)
+        self.io_loop.run_sync(self.check_hub_version)
+        self.io_loop.add_callback(self.keep_activity_updated)
         super().start()
 
     def init_hub_auth(self):

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -411,14 +411,10 @@ class StubSingleUserSpawner(MockSpawner):
         print(args, env)
 
         def _run():
-            asyncio.set_event_loop(asyncio.new_event_loop())
-            io_loop = IOLoop()
-            io_loop.make_current()
-            io_loop.add_callback(lambda: evt.set())
-
             with mock.patch.dict(os.environ, env):
                 app = self._app = MockSingleUserServer()
                 app.initialize(args)
+                app.io_loop.add_callback(lambda: evt.set())
                 assert app.hub_auth.oauth_client_id
                 assert app.hub_auth.api_token
                 assert app.hub_auth.oauth_scopes


### PR DESCRIPTION
- define our own init_ioloop (added in jupyter-server, but not available in notebook)
- call it ASAP  (see https://github.com/jupyter-server/jupyter_server/pull/934)
- put init_httpserver in IOLoop.run_sync because instantiating a server accesses the current loop
- run cleanup via asyncio.run