### PR TITLE
backport nbclassic fixes to 2.x

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,10 @@ cryptography
 html5lib  # needed for beautifulsoup
 jupyterlab >=3
 mock
+# nbclassic provides the '/tree/' handler, which we use in tests
+# it is a transitive dependency via jupyterlab,
+# but depend on it directly
+nbclassic
 pre-commit
 pytest>=3.3
 pytest-asyncio; python_version < "3.7"

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -755,10 +755,12 @@ class SingleUserNotebookAppMixin(Configurable):
         if 'jinja2_env' in settings:
             # default jinja env (should we do this on jupyter-server, or only notebook?)
             jinja_envs.append(settings['jinja2_env'])
-        if 'notebook_jinja2_env' in settings:
-            # when running with jupyter-server, classic notebook (nbclassic server extension)
-            # gets its own jinja env, which needs the same patch
-            jinja_envs.append(settings['notebook_jinja2_env'])
+        for ext_name in ("notebook", "nbclassic"):
+            env_name = f"{ext_name}_jinja2_env"
+            if env_name in settings:
+                # when running with jupyter-server, classic notebook (nbclassic server extension or notebook v7)
+                # gets its own jinja env, which needs the same patch
+                jinja_envs.append(settings['notebook_jinja2_env'])
 
         # patch jinja env loading to get modified template, only for base page.html
         def get_page(name):

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -760,7 +760,7 @@ class SingleUserNotebookAppMixin(Configurable):
             if env_name in settings:
                 # when running with jupyter-server, classic notebook (nbclassic server extension or notebook v7)
                 # gets its own jinja env, which needs the same patch
-                jinja_envs.append(settings['notebook_jinja2_env'])
+                jinja_envs.append(settings[env_name])
 
         # patch jinja env loading to get modified template, only for base page.html
         def get_page(name):

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -199,10 +199,22 @@ def test_singleuser_app_class(JUPYTERHUB_SINGLEUSER_APP):
         import jupyter_server  # noqa
     except ImportError:
         have_server = False
-        expect_error = "jupyter_server" in JUPYTERHUB_SINGLEUSER_APP
     else:
         have_server = True
-        expect_error = False
+    try:
+        import notebook.notebookapp  # noqa
+    except ImportError:
+        have_notebook = False
+    else:
+        have_notebook = True
+
+    if JUPYTERHUB_SINGLEUSER_APP.startswith("notebook."):
+        expect_error = not have_notebook
+    elif JUPYTERHUB_SINGLEUSER_APP.startswith("jupyter_server."):
+        expect_error = not have_server
+    else:
+        # not specified, will try both
+        expect_error = not (have_server or have_notebook)
 
     if expect_error:
         ctx = pytest.raises(CalledProcessError)


### PR DESCRIPTION
backports nbclassic compatibility fixes and detection of the notebook app in a test

backports #3971 and #3977 which should get tests passing on 2.x again (#3984)