### PR TITLE
Show user last activity not server in dashboard

### DIFF
--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -258,7 +258,7 @@ const ServerDashboard = (props) => {
           )}
         </td>
         <td data-testid="user-row-last-activity">
-          {server.last_activity ? timeSince(server.last_activity) : "Never"}
+          {user.last_activity ? timeSince(server.last_activity) : "Never"}
         </td>
         <td data-testid="user-row-server-activity">
           {server.started ? (


### PR DESCRIPTION
As proposed on https://github.com/jupyterhub/jupyterhub/issues/3981

fixes #3981