### PR TITLE
admin: format user/server-info tables

### DIFF
--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -201,6 +201,25 @@ const ServerDashboard = (props) => {
   };
 
   const ServerRowTable = ({ data }) => {
+    const sortedData = Object.keys(data)
+      .sort()
+      .reduce(function (result, key) {
+        let value = data[key];
+        switch (key) {
+          case "last_activity":
+          case "created":
+          case "started":
+            // format timestamps
+            value = value ? timeSince(value) : value;
+            break;
+        }
+        if (Array.isArray(value)) {
+          // cast arrays (e.g. roles, groups) to string
+          value = value.sort().join(", ");
+        }
+        result[key] = value;
+        return result;
+      }, {});
     return (
       <ReactObjectTableViewer
         className="table-striped table-bordered"
@@ -214,7 +233,7 @@ const ServerDashboard = (props) => {
         valueStyle={{
           padding: "4px",
         }}
-        data={data}
+        data={sortedData}
       />
     );
   };
@@ -251,11 +270,7 @@ const ServerDashboard = (props) => {
         <td data-testid="user-row-admin">{user.admin ? "admin" : ""}</td>
 
         <td data-testid="user-row-server">
-          {server.name ? (
-            <p className="text-secondary">{server.name}</p>
-          ) : (
-            <p style={{ color: "lightgrey" }}>[MAIN]</p>
-          )}
+          <p className="text-secondary">{server.name}</p>
         </td>
         <td data-testid="user-row-last-activity">
           {server.last_activity ? timeSince(server.last_activity) : "Never"}


### PR DESCRIPTION
- sort keys for consistent presentation
- use text list for roles, groups, which aren't well rendered by the table-formatter (number index isn't helpful)
- render timestamps
- leave empty name for default server, instead of '[MAIN]' which isn't terminology used anywhere else, and probably confusing for the majority of users who don't use named servers

before:
<img width="1317" alt="Screen Shot 2022-08-02 at 12 26 48" src="https://user-images.githubusercontent.com/151929/182353562-d3c259a6-9177-4c7e-b19f-d30be59c018e.png">


after:

<img width="1342" alt="Screen Shot 2022-08-02 at 12 25 34" src="https://user-images.githubusercontent.com/151929/182353578-a5f91604-717d-4bf9-97e6-f7a0df358ac5.png">

