### PR TITLE
Integrate Pagination API into Admin JSX

### DIFF
--- a/jsx/src/App.jsx
+++ b/jsx/src/App.jsx
@@ -19,34 +19,6 @@ import "./style/root.css";
 const store = createStore(reducers, initialState);
 
 const App = () => {
-  // useEffect(() => {
-  //   let { limit, user_page, groups_page } = initialState;
-  //   let api = withAPI()().props;
-  //   api
-  //     .updateUsers(user_page * limit, limit)
-  //     .then((data) => {
-  //       console.log(data);
-  //       let { _pagination, items } = data;
-  //       store.dispatch({
-  //         type: "USER_PAGE",
-  //         value: { data: items, page: _pagination },
-  //       });
-  //     })
-  //     .catch((err) => console.log(err));
-
-  //   api
-  //     .updateGroups(groups_page * limit, limit)
-  //     .then((data) => {
-  //       console.log(data);
-  //       let { _pagination, items } = data;
-  //       store.dispatch({
-  //         type: "GROUPS_PAGE",
-  //         value: { data: items, page: _pagination },
-  //       });
-  //     })
-  //     .catch((err) => console.log(err));
-  // });
-
   return (
     <div className="resets">
       <Provider store={store}>

--- a/jsx/src/App.jsx
+++ b/jsx/src/App.jsx
@@ -4,7 +4,6 @@ import { Provider } from "react-redux";
 import { createStore } from "redux";
 import { compose } from "recompose";
 import { initialState, reducers } from "./Store";
-import { jhapiRequest } from "./util/jhapiUtil";
 import withAPI from "./util/withAPI";
 import { HashRouter, Switch, Route } from "react-router-dom";
 
@@ -25,16 +24,28 @@ const App = () => {
     let api = withAPI()().props;
     api
       .updateUsers(user_page * limit, limit)
-      .then((data) =>
-        store.dispatch({ type: "USER_PAGE", value: { data: data, page: 0 } })
-      )
+      .then((data) => {
+        console.log(data);
+        let { _pagination, items } = data,
+          { offset, limit } = _pagination;
+        store.dispatch({
+          type: "USER_PAGE",
+          value: { data: items, page: Math.floor(offset / limit) },
+        });
+      })
       .catch((err) => console.log(err));
 
     api
       .updateGroups(groups_page * limit, limit)
-      .then((data) =>
-        store.dispatch({ type: "GROUPS_PAGE", value: { data: data, page: 0 } })
-      )
+      .then((data) => {
+        console.log(data);
+        let { _pagination, items } = data,
+          { offset, limit } = _pagination;
+        store.dispatch({
+          type: "GROUPS_PAGE",
+          value: { data: items, page: Math.floor(offset / limit) },
+        });
+      })
       .catch((err) => console.log(err));
   });
 

--- a/jsx/src/App.jsx
+++ b/jsx/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { createStore } from "redux";
@@ -19,33 +19,33 @@ import "./style/root.css";
 const store = createStore(reducers, initialState);
 
 const App = () => {
-  useEffect(() => {
-    let { limit, user_page, groups_page } = initialState;
-    let api = withAPI()().props;
-    api
-      .updateUsers(user_page * limit, limit)
-      .then((data) => {
-        console.log(data);
-        let { _pagination, items } = data;
-        store.dispatch({
-          type: "USER_PAGE",
-          value: { data: items, page: _pagination },
-        });
-      })
-      .catch((err) => console.log(err));
+  // useEffect(() => {
+  //   let { limit, user_page, groups_page } = initialState;
+  //   let api = withAPI()().props;
+  //   api
+  //     .updateUsers(user_page * limit, limit)
+  //     .then((data) => {
+  //       console.log(data);
+  //       let { _pagination, items } = data;
+  //       store.dispatch({
+  //         type: "USER_PAGE",
+  //         value: { data: items, page: _pagination },
+  //       });
+  //     })
+  //     .catch((err) => console.log(err));
 
-    api
-      .updateGroups(groups_page * limit, limit)
-      .then((data) => {
-        console.log(data);
-        let { _pagination, items } = data;
-        store.dispatch({
-          type: "GROUPS_PAGE",
-          value: { data: items, page: _pagination },
-        });
-      })
-      .catch((err) => console.log(err));
-  });
+  //   api
+  //     .updateGroups(groups_page * limit, limit)
+  //     .then((data) => {
+  //       console.log(data);
+  //       let { _pagination, items } = data;
+  //       store.dispatch({
+  //         type: "GROUPS_PAGE",
+  //         value: { data: items, page: _pagination },
+  //       });
+  //     })
+  //     .catch((err) => console.log(err));
+  // });
 
   return (
     <div className="resets">

--- a/jsx/src/App.jsx
+++ b/jsx/src/App.jsx
@@ -26,11 +26,10 @@ const App = () => {
       .updateUsers(user_page * limit, limit)
       .then((data) => {
         console.log(data);
-        let { _pagination, items } = data,
-          { offset, limit } = _pagination;
+        let { _pagination, items } = data;
         store.dispatch({
           type: "USER_PAGE",
-          value: { data: items, page: Math.floor(offset / limit) },
+          value: { data: items, page: _pagination },
         });
       })
       .catch((err) => console.log(err));
@@ -39,11 +38,10 @@ const App = () => {
       .updateGroups(groups_page * limit, limit)
       .then((data) => {
         console.log(data);
-        let { _pagination, items } = data,
-          { offset, limit } = _pagination;
+        let { _pagination, items } = data;
         store.dispatch({
           type: "GROUPS_PAGE",
-          value: { data: items, page: Math.floor(offset / limit) },
+          value: { data: items, page: _pagination },
         });
       })
       .catch((err) => console.log(err));

--- a/jsx/src/components/GroupEdit/GroupEdit.jsx
+++ b/jsx/src/components/GroupEdit/GroupEdit.jsx
@@ -122,7 +122,6 @@ const GroupEdit = (props) => {
                     : setErrorAlert(`Failed to edit group.`);
                 })
                 .catch(() => {
-                  console.log("outer");
                   setErrorAlert(`Failed to edit group.`);
                 });
             }}

--- a/jsx/src/components/Groups/Groups.jsx
+++ b/jsx/src/components/Groups/Groups.jsx
@@ -76,7 +76,7 @@ const Groups = (props) => {
                 visible={groups_data.length}
                 total={total}
                 next={() => setOffset(offset + limit)}
-                prev={() => setOffset(offset >= limit ? offset - limit : 0 )}
+                prev={() => setOffset(offset >= limit ? offset - limit : 0)}
               />
             </div>
             <div className="panel-footer">

--- a/jsx/src/components/Groups/Groups.jsx
+++ b/jsx/src/components/Groups/Groups.jsx
@@ -76,7 +76,7 @@ const Groups = (props) => {
                 visible={groups_data.length}
                 total={total}
                 next={() => setOffset(offset + limit)}
-                prev={() => setOffset(offset - limit)}
+                prev={() => setOffset(offset >= limit ? offset - limit : 0 )}
               />
             </div>
             <div className="panel-footer">

--- a/jsx/src/components/Groups/Groups.jsx
+++ b/jsx/src/components/Groups/Groups.jsx
@@ -16,8 +16,6 @@ const Groups = (props) => {
 
   var { updateGroups, history } = props;
 
-  console.log(groups_data, groups_page);
-
   const dispatchPageUpdate = (data, page) => {
     dispatch({
       type: "GROUPS_PAGE",

--- a/jsx/src/components/Groups/Groups.jsx
+++ b/jsx/src/components/Groups/Groups.jsx
@@ -6,8 +6,7 @@ import { Link } from "react-router-dom";
 import PaginationFooter from "../PaginationFooter/PaginationFooter";
 
 const Groups = (props) => {
-  var user_data = useSelector((state) => state.user_data),
-    groups_data = useSelector((state) => state.groups_data),
+  var groups_data = useSelector((state) => state.groups_data),
     groups_page = useSelector((state) => state.groups_page),
     dispatch = useDispatch();
 
@@ -19,16 +18,6 @@ const Groups = (props) => {
 
   console.log(groups_data, groups_page);
 
-  useEffect(() => {
-    updateGroups(offset, limit).then((data) =>
-      dispatchPageUpdate(data.items, data._pagination)
-    );
-  }, [offset, limit]);
-
-  if (!groups_data || !user_data || !groups_page) {
-    return <div data-testid="no-show"></div>;
-  }
-
   const dispatchPageUpdate = (data, page) => {
     dispatch({
       type: "GROUPS_PAGE",
@@ -38,6 +27,16 @@ const Groups = (props) => {
       },
     });
   };
+
+  useEffect(() => {
+    updateGroups(offset, limit).then((data) =>
+      dispatchPageUpdate(data.items, data._pagination)
+    );
+  }, [offset, limit]);
+
+  if (!groups_data || !groups_page) {
+    return <div data-testid="no-show"></div>;
+  }
 
   return (
     <div className="container" data-testid="container">
@@ -60,7 +59,6 @@ const Groups = (props) => {
                           pathname: "/group-edit",
                           state: {
                             group_data: e,
-                            user_data: user_data,
                           },
                         }}
                       >
@@ -104,8 +102,6 @@ const Groups = (props) => {
 };
 
 Groups.propTypes = {
-  user_data: PropTypes.array,
-  groups_data: PropTypes.array,
   updateUsers: PropTypes.func,
   updateGroups: PropTypes.func,
   history: PropTypes.shape({

--- a/jsx/src/components/Groups/Groups.test.js
+++ b/jsx/src/components/Groups/Groups.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { act } from "react-dom/test-utils";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import { createStore } from "redux";
 import { HashRouter } from "react-router-dom";
@@ -28,13 +28,19 @@ var groupsJsx = (callbackSpy) => (
 );
 
 var mockAppState = () => ({
-  user_data: JSON.parse(
-    '[{"kind":"user","name":"foo","admin":true,"groups":[],"server":"/user/foo/","pending":null,"created":"2020-12-07T18:46:27.112695Z","last_activity":"2020-12-07T21:00:33.336354Z","servers":{"":{"name":"","last_activity":"2020-12-07T20:58:02.437408Z","started":"2020-12-07T20:58:01.508266Z","pending":null,"ready":true,"state":{"pid":28085},"url":"/user/foo/","user_options":{},"progress_url":"/hub/api/users/foo/server/progress"}}},{"kind":"user","name":"bar","admin":false,"groups":[],"server":null,"pending":null,"created":"2020-12-07T18:46:27.115528Z","last_activity":"2020-12-07T20:43:51.013613Z","servers":{}}]'
-  ),
   groups_data: JSON.parse(
     '[{"kind":"group","name":"testgroup","users":[]}, {"kind":"group","name":"testgroup2","users":["foo", "bar"]}]'
   ),
-  limit: 10,
+  groups_page: {
+    offset: 0,
+    limit: 2,
+    total: 4,
+    next: {
+      offset: 2,
+      limit: 2,
+      url: "http://localhost:8000/hub/api/groups?offset=2&limit=2",
+    },
+  },
 });
 
 beforeEach(() => {
@@ -87,4 +93,19 @@ test("Renders nothing if required data is not available", async () => {
 
   let noShow = screen.getByTestId("no-show");
   expect(noShow).toBeVisible();
+});
+
+test("Interacting with PaginationFooter causes state update and refresh via useEffect call", async () => {
+  let callbackSpy = mockAsync();
+
+  await act(async () => {
+    render(groupsJsx(callbackSpy));
+  });
+
+  expect(callbackSpy).toBeCalledWith(0, 2);
+
+  let next = screen.getByTestId("paginate-next");
+  fireEvent.click(next);
+
+  expect(callbackSpy).toHaveBeenCalledWith(2, 2);
 });

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -11,7 +11,7 @@ const PaginationFooter = (props) => {
         Displaying {offset}-{offset + visible}
         <br></br>
         <br></br>
-        {offset >= limit ? (
+        {offset >= 1 ? (
           <button className="btn btn-sm btn-light spaced">
             <span
               className="active-pagination"

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -13,7 +13,11 @@ const PaginationFooter = (props) => {
         <br></br>
         {offset >= limit ? (
           <button className="btn btn-sm btn-light spaced">
-            <span className="active-pagination" onClick={prev}>
+            <span
+              className="active-pagination"
+              data-testid="paginate-prev"
+              onClick={prev}
+            >
               Previous
             </span>
           </button>
@@ -24,7 +28,11 @@ const PaginationFooter = (props) => {
         )}
         {offset + visible < total ? (
           <button className="btn btn-sm btn-light spaced">
-            <span className="active-pagination" onClick={next}>
+            <span
+              className="active-pagination"
+              data-testid="paginate-next"
+              onClick={next}
+            >
               Next
             </span>
           </button>

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -1,33 +1,32 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import "./pagination-footer.css";
 
 const PaginationFooter = (props) => {
-  let { endpoint, page, limit, numOffset, numElements } = props;
+  let { offset, limit, visible, total, next, prev } = props;
   return (
     <div className="pagination-footer">
       <p>
-        Displaying {numOffset}-{numOffset + numElements}
+        Displaying {offset}-{offset + visible}
         <br></br>
         <br></br>
-        {page >= 1 ? (
+        {offset >= limit ? (
           <button className="btn btn-sm btn-light spaced">
-            <Link to={`${endpoint}?page=${page - 1}`}>
-              <span className="active-pagination">Previous</span>
-            </Link>
+            <span className="active-pagination" onClick={prev}>
+              Previous
+            </span>
           </button>
         ) : (
           <button className="btn btn-sm btn-light spaced">
             <span className="inactive-pagination">Previous</span>
           </button>
         )}
-        {numElements >= limit ? (
+        {offset + visible < total ? (
           <button className="btn btn-sm btn-light spaced">
-            <Link to={`${endpoint}?page=${page + 1}`}>
-              <span className="active-pagination">Next</span>
-            </Link>
+            <span className="active-pagination" onClick={next}>
+              Next
+            </span>
           </button>
         ) : (
           <button className="btn btn-sm btn-light spaced">

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import regeneratorRuntime from "regenerator-runtime";
 import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 
@@ -90,7 +89,7 @@ const ServerDashboard = (props) => {
 
   if (page != user_page) {
     updateUsers(...slice).then((data) =>
-      dispatchPageUpdate(data, page, name_filter)
+      dispatchPageUpdate(data.items, page, name_filter)
     );
   }
 
@@ -98,7 +97,7 @@ const ServerDashboard = (props) => {
   const handleSearch = debounce(async (event) => {
     // setNameFilter(event.target.value);
     updateUsers(page * limit, limit, event.target.value).then((data) =>
-      dispatchPageUpdate(data, page, name_filter)
+      dispatchPageUpdate(data.items, page, name_filter)
     );
   }, 300);
 
@@ -119,7 +118,7 @@ const ServerDashboard = (props) => {
               if (res.status < 300) {
                 updateUsers(...slice)
                   .then((data) => {
-                    dispatchPageUpdate(data, page, name_filter);
+                    dispatchPageUpdate(data.items, page, name_filter);
                   })
                   .catch(() => {
                     setIsDisabled(false);
@@ -155,7 +154,7 @@ const ServerDashboard = (props) => {
               if (res.status < 300) {
                 updateUsers(...slice)
                   .then((data) => {
-                    dispatchPageUpdate(data, page, name_filter);
+                    dispatchPageUpdate(data.items, page, name_filter);
                   })
                   .catch(() => {
                     setErrorAlert(`Failed to update users list.`);
@@ -457,7 +456,7 @@ const ServerDashboard = (props) => {
                       .then((res) => {
                         updateUsers(...slice)
                           .then((data) => {
-                            dispatchPageUpdate(data, page, name_filter);
+                            dispatchPageUpdate(data.items, page, name_filter);
                           })
                           .catch(() =>
                             setErrorAlert(`Failed to update users list.`)
@@ -493,7 +492,7 @@ const ServerDashboard = (props) => {
                       .then((res) => {
                         updateUsers(...slice)
                           .then((data) => {
-                            dispatchPageUpdate(data, page, name_filter);
+                            dispatchPageUpdate(data.items, page, name_filter);
                           })
                           .catch(() =>
                             setErrorAlert(`Failed to update users list.`)

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -46,6 +46,16 @@ var mockAppState = () => ({
   user_data: JSON.parse(
     '[{"kind":"user","name":"foo","admin":true,"groups":[],"server":"/user/foo/","pending":null,"created":"2020-12-07T18:46:27.112695Z","last_activity":"2020-12-07T21:00:33.336354Z","servers":{"":{"name":"","last_activity":"2020-12-07T20:58:02.437408Z","started":"2020-12-07T20:58:01.508266Z","pending":null,"ready":true,"state":{"pid":28085},"url":"/user/foo/","user_options":{},"progress_url":"/hub/api/users/foo/server/progress"}}},{"kind":"user","name":"bar","admin":false,"groups":[],"server":null,"pending":null,"created":"2020-12-07T18:46:27.115528Z","last_activity":"2020-12-07T20:43:51.013613Z","servers":{}}]'
   ),
+  user_page: {
+    offset: 0,
+    limit: 2,
+    total: 4,
+    next: {
+      offset: 2,
+      limit: 2,
+      url: "http://localhost:8000/hub/api/groups?offset=2&limit=2",
+    },
+  },
 });
 
 beforeEach(() => {
@@ -532,4 +542,19 @@ test("Search for user calls updateUsers with name filter", async () => {
   clock.tick(400);
   expect(mockUpdateUsers.mock.calls[2][2]).toEqual("ab");
   expect(mockUpdateUsers.mock.calls).toHaveLength(3);
+});
+
+test("Interacting with PaginationFooter causes state update and refresh via useEffect call", async () => {
+  let callbackSpy = mockAsync();
+
+  await act(async () => {
+    render(serverDashboardJsx(callbackSpy));
+  });
+
+  expect(callbackSpy).toBeCalledWith(0, 2, undefined);
+
+  let next = screen.getByTestId("paginate-next");
+  fireEvent.click(next);
+
+  expect(callbackSpy).toHaveBeenCalledWith(2, 2, undefined);
 });

--- a/jsx/src/util/jhapiUtil.js
+++ b/jsx/src/util/jhapiUtil.js
@@ -6,6 +6,7 @@ export const jhapiRequest = (endpoint, method, data) => {
     json: true,
     headers: {
       "Content-Type": "application/json",
+      Accept: "application/jupyterhub-pagination+json",
     },
     body: data ? JSON.stringify(data) : null,
   });


### PR DESCRIPTION
In reference to https://github.com/jupyterhub/jupyterhub/issues/3999 

- Updated front-end to match pagination API spec
- Reorganize `PaginationFooter` component to rely more heavily on API `_pagination` values.
- Make `PaginationFooter` change page via callback
- Move users/groups API request out of `App.jsx` and into individual components. This way we can listen to values (offset, limit) and update on the fly.
- Update existing unit tests / add pagination unit tests to `ServerDashboard` and `Groups`