### PR TITLE
restore trimming of username input

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -256,6 +256,9 @@ class Authenticator(LoggingConfigurable):
         if not username:
             # empty usernames are not allowed
             return False
+        if username != username.strip():
+            # starting/ending with space is not allowed
+            return False
         if not self.username_regex:
             return True
         return bool(self.username_regex.match(username))

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -145,7 +145,9 @@ class LoginHandler(BaseHandler):
         # parse the arguments dict
         data = {}
         for arg in self.request.arguments:
-            data[arg] = self.get_argument(arg, strip=False)
+            # strip username, but not other fields like passwords,
+            # which should be allowed to start or end with space
+            data[arg] = self.get_argument(arg, strip=arg == "username")
 
         auth_timer = self.statsd.timer('login.authenticate').start()
         user = await self.login_user(data)

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -740,9 +740,17 @@ async def test_login_fail(app):
     assert not r.cookies
 
 
-async def test_login_strip(app):
-    """Test that login form doesn't strip whitespace from passwords"""
-    form_data = {'username': 'spiff', 'password': ' space man '}
+@pytest.mark.parametrize(
+    "form_user, auth_user, form_password",
+    [
+        ("spiff", "spiff", " space man "),
+        (" spiff ", "spiff", " space man "),
+    ],
+)
+async def test_login_strip(app, form_user, auth_user, form_password):
+    """Test that login form strips space form usernames, but not passwords"""
+    form_data = {"username": form_user, "password": form_password}
+    expected_auth = {"username": auth_user, "password": form_password}
     base_url = public_url(app)
     called_with = []
 
@@ -754,7 +762,7 @@ async def test_login_strip(app):
             base_url + 'hub/login', data=form_data, allow_redirects=False
         )
 
-    assert called_with == [form_data]
+    assert called_with == [expected_auth]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
continue to not trim password or custom fields (added in #1111)

trailing/leading space is also explicitly forbidden in validate_username. I expect this to only block typos, but since it's _technically_ backward compatible, let's get it in 3.0.

closes #4010 