### PR TITLE
Use correct expiration labels in drop-down menu on token page.

### DIFF
--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -24,9 +24,10 @@
         {% block expiration_options %}
         <select id="token-expiration-seconds"
                 class="form-control">
-          <option value="3600">1 Day</option>
-          <option value="86400">1 Week</option>
-          <option value="604800">1 Month</option>
+          <!-- unit used for each value is `seconds` -->
+          <option value="3600">1 Hour</option>
+          <option value="86400">1 Day</option>
+          <option value="604800">1 Week</option>
           <option value="" selected="selected">Never</option>
         </select>
         {% endblock expiration_options %}


### PR DESCRIPTION
According to the REST API documentation for the POST end-point `/users/{name}/token`, the expected units of the `expires_in` attribute are seconds.  As such, the titles for the options of the "Token expires" drop-down menu from the template `share/jupyterhub/templates/token.html` specify the wrong length of time. 

This pull request corrects that by assuming the values for the options are correct, and updating each option's title. 
