### PR TITLE
Use XSRF tokens for cross-site checks

### DIFF
--- a/jsx/src/util/jhapiUtil.js
+++ b/jsx/src/util/jhapiUtil.js
@@ -1,7 +1,16 @@
+const jhdata = window.jhdata || {};
+const base_url = jhdata.base_url || "/";
+const xsrfToken = jhdata.xsrf_token;
+
 export const jhapiRequest = (endpoint, method, data) => {
-  let base_url = window.base_url || "/",
-    api_url = `${base_url}hub/api`;
-  return fetch(api_url + endpoint, {
+  let api_url = `${base_url}hub/api`;
+  let suffix = "";
+  if (xsrfToken) {
+    // add xsrf token to url parameter
+    var sep = endpoint.indexOf("?") === -1 ? "?" : "&";
+    suffix = sep + "_xsrf=" + xsrf_token;
+  }
+  return fetch(api_url + endpoint + suffix, {
     method: method,
     json: true,
     headers: {

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -383,8 +383,6 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
     @web.authenticated
     def post(self):
         uri, http_method, body, headers = self.extract_oauth_params()
-        # TODO: per-page xsrf token to verify origin on this page!
-
         # The scopes the user actually authorized, i.e. checkboxes
         # that were selected.
         scopes = self.get_arguments('scopes')

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -51,6 +51,9 @@ class ShutdownAPIHandler(APIHandler):
 
 
 class RootAPIHandler(APIHandler):
+    def check_xsrf_cookie(self):
+        return
+
     def get(self):
         """GET /api/ returns info about the Hub and its API.
 

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -337,6 +337,15 @@ class UserAPIHandler(APIHandler):
 class UserTokenListAPIHandler(APIHandler):
     """API endpoint for listing/creating tokens"""
 
+    # defer check_xsrf_cookie so we can accept auth
+    # in the `auth` request field, which shouldn't require xsrf cookies
+    _skip_post_check_xsrf = True
+
+    def check_xsrf_cookie(self):
+        if self.request.method == 'POST' and self._skip_post_check_xsrf:
+            return
+        return super().check_xsrf_cookie()
+
     @needs_scope('read:tokens')
     def get(self, user_name):
         """Get tokens for a given user"""
@@ -374,6 +383,7 @@ class UserTokenListAPIHandler(APIHandler):
                 if isinstance(name, dict):
                     # not a simple string so it has to be a dict
                     name = name.get('name')
+                # don't check xsrf if we've authenticated via the request body
             except web.HTTPError as e:
                 # turn any authentication error into 403
                 raise web.HTTPError(403)
@@ -384,7 +394,14 @@ class UserTokenListAPIHandler(APIHandler):
                     "Error authenticating request for %s: %s", self.request.uri, e
                 )
                 raise web.HTTPError(403)
+            if name is None:
+                raise web.HTTPError(403)
             requester = self.find_user(name)
+        else:
+            # perform delayed xsrf check
+            # if we aren't authenticating via the request body
+            self._skip_post_check_xsrf = False
+            self.check_xsrf_cookie()
         if requester is None:
             # couldn't identify requester
             raise web.HTTPError(403)

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2721,6 +2721,16 @@ class JupyterHub(Application):
                 )
                 oauth_no_confirm_list.add(service.oauth_client_id)
 
+        # configure xsrf cookie
+        # (user xsrf_cookie_kwargs works as override)
+        xsrf_cookie_kwargs = self.tornado_settings.setdefault("xsrf_cookie_kwargs", {})
+        if not xsrf_cookie_kwargs:
+            # default to cookie_options
+            xsrf_cookie_kwargs.update(self.tornado_settings.get("cookie_options", {}))
+
+        # restrict xsrf cookie to hub base path
+        xsrf_cookie_kwargs["path"] = self.hub.base_url
+
         settings = dict(
             log_function=log_request,
             config=self.config,
@@ -2774,6 +2784,7 @@ class JupyterHub(Application):
             shutdown_on_logout=self.shutdown_on_logout,
             eventlog=self.eventlog,
             app=self,
+            xsrf_cookies=True,
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -233,6 +233,16 @@ class BaseHandler(RequestHandler):
     # Login and cookie-related
     # ---------------------------------------------------------------
 
+    def check_xsrf_cookie(self):
+        try:
+            return super().check_xsrf_cookie()
+        except Exception as e:
+            # ensure _juptyerhub_user is defined on rejected requests
+            if not hasattr(self, "_jupyterhub_user"):
+                self._jupyterhub_user = None
+            self._resolve_roles_and_scopes()
+            raise
+
     @property
     def admin_users(self):
         return self.settings.setdefault('admin_users', set())
@@ -379,6 +389,10 @@ class BaseHandler(RequestHandler):
                 recorded = self._record_activity(orm_token.user, now) or recorded
         if recorded:
             self.db.commit()
+
+        # record that we've been token-authenticated
+        # XSRF checks are skipped when using token auth
+        self._token_authenticated = True
 
         if orm_token.service:
             return orm_token.service
@@ -717,7 +731,7 @@ class BaseHandler(RequestHandler):
         if not next_url_from_param:
             # when a request made with ?next=... assume all the params have already been encoded
             # otherwise, preserve params from the current request across the redirect
-            next_url = self.append_query_parameters(next_url, exclude=['next'])
+            next_url = self.append_query_parameters(next_url, exclude=['next', '_xsrf'])
         return next_url
 
     def append_query_parameters(self, url, exclude=None):
@@ -1257,6 +1271,7 @@ class BaseHandler(RequestHandler):
         """
         template_ns = {}
         template_ns.update(self.template_namespace)
+        template_ns["xsrf_token"] = self.xsrf_token.decode("ascii")
         template_ns.update(ns)
         template = self.get_template(name, sync)
         if sync:
@@ -1279,6 +1294,7 @@ class BaseHandler(RequestHandler):
             services=self.get_accessible_services(user),
             parsed_scopes=self.parsed_scopes,
             expanded_scopes=self.expanded_scopes,
+            xsrf=self.xsrf_token.decode('ascii'),
         )
         if self.settings['template_vars']:
             ns.update(self.settings['template_vars'])

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -101,7 +101,9 @@ class LoginHandler(BaseHandler):
             "login_url": self.settings['login_url'],
             "authenticator_login_url": url_concat(
                 self.authenticator.login_url(self.hub.base_url),
-                {'next': self.get_argument('next', '')},
+                {
+                    'next': self.get_argument('next', ''),
+                },
             ),
         }
         custom_html = Template(
@@ -147,7 +149,10 @@ class LoginHandler(BaseHandler):
     async def post(self):
         # parse the arguments dict
         data = {}
-        for arg in self.request.arguments:
+        for arg in self.request.body_arguments:
+            if arg == "_xsrf":
+                # don't include xsrf token in auth input
+                continue
             # strip username, but not other fields like passwords,
             # which should be allowed to start or end with space
             data[arg] = self.get_argument(arg, strip=arg == "username")

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -99,7 +99,9 @@ class SpawnHandler(BaseHandler):
             auth_state=auth_state,
             spawner_options_form=spawner_options_form,
             error_message=message,
-            url=self.request.uri,
+            url=url_concat(
+                self.request.uri, {"_xsrf": self.xsrf_token.decode('ascii')}
+            ),
             spawner=for_user.spawner,
         )
 
@@ -404,7 +406,9 @@ class SpawnPendingHandler(BaseHandler):
                 page,
                 user=user,
                 spawner=spawner,
-                progress_url=spawner._progress_url,
+                progress_url=url_concat(
+                    spawner._progress_url, {"_xsrf": self.xsrf_token.decode('ascii')}
+                ),
                 auth_state=auth_state,
             )
             self.finish(html)

--- a/jupyterhub/log.py
+++ b/jupyterhub/log.py
@@ -66,7 +66,7 @@ class CoroutineLogFormatter(LogFormatter):
 # url params to be scrubbed if seen
 # any url param that *contains* one of these
 # will be scrubbed from logs
-SCRUB_PARAM_KEYS = ('token', 'auth', 'key', 'code', 'state')
+SCRUB_PARAM_KEYS = ('token', 'auth', 'key', 'code', 'state', '_xsrf')
 
 
 def _scrub_uri(uri):

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -6,7 +6,7 @@ import sys
 import uuid
 from datetime import datetime, timedelta
 from unittest import mock
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, urlparse
 
 from pytest import fixture, mark
 from tornado.httputil import url_concat
@@ -95,108 +95,31 @@ async def test_post_content_type(app, content_type, status):
     assert r.status_code == status
 
 
+@mark.parametrize("xsrf_in_url", [True, False])
 @mark.parametrize(
-    "host, referer, extraheaders, status",
+    "method, path",
     [
-        ('$host', '$url', {}, 200),
-        (None, None, {}, 200),
-        (None, 'null', {}, 403),
-        (None, 'http://attack.com/csrf/vulnerability', {}, 403),
-        ('$host', {"path": "/user/someuser"}, {}, 403),
-        ('$host', {"path": "{path}/foo/bar/subpath"}, {}, 200),
-        # mismatch host
-        ("mismatch.com", "$url", {}, 403),
-        # explicit host, matches
-        ("fake.example", {"netloc": "fake.example"}, {}, 200),
-        # explicit port, matches implicit port
-        ("fake.example:80", {"netloc": "fake.example"}, {}, 200),
-        # explicit port, mismatch
-        ("fake.example:81", {"netloc": "fake.example"}, {}, 403),
-        # implicit ports, mismatch proto
-        ("fake.example", {"netloc": "fake.example", "scheme": "https"}, {}, 403),
-        # explicit ports, match
-        ("fake.example:81", {"netloc": "fake.example:81"}, {}, 200),
-        # Test proxy protocol defined headers taken into account by utils.get_browser_protocol
-        (
-            "fake.example",
-            {"netloc": "fake.example", "scheme": "https"},
-            {'X-Scheme': 'https'},
-            200,
-        ),
-        (
-            "fake.example",
-            {"netloc": "fake.example", "scheme": "https"},
-            {'X-Forwarded-Proto': 'https'},
-            200,
-        ),
-        (
-            "fake.example",
-            {"netloc": "fake.example", "scheme": "https"},
-            {
-                'Forwarded': 'host=fake.example;proto=https,for=1.2.34;proto=http',
-                'X-Scheme': 'http',
-            },
-            200,
-        ),
-        (
-            "fake.example",
-            {"netloc": "fake.example", "scheme": "https"},
-            {
-                'Forwarded': 'host=fake.example;proto=http,for=1.2.34;proto=http',
-                'X-Scheme': 'https',
-            },
-            403,
-        ),
-        ("fake.example", {"netloc": "fake.example"}, {'X-Scheme': 'https'}, 403),
-        ("fake.example", {"netloc": "fake.example"}, {'X-Scheme': 'https, http'}, 403),
+        ("GET", "user"),
+        ("POST", "users/{username}/tokens"),
     ],
 )
-async def test_cors_check(request, app, host, referer, extraheaders, status):
-    url = ujoin(public_host(app), app.hub.base_url)
-    real_host = urlparse(url).netloc
-    if host == "$host":
-        host = real_host
-
-    if referer == '$url':
-        referer = url
-    elif isinstance(referer, dict):
-        parsed_url = urlparse(url)
-        # apply {}
-        url_ns = {key: getattr(parsed_url, key) for key in parsed_url._fields}
-        for key, value in referer.items():
-            referer[key] = value.format(**url_ns)
-        referer = urlunparse(parsed_url._replace(**referer))
-
-    # disable default auth header, cors is for cookie auth
-    headers = {"Authorization": ""}
-    if host is not None:
-        headers['X-Forwarded-Host'] = host
-    if referer is not None:
-        headers['Referer'] = referer
-    headers.update(extraheaders)
-
-    # add admin user
-    user = find_user(app.db, 'admin')
-    if user is None:
-        user = add_user(app.db, name='admin', admin=True)
-    cookies = await app.login_user('admin')
-
-    # test custom forwarded_host_header behavior
-    app.forwarded_host_header = 'X-Forwarded-Host'
-
-    # reset the config after the test to avoid leaking state
-    def reset_header():
-        app.forwarded_host_header = ""
-
-    request.addfinalizer(reset_header)
+async def test_xsrf_check(app, username, method, path, xsrf_in_url):
+    cookies = await app.login_user(username)
+    xsrf = cookies['_xsrf']
+    url = path.format(username=username)
+    if xsrf_in_url:
+        url = f"{url}?_xsrf={xsrf}"
 
     r = await api_request(
         app,
-        'users',
-        headers=headers,
+        url,
+        noauth=True,
         cookies=cookies,
     )
-    assert r.status_code == status
+    if xsrf_in_url:
+        assert r.status_code == 200
+    else:
+        assert r.status_code == 403
 
 
 # --------------

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -114,7 +114,7 @@ async def test_singleuser_auth(
         return
     r.raise_for_status()
     # submit the oauth form to complete authorization
-    r = await s.post(r.url, data={'scopes': ['identify']}, headers={'Referer': r.url})
+    r = await s.post(r.url, data={'scopes': ['identify'], '_xsrf': s.cookies['_xsrf']})
     final_url = urlparse(r.url).path.rstrip('/')
     final_path = url_path_join(
         '/user/', user.name, spawner.name, spawner.default_url or "/tree"

--- a/share/jupyterhub/static/js/jhapi.js
+++ b/share/jupyterhub/static/js/jhapi.js
@@ -6,6 +6,7 @@ define(["jquery", "utils"], function ($, utils) {
 
   var JHAPI = function (base_url) {
     this.base_url = base_url;
+    this.xsrf_token = window.jhdata.xsrf_token;
   };
 
   var default_options = {
@@ -40,6 +41,11 @@ define(["jquery", "utils"], function ($, utils) {
       "api",
       utils.encode_uri_components(path),
     );
+    if (this.xsrf_token) {
+      // add xsrf token to url parameter
+      var sep = url.indexOf("?") === -1 ? "?" : "&";
+      url = url + sep + "_xsrf=" + this.xsrf_token;
+    }
     $.ajax(url, options);
   };
 

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -20,12 +20,12 @@
   We strongly recommend enabling HTTPS for JupyterHub.
   </p>
 
-  <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
+  <a role="button" class='btn btn-jupyter btn-lg' href='{{ authenticator_login_url | safe }}'>
     Sign in with {{login_service}}
   </a>
 </div>
 {% else %}
-<form action="{{authenticator_login_url}}" method="post" role="form">
+<form action="{{ authenticator_login_url | safe }}" method="post" role="form">
   <div class="auth-form-header">
     <h1>Sign in</h1>
   </div>
@@ -41,6 +41,7 @@
       {{login_error}}
     </p>
     {% endif %}
+    <input type="hidden" name="_xsrf" value="{{ xsrf }}"/>
     <label for="username_input">Username:</label>
     <input
       id="username_input"

--- a/share/jupyterhub/templates/oauth.html
+++ b/share/jupyterhub/templates/oauth.html
@@ -23,6 +23,7 @@
     <h3>This will grant the application permission to:</h3>
     <div>
         <form method="POST" action="">
+            <input type="hidden" name="_xsrf" value="{{ xsrf }}"/>
             {# these are the 'real' inputs to the form -#}
             {% for scope in allowed_scopes %}
             <input type="hidden" name="scopes" value="{{ scope }}"/>

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -80,6 +80,7 @@
         {% else %}
         options_form: false,
         {% endif %}
+        xsrf_token: "{{ xsrf_token }}",
       }
     </script>
 

--- a/share/jupyterhub/templates/spawn.html
+++ b/share/jupyterhub/templates/spawn.html
@@ -20,7 +20,7 @@
         Error: {{error_message}}
       </p>
     {% endif %}
-    <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
+    <form enctype="multipart/form-data" id="spawn_form" action="{{ url | safe }}" method="post" role="form">
       {{spawner_options_form | safe}}
       <br>
       <div class="feedback-container">


### PR DESCRIPTION
## The problem

We want to validate that cookie-authenticated requests (requests authenticated with browser-stored credentials and not tokens) from the Hub are coming from the Hub, and not from pages served by e.g. services or single-user servers (those requests should use API tokens to authenticate).

Previously, we used various header checks to implement what are normally `Origin` header checks, but browsers have elected to send these only with explicitly cross-origin requests, rather than all requests, so we had to improvise a bit with a combination of headers. This has proved unreliable, especially when additional proxies are involved, all of which can modify the headers on the way by in different ways.

## The solution

There is another mechanism meant to protect against the same event: the XSRF token. I won't go into detail, but we use it in other Jupyter server API requests, and it is a mechanism to verify that the page sending the request has access to the credentials (cookies) for the target site.

## This PR

Removes all Referer checks, which have proven unreliable and have never been particularly strong. Referer's never been something that should be relied upon, since browsers can disable it entirely for privacy, and pages should still work when they do this.

We can set the XSRF cookie on paths for more robust inter-path protections, but it's still pretty easy to circumvent for the singleuser server -> hub case unless user subdomains are used (this isn't really different than our use of Referer, just the mechanism).

closes #3556 
closes #4024


## (potentially) Breaking change

This could be considered backward-incompatible in that cookie-authenticated API requests to the Hub need to now send the xsrf token. The reason I don't consider this a necessarily breaking change is that there aren't any supported extension points where cookie-authenticated API requests can really be made, except by our own page. Though _technically_ a fully custom HTML template could make all kinds of API requests. If they used our `jhapi` helper js, they wouldn't be affected. It will also break bypasses of the Referer checks, but that's fixing a bug, not breaking a valid use.