### PR TITLE
Pass launch_instance args on correctly.

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -16,6 +16,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from getpass import getuser
 from operator import itemgetter
 from textwrap import dedent
@@ -3304,7 +3305,7 @@ class JupyterHub(Application):
         loop = IOLoop(make_current=False)
 
         try:
-            loop.run_sync(self.launch_instance_async, argv)
+            loop.run_sync(partial(self.launch_instance_async, argv))
         except Exception:
             loop.close()
             raise


### PR DESCRIPTION
Greetings JupyterHub experts. Thanks for your excellent software!

Tentative bug fix:

I think the hub `launch_instance` class method should be passing its args on to `launch_instance_async`(?), but currently it is passing them to `loop.run_sync` which is expecting a timeout value there.


