### PR TITLE
Fix crash when removing scopes attribute from an existing role

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2061,7 +2061,7 @@ class JupyterHub(Application):
             # Check if some roles have obtained new permissions (to avoid 'scope creep')
             old_role = orm.Role.find(self.db, name=role_name)
             if old_role:
-                if not set(role_spec['scopes']).issubset(old_role.scopes):
+                if not set(role_spec.get('scopes', [])).issubset(old_role.scopes):
                     self.log.warning(
                         "Role %s has obtained extra permissions" % role_name
                     )

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -172,7 +172,7 @@ def create_role(db, role_dict):
             app_log.info('Role %s added to database', name)
     else:
         for attr in ["description", "scopes"]:
-            default_value = getattr(orm.Role,attr).default
+            default_value = getattr(orm.Role, attr).default
             if default_value:
                 default_value = default_value.arg
 

--- a/jupyterhub/roles.py
+++ b/jupyterhub/roles.py
@@ -162,21 +162,21 @@ def create_role(db, role_dict):
         from .scopes import _check_scopes_exist
 
         _check_scopes_exist(scopes, who_for=f"role {role_dict['name']}")
+    else:
+        app_log.warning('Role %s will have no scopes', name)
 
     if role is None:
-        if not scopes:
-            app_log.warning('Warning: New defined role %s has no scopes', name)
-
         role = orm.Role(name=name, description=description, scopes=scopes)
         db.add(role)
         if role_dict not in default_roles:
             app_log.info('Role %s added to database', name)
     else:
         for attr in ["description", "scopes"]:
-            try:
-                new_value = role_dict[attr]
-            except KeyError:
-                continue
+            default_value = getattr(orm.Role,attr).default
+            if default_value:
+                default_value = default_value.arg
+
+            new_value = role_dict.get(attr, default_value)
             old_value = getattr(role, attr)
             if new_value != old_value:
                 setattr(role, attr, new_value)


### PR DESCRIPTION
JupyterHub currently crashes on startup with 
`KeyError: 'scopes'` at `if not set(role_spec['scopes']).issubset(old_role.scopes):`
if the `scopes` attribute was removed from a previously defined role. Since the documentation [explicitly states](https://jupyterhub.readthedocs.io/en/stable/rbac/roles.html#defining-roles) that all fields except `name` are optional, this fixes the crash and makes removal actually work (instead of silently using the old value).