### PR TITLE
Modified users.servers type from array to object in rest-api.yml

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1169,14 +1169,13 @@ components:
           description: Timestamp of last-seen activity from the user
           format: date-time
         servers:
-          type: array
+          type: object
           description: |
             The servers for this user.
             By default: only includes _active_ servers.
             Changed in 3.0: if `?include_stopped_servers` parameter is specified,
             stopped servers will be included as well.
-          items:
-            $ref: "#/components/schemas/Server"
+          $ref: "#/components/schemas/Server"
         auth_state:
           type: object
           properties: {}

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1175,7 +1175,8 @@ components:
             By default: only includes _active_ servers.
             Changed in 3.0: if `?include_stopped_servers` parameter is specified,
             stopped servers will be included as well.
-          $ref: "#/components/schemas/Server"
+          items:
+            $ref: "#/components/schemas/Server"
         auth_state:
           type: object
           properties: {}


### PR DESCRIPTION
Fixed issue in documentation, users.servers returns list of dict which now fixed to returning dict. 
Modified users.servers type from array to object in rest-api.yml 
closes #4036 