### PR TITLE
Set read-only permissions in github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,10 +82,6 @@ jobs:
           twine upload --skip-existing dist/*
 
   publish-docker:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-      metadata: read # to get tags
-
     runs-on: ubuntu-20.04
 
     services:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build-release:
     runs-on: ubuntu-20.04
@@ -79,6 +82,10 @@ jobs:
           twine upload --skip-existing dist/*
 
   publish-docker:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      metadata: read # to get tags
+
     runs-on: ubuntu-20.04
 
     services:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -34,6 +34,9 @@ env:
   LANG: C.UTF-8
   PYTEST_ADDOPTS: "--verbose --color=yes"
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   validate-rest-api-definition:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.