### PR TITLE
Fully resolve requested scopes in oauth

### DIFF
--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -296,7 +296,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
             required_scopes = {*scopes.identify_scopes(), *scopes.access_scopes(client)}
             user_scopes |= {"inherit", *required_scopes}
 
-            allowed_scopes, excluded_scopes = scopes._resolve_requested_scopes(
+            allowed_scopes, disallowed_scopes = scopes._resolve_requested_scopes(
                 requested_scopes,
                 user_scopes,
                 user=user.orm_user,
@@ -304,7 +304,7 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
                 db=self.db,
             )
 
-            if excluded_scopes:
+            if disallowed_scopes:
                 self.log.warning(
                     f"Service {client.description} requested scopes {','.join(requested_scopes)}"
                     f" for user {self.current_user.name},"

--- a/jupyterhub/apihandlers/auth.py
+++ b/jupyterhub/apihandlers/auth.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import json
 from datetime import datetime
+from unittest import mock
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
 from oauthlib import oauth2
@@ -241,12 +242,18 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
 
         uri, http_method, body, headers = self.extract_oauth_params()
         try:
-            (
-                requested_scopes,
-                credentials,
-            ) = self.oauth_provider.validate_authorization_request(
-                uri, http_method, body, headers
-            )
+            with mock.patch.object(
+                self.oauth_provider.request_validator,
+                "_current_user",
+                self.current_user,
+                create=True,
+            ):
+                (
+                    requested_scopes,
+                    credentials,
+                ) = self.oauth_provider.validate_authorization_request(
+                    uri, http_method, body, headers
+                )
             credentials = self.add_credentials(credentials)
             client = self.oauth_provider.fetch_by_client_id(credentials['client_id'])
             allowed = False
@@ -289,10 +296,13 @@ class OAuthAuthorizeHandler(OAuthHandler, BaseHandler):
             required_scopes = {*scopes.identify_scopes(), *scopes.access_scopes(client)}
             user_scopes |= {"inherit", *required_scopes}
 
-            allowed_scopes = requested_scopes.intersection(user_scopes)
-            excluded_scopes = requested_scopes.difference(user_scopes)
-            # TODO: compute lower-level intersection of remaining _expanded_ scopes
-            # (e.g. user has admin:users, requesting read:users!group=x)
+            allowed_scopes, excluded_scopes = scopes._resolve_requested_scopes(
+                requested_scopes,
+                user_scopes,
+                user=user.orm_user,
+                client=client,
+                db=self.db,
+            )
 
             if excluded_scopes:
                 self.log.warning(

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -95,7 +95,7 @@ scope_definitions = {
     },
     'read:servers': {
         'description': 'Read users’ names and their server models (excluding the server state).',
-        'subscopes': ['read:users:name'],
+        'subscopes': [],
     },
     'delete:servers': {'description': "Stop and delete users' servers."},
     'tokens': {
@@ -463,14 +463,6 @@ def _expand_scope(scope):
         expanded_scopes = {
             f"{scope_name}!{filter_}" for scope_name in expanded_scope_names
         }
-        # special handling of server filter
-        # any read access via server filter includes permission to read the user's name
-        resource, _, value = filter_.partition('=')
-        if resource == 'server' and any(
-            scope_name.startswith("read:") for scope_name in expanded_scope_names
-        ):
-            username, _, server = value.partition('/')
-            expanded_scopes.add(f'read:users:name!user={username}')
     else:
         expanded_scopes = expanded_scope_names
 

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -95,7 +95,7 @@ scope_definitions = {
     },
     'read:servers': {
         'description': 'Read users’ names and their server models (excluding the server state).',
-        'subscopes': [],
+        'subscopes': ['read:users:name'],
     },
     'delete:servers': {'description': "Stop and delete users' servers."},
     'tokens': {
@@ -461,7 +461,12 @@ def _expand_scope(scope):
     # reapply !filter
     if filter_:
         expanded_scopes = {
-            f"{scope_name}!{filter_}" for scope_name in expanded_scope_names
+            f"{scope_name}!{filter_}"
+            for scope_name in expanded_scope_names
+            # server scopes have some cross-resource subscopes
+            # where the !server filter doesn't make sense,
+            # e.g. read:servers -> read:users:name
+            if not (filter_.startswith("server") and scope_name.startswith("read:user"))
         }
     else:
         expanded_scopes = expanded_scope_names

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -378,8 +378,8 @@ class Spawner(LoggingConfigurable):
                     raise ValueError(f"No such role(s): {', '.join(missing_roles)}")
                 scopes.extend(roles_to_scopes(roles))
 
-        # always add access scopes
-        scopes.extend(self.oauth_access_scopes)
+        # always add access scope
+        scopes.append(f"access:servers!server={self.user.name}/{self.name}")
         return sorted(set(scopes))
 
     will_resume = Bool(

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -203,7 +203,7 @@ def test_orm_roles_delete_cascade(db):
                 'read:users:activity',
             },
         ),
-        (['read:servers'], {'read:servers'}),
+        (['read:servers'], {'read:servers', 'read:users:name'}),
         (
             ['admin:groups'],
             {
@@ -227,6 +227,7 @@ def test_orm_roles_delete_cascade(db):
                 'read:roles:groups',
                 'read:groups:name',
                 'read:servers',
+                'read:users:name',
             },
         ),
         (

--- a/jupyterhub/tests/test_roles.py
+++ b/jupyterhub/tests/test_roles.py
@@ -203,7 +203,7 @@ def test_orm_roles_delete_cascade(db):
                 'read:users:activity',
             },
         ),
-        (['read:servers'], {'read:servers', 'read:users:name'}),
+        (['read:servers'], {'read:servers'}),
         (
             ['admin:groups'],
             {
@@ -227,7 +227,6 @@ def test_orm_roles_delete_cascade(db):
                 'read:roles:groups',
                 'read:groups:name',
                 'read:servers',
-                'read:users:name',
             },
         ),
         (

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -15,6 +15,7 @@ from ..scopes import (
     _check_scope_access,
     _expand_self_scope,
     _intersect_expanded_scopes,
+    _resolve_requested_scopes,
     expand_scopes,
     get_scopes_for,
     identify_scopes,
@@ -1202,3 +1203,88 @@ def test_expand_scopes(app, user, scopes, expected, mockservice_external):
     expanded = expand_scopes(scopes, owner=user.orm_user, oauth_client=oauth_client)
     assert isinstance(expanded, frozenset)
     assert sorted(expanded) == sorted(expected)
+
+
+@pytest.mark.parametrize(
+    "requested_scopes, have_scopes, expected_allowed, expected_excluded",
+    [
+        (
+            ["read:users:name!user"],
+            ["read:users:name!user={user}"],
+            ["read:users:name!user"],
+            [],
+        ),
+        (
+            ["read:servers!server"],
+            ["read:servers!user"],
+            ["read:servers!server"],
+            [],
+        ),
+        (
+            ["read:servers!server={server}"],
+            ["read:servers"],
+            ["read:servers!server={server}"],
+            [],
+        ),
+        (
+            ["admin:servers!server"],
+            ["read:servers"],
+            ["read:servers!server={server}"],
+            ["admin:servers!server"],
+        ),
+        (
+            ["admin:servers", "read:users"],
+            ["read:users"],
+            ["read:users"],
+            ["admin:servers"],
+        ),
+    ],
+)
+def test_resolve_requested_scopes(
+    app,
+    user,
+    group,
+    requested_scopes,
+    have_scopes,
+    expected_allowed,
+    expected_excluded,
+    mockservice_external,
+):
+    if isinstance(requested_scopes, str):
+        requested_scopes = [requested_scopes]
+
+    db = app.db
+    service = mockservice_external
+    spawner_name = "salmon"
+    server_name = f"{user.name}/{spawner_name}"
+    if '!server' in str(requested_scopes + have_scopes):
+        oauth_client = orm.OAuthClient()
+        db.add(oauth_client)
+        spawner = user.spawners[spawner_name]
+        spawner.orm_spawner.oauth_client = oauth_client
+        db.commit()
+        assert oauth_client.spawner is spawner.orm_spawner
+    else:
+        oauth_client = service.oauth_client
+        assert oauth_client is not None
+
+    def format_scopes(scopes):
+        return {
+            s.format(service=service.name, server=server_name, user=user.name)
+            for s in scopes
+        }
+
+    requested_scopes = format_scopes(requested_scopes)
+    have_scopes = format_scopes(have_scopes)
+    expected_allowed = format_scopes(expected_allowed)
+    expected_excluded = format_scopes(expected_excluded)
+
+    allowed, excluded = _resolve_requested_scopes(
+        requested_scopes,
+        have_scopes,
+        user=user.orm_user,
+        client=oauth_client,
+        db=db,
+    )
+    assert allowed == expected_allowed
+    assert excluded == expected_excluded

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -554,7 +554,9 @@ async def test_server_state_access(
             await api_request(
                 app, 'users', user.name, 'servers', server_name, method='post'
             )
-        service = create_service_with_scopes(*scopes)
+        service = create_service_with_scopes(
+            f"read:users:name!user={user.name}", *scopes
+        )
         api_token = service.new_api_token()
         headers = {'Authorization': 'token %s' % api_token}
         r = await api_request(app, 'users', user.name, headers=headers)

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -1211,7 +1211,7 @@ def test_expand_scopes(app, user, scopes, expected, mockservice_external):
 
 
 @pytest.mark.parametrize(
-    "requested_scopes, have_scopes, expected_allowed, expected_excluded",
+    "requested_scopes, have_scopes, expected_allowed, expected_disallowed",
     [
         (
             ["read:users:name!user"],
@@ -1252,7 +1252,7 @@ def test_resolve_requested_scopes(
     requested_scopes,
     have_scopes,
     expected_allowed,
-    expected_excluded,
+    expected_disallowed,
     mockservice_external,
 ):
     if isinstance(requested_scopes, str):
@@ -1282,9 +1282,9 @@ def test_resolve_requested_scopes(
     requested_scopes = format_scopes(requested_scopes)
     have_scopes = format_scopes(have_scopes)
     expected_allowed = format_scopes(expected_allowed)
-    expected_excluded = format_scopes(expected_excluded)
+    expected_disallowed = format_scopes(expected_disallowed)
 
-    allowed, excluded = _resolve_requested_scopes(
+    allowed, disallowed = _resolve_requested_scopes(
         requested_scopes,
         have_scopes,
         user=user.orm_user,
@@ -1292,4 +1292,4 @@ def test_resolve_requested_scopes(
         db=db,
     )
     assert allowed == expected_allowed
-    assert excluded == expected_excluded
+    assert disallowed == expected_disallowed

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -17,6 +17,7 @@ import pytest
 from .. import orm
 from .. import spawner as spawnermod
 from ..objects import Hub, Server
+from ..scopes import access_scopes
 from ..spawner import LocalProcessSpawner, Spawner
 from ..user import User
 from ..utils import AnyTimeoutError, new_token, url_path_join
@@ -444,7 +445,7 @@ async def test_spawner_oauth_scopes(app, user):
     await spawner.user.spawn()
     oauth_client = spawner.orm_spawner.oauth_client
     assert sorted(oauth_client.allowed_scopes) == sorted(
-        allowed_scopes + spawner.oauth_access_scopes
+        allowed_scopes + list(access_scopes(oauth_client))
     )
     await spawner.user.stop()
 


### PR DESCRIPTION
Previously, when checking if an oauth client was allowed to request a scope or if a user was allowed to issue a token with a scope, the user must have the _exact_ scopes listed, or they would be excluded. This includes filters.

With this change, the full intersection is calculated. A critical example is e.g. read-only access to user servers, where a user might have the permissions:

```
custom:execute!user
custom:read
```
(i.e. users can execute on their own servers, but read on anyone else's)

and the server would issue tokens with:

```
custom:read!server
custom:execute:!server
```

The resulting token for the owner of this server should have the full permissions (!server intersects with !user for the owner), while a visitor will only get `custom:read!server` (read-only access to just this server because !server is a subset of all servers, and !server does _not_ intersect with !user for the visitor).

This is actually a _regression_ from 2.0, where we had special cased allowing issuing of tokens if the user had _some_ access to a particular scope, and we relied on request-time application of the filters.

I think this finally delivers everything I was going for with the custom scopes.

I also cleaned up some implicit scope behaviors that shouldn't have any practical consequences.