### PR TITLE
set stacklevel for oauth_scopes deprecation warning

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -349,7 +349,9 @@ class HubAuth(SingletonConfigurable):
     @property
     def oauth_scopes(self):
         warnings.warn(
-            "HubAuth.oauth_scopes is deprecated in JupyterHub 3.0. Use .access_scopes"
+            "HubAuth.oauth_scopes is deprecated in JupyterHub 3.0. Use .access_scopes",
+            DeprecationWarning,
+            stacklevel=2,
         )
         return self.access_scopes
 


### PR DESCRIPTION
so it's visible where the deprecated API is called