### PR TITLE
Improve rbac/roles documentation

### DIFF
--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -1,4 +1,5 @@
 (roles)=
+
 # Roles
 
 JupyterHub provides four (4) roles that are available by default:
@@ -42,6 +43,7 @@ A group does not require any role, and has no roles by default. If a user is a m
 A token’s permissions are evaluated based on their owning entity. Since a token is always issued for a user or service, it can never have more permissions than its owner. If no specific scopes are requested for a new token, the token is assigned the scopes of the `token` role.
 
 (define-role-target)=
+
 ## Defining Roles
 
 Roles can be defined or modified in the configuration file as a list of dictionaries. An example:
@@ -110,6 +112,7 @@ If no scopes are defined for _new role_, JupyterHub will raise a warning. Provid
 In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so. All the role bearers permissions present in the definition will change accordingly.
 
 (overriding-default-roles)=
+
 ### Overriding Default Roles
 
 Role definitions can include those of the "default" roles listed above (admin excluded),
@@ -150,6 +153,7 @@ c.JupyterHub.load_roles = [
 ```
 
 (removing-roles-target)=
+
 ## Removing Roles
 
 Only the entities present in the role definition in the `jupyterhub_config.py` remain the role bearers. If a user, service or group is removed from the role definition, they will lose the role on the next startup.

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -107,7 +107,6 @@ If no scopes are defined for _new role_, JupyterHub will raise a warning. Provid
 
 In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so. All the role bearers permissions present in the definition will change accordingly.
 
-
 ### Overriding Default Roles
 
 Role definitions can include those of the "default" roles listed above (admin excluded),

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -1,8 +1,6 @@
-(roles)=
-
 # Roles
 
-JupyterHub provides four roles that are available by default:
+JupyterHub provides four (4) roles that are available by default:
 
 ```{admonition} **Default roles**
 - `user` role provides a {ref}`default user scope <default-user-scope-target>` `self` that grants access to the user's own resources.
@@ -13,11 +11,11 @@ JupyterHub provides four roles that are available by default:
 **These roles cannot be deleted.**
 ```
 
-These default roles have a default collection of scopes,
-but you can define the scopes associated with each role (excluding admin) to suit your needs,
+These roles are so named because they have a default collection of scopes.
+However, you can define the scopes associated with each role (excluding the admin role) to suit your needs,
 as seen [below](overriding-default-roles).
 
-The `user`, `admin`, and `token` roles by default all preserve the permissions prior to RBAC.
+The `user`, `admin`, and `token` roles, by default, all preserve the permissions prior to Role-based Access Control (RBAC).
 Only the `server` role is changed from pre-2.0, to reduce its permissions to activity-only
 instead of the default of a full access token.
 
@@ -31,18 +29,16 @@ Roles can be assigned to the following entities:
 An entity can have zero, one, or multiple roles, and there are no restrictions on which roles can be assigned to which entity. Roles can be added to or removed from entities at any time.
 
 **Users** \
-When a new user gets created, they are assigned their default role `user`. Additionaly, if the user is created with admin privileges (via `c.Authenticator.admin_users` in `jupyterhub_config.py` or `admin: true` via API), they will be also granted `admin` role. If existing user's admin status changes via API or `jupyterhub_config.py`, their default role will be updated accordingly (after next startup for the latter).
+When a new user gets created, they are assigned their default role, `user`. Additionally, if the user is created with admin privileges (via `c.Authenticator.admin_users` in `jupyterhub_config.py` or `admin: true` via API), they will be also granted `admin` role. If existing user's admin status changes via API or `jupyterhub_config.py`, their default role will be updated accordingly (after next startup for the latter).
 
 **Services** \
-Services do not have a default role. Services without roles have no access to the guarded API end-points, so most services will require assignment of a role in order to function.
+Services do not have a default role. Services without roles have no access to the guarded API end-points. So, most services will require assignment of a role in order to function.
 
 **Groups** \
 A group does not require any role, and has no roles by default. If a user is a member of a group, they automatically inherit any of the group's permissions (see {ref}`resolving-roles-scopes-target` for more details). This is useful for assigning a set of common permissions to several users.
 
 **Tokens** \
 A token’s permissions are evaluated based on their owning entity. Since a token is always issued for a user or service, it can never have more permissions than its owner. If no specific scopes are requested for a new token, the token is assigned the scopes of the `token` role.
-
-(define-role-target)=
 
 ## Defining Roles
 
@@ -111,9 +107,8 @@ If no scopes are defined for _new role_, JupyterHub will raise a warning. Provid
 
 In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so. All the role bearers permissions present in the definition will change accordingly.
 
-(overriding-default-roles)=
 
-### Overriding default roles
+### Overriding Default Roles
 
 Role definitions can include those of the "default" roles listed above (admin excluded),
 if the default scopes associated with those roles do not suit your deployment.
@@ -152,9 +147,7 @@ c.JupyterHub.load_roles = [
 ]
 ```
 
-(removing-roles-target)=
-
-## Removing roles
+## Removing Roles
 
 Only the entities present in the role definition in the `jupyterhub_config.py` remain the role bearers. If a user, service or group is removed from the role definition, they will lose the role on the next startup.
 

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -1,3 +1,4 @@
+(roles)=
 # Roles
 
 JupyterHub provides four (4) roles that are available by default:
@@ -40,6 +41,7 @@ A group does not require any role, and has no roles by default. If a user is a m
 **Tokens** \
 A token’s permissions are evaluated based on their owning entity. Since a token is always issued for a user or service, it can never have more permissions than its owner. If no specific scopes are requested for a new token, the token is assigned the scopes of the `token` role.
 
+(define-role-target)=
 ## Defining Roles
 
 Roles can be defined or modified in the configuration file as a list of dictionaries. An example:
@@ -107,6 +109,7 @@ If no scopes are defined for _new role_, JupyterHub will raise a warning. Provid
 
 In case the role with a certain name already exists in the database, its definition and scopes will be overwritten. This holds true for all roles except the `admin` role, which cannot be overwritten; an error will be raised if trying to do so. All the role bearers permissions present in the definition will change accordingly.
 
+(overriding-default-roles)=
 ### Overriding Default Roles
 
 Role definitions can include those of the "default" roles listed above (admin excluded),
@@ -146,6 +149,7 @@ c.JupyterHub.load_roles = [
 ]
 ```
 
+(removing-roles-target)=
 ## Removing Roles
 
 Only the entities present in the role definition in the `jupyterhub_config.py` remain the role bearers. If a user, service or group is removed from the role definition, they will lose the role on the next startup.

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -11,7 +11,7 @@ JupyterHub provides four (4) roles that are available by default:
 **These roles cannot be deleted.**
 ```
 
-These roles are so named because they have a default collection of scopes.
+We call these 'default' roles because they are available by default and have a default collection of scopes.
 However, you can define the scopes associated with each role (excluding the admin role) to suit your needs,
 as seen [below](overriding-default-roles).
 


### PR DESCRIPTION
This PR fixes, in part, issue [#41](https://github.com/jupyterhub/outreachy/issues/41).
In order to promote comprehension of the documentation, I read and made the following changes to "roles.md" file: 

- Fix up grammar and eliminate typos,
- Remove redundant/repetitive words,
- Adjust punctuation,
- Use initial caps where necessary,
- Add meaning of abbreviation.