### PR TITLE
modified announcement README and config.py

### DIFF
--- a/examples/service-announcement/README.md
+++ b/examples/service-announcement/README.md
@@ -7,8 +7,7 @@ To run the service as a hub-managed service simply include in your JupyterHub
 configuration file something like:
 
 :notebook:**Info**: You can run the announcement service example from the `examples`
- directory, using one of the several services provided by JupyterHub.
-
+directory, using one of the several services provided by JupyterHub.
 
 ```python
 

--- a/examples/service-announcement/README.md
+++ b/examples/service-announcement/README.md
@@ -18,7 +18,7 @@ from pathlib import Path
 # absolute path to announcement.py
 announcement_py = str(Path(__file__).parent.joinpath("announcement.py").resolve())
 
-#ensure get_config() is added to in
+#ensure get_config() is added in
  c = get_config()
 
 ...

--- a/examples/service-announcement/README.md
+++ b/examples/service-announcement/README.md
@@ -6,12 +6,29 @@ that appear when JupyterHub renders pages.
 To run the service as a hub-managed service simply include in your JupyterHub
 configuration file something like:
 
+:notebook:**Info**: You can run the announcement service example from the `examples`
+ directory, using one of the several services provided by JupyterHub.
+
+
 ```python
+
+import sys
+
+from pathlib import Path
+# absolute path to announcement.py
+announcement_py = str(Path(__file__).parent.joinpath("announcement.py").resolve())
+
+#ensure get_config() is added to in
+ c = get_config()
+
+...
+..
+
 c.JupyterHub.services = [
         {
             'name': 'announcement',
             'url': 'http://127.0.0.1:8888',
-            'command': [sys.executable, "-m", "announcement", "--port", "8888"],
+            'command': [sys.executable, announcement_py, "--port", "8888"],
         }
 ]
 ```

--- a/examples/service-announcement/jupyterhub_config.py
+++ b/examples/service-announcement/jupyterhub_config.py
@@ -1,5 +1,7 @@
 import sys
 
+c = get_config()
+
 # To run the announcement service managed by the hub, add this.
 
 port = 9999


### PR DESCRIPTION
This pull request addresses issue #3875. @minrk please review.

Fixes:
- By adding an absolute path to the `announcement.py`, the announcement service example can now be ran with no extra configuration requirement or coding  by the user.