### PR TITLE
Link back to rbac from use-cases

### DIFF
--- a/docs/source/rbac/use-cases.md
+++ b/docs/source/rbac/use-cases.md
@@ -9,7 +9,7 @@ To determine which scopes a role should have, one can follow these steps:
 5. Customize the scopes with filters if needed
 6. Define the role with required scopes and assign to users/services/groups/tokens
 
-Below, different use cases are presented on how to use the [RBAC framework](https://en.wikipedia.org/wiki/Role-based_access_control).
+Below, different use cases are presented on how to use the [RBAC framework](https://jupyterhub.readthedocs.io/en/stable/rbac/index.html).
 
 ## Service to cull idle servers
 

--- a/docs/source/rbac/use-cases.md
+++ b/docs/source/rbac/use-cases.md
@@ -9,12 +9,12 @@ To determine which scopes a role should have, one can follow these steps:
 5. Customize the scopes with filters if needed
 6. Define the role with required scopes and assign to users/services/groups/tokens
 
-Below, different use cases are presented on how to use the RBAC framework.
+Below, different use cases are presented on how to use the [RBAC framework](https://en.wikipedia.org/wiki/Role-based_access_control).
 
 ## Service to cull idle servers
 
 Finding and shutting down idle servers can save a lot of computational resources.
-We can make use of [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler) to manage this for us.
+**We can make use of [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler) to manage this for us.**
 Below follows a short tutorial on how to add a cull-idle service in the RBAC system.
 
 1. Install the cull-idle server script with `pip install jupyterhub-idle-culler`.

--- a/docs/source/rbac/use-cases.md
+++ b/docs/source/rbac/use-cases.md
@@ -9,7 +9,7 @@ To determine which scopes a role should have, one can follow these steps:
 5. Customize the scopes with filters if needed
 6. Define the role with required scopes and assign to users/services/groups/tokens
 
-Below, different use cases are presented on how to use the [RBAC framework](https://jupyterhub.readthedocs.io/en/stable/rbac/index.html).
+Below, different use cases are presented on how to use the [RBAC framework](./index.md)
 
 ## Service to cull idle servers
 


### PR DESCRIPTION
Worked on the documentation page  (jupyterhub/docs/source/rbac/use-case.md)

Added a wikipedia reference to [RBCA framework] and also emphasized on the solution under the *service to cull idle servers*