### PR TITLE
Remove redundant ref target for roles

### DIFF
--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -1,5 +1,3 @@
-(roles)=
-
 # Roles
 
 JupyterHub provides four (4) roles that are available by default:


### PR DESCRIPTION
it's already addressable at that same target name, having this here results in ambiguous ref targets in MyST