### PR TITLE
ci: use non-deprecated codecov uploader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,9 +234,7 @@ jobs:
         run: |
           pytest --maxfail=2 --cov=jupyterhub jupyterhub/tests
 
-      - name: Submit codecov report
-        run: |
-          codecov
+      - uses: codecov/codecov-action@v3
 
   docker-build:
     runs-on: ubuntu-20.04

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@
 # seems to be a pip bug
 attrs>=17.4.0
 beautifulsoup4
-codecov
 coverage
 cryptography
 html5lib  # needed for beautifulsoup


### PR DESCRIPTION
The python based CLI codecov is deprecated. They now recommend use of a binary that is also available by using a github action as we will go ahead and do here.

