### PR TITLE
Dockerfile: add python-is-python3 to hub image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update \
     curl \
     gnupg \
     locales \
+    python-is-python3 \
     python3-pip \
     python3-pycurl \
     nodejs \


### PR DESCRIPTION
Adds the `python-is-python3` Debian package so that the `python` binary on the system PATH refers to the Python 3 installation.