### PR TITLE
[docs] typo in access:servers scope

### DIFF
--- a/docs/source/reference/rest.md
+++ b/docs/source/reference/rest.md
@@ -193,7 +193,7 @@ r.json()
 
 The same API token can also authorize access to the [Jupyter Notebook REST API][]
 
-provided by notebook servers managed by JupyterHub if it has the necessary `access:users:servers` scope.
+provided by notebook servers managed by JupyterHub if it has the necessary `access:servers` scope.
 
 (api-pagination)=
 

--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -249,7 +249,7 @@ which makes a request of the Hub, and returns:
     "name": "username",
     "groups": ["list", "of", "groups"],
     "scopes": [
-        "access:users:servers!server=username/",
+        "access:servers!server=username/",
     ],
   }
   ```


### PR DESCRIPTION
it's not access:users:servers