### PR TITLE
avoid contraction in setup.rst

### DIFF
--- a/docs/source/contributing/setup.rst
+++ b/docs/source/contributing/setup.rst
@@ -130,7 +130,7 @@ Happy developing!
 Using DummyAuthenticator & SimpleLocalProcessSpawner
 ====================================================
 
-To simplify testing of JupyterHub, it’s helpful to use
+To simplify testing of JupyterHub, it is helpful to use
 :class:`~jupyterhub.auth.DummyAuthenticator` instead of the default JupyterHub
 authenticator and SimpleLocalProcessSpawner instead of the default spawner.
 


### PR DESCRIPTION
When I needed to set up Linux on my windows, i found out the easier to do so was through Windows Subsystem for Linux. Hence, I needed to add the guide to the development setup