### PR TITLE
Add active users prometheus metrics

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -72,7 +72,6 @@ from .log import CoroutineLogFormatter, log_request
 from .metrics import (
     HUB_STARTUP_DURATION_SECONDS,
     INIT_SPAWNERS_DURATION_SECONDS,
-    MONTHLY_ACTIVE_USERS,
     RUNNING_SERVERS,
     TOTAL_USERS,
     PeriodicMetricsCollector,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -70,7 +70,6 @@ from .emptyclass import EmptyClass
 from .handlers.static import CacheControlStaticFilesHandler, LogoHandler
 from .log import CoroutineLogFormatter, log_request
 from .metrics import (
-    DAILY_ACTIVE_USERS,
     HUB_STARTUP_DURATION_SECONDS,
     INIT_SPAWNERS_DURATION_SECONDS,
     MONTHLY_ACTIVE_USERS,

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -70,10 +70,13 @@ from .emptyclass import EmptyClass
 from .handlers.static import CacheControlStaticFilesHandler, LogoHandler
 from .log import CoroutineLogFormatter, log_request
 from .metrics import (
+    DAILY_ACTIVE_USERS,
     HUB_STARTUP_DURATION_SECONDS,
     INIT_SPAWNERS_DURATION_SECONDS,
+    MONTHLY_ACTIVE_USERS,
     RUNNING_SERVERS,
     TOTAL_USERS,
+    PeriodicMetricsCollector,
 )
 from .oauth.provider import make_provider
 from .objects import Hub, Server
@@ -1159,7 +1162,7 @@ class JupyterHub(Application):
         Setting this can limit the total resources a user can consume.
 
         If set to 0, no limit is enforced.
-        
+
         Can be an integer or a callable/awaitable based on the handler object:
 
         ::
@@ -2894,6 +2897,8 @@ class JupyterHub(Application):
                 await self.proxy.check_routes(self.users, self._service_map)
 
             asyncio.ensure_future(finish_init_spawners())
+        metrics_updater = PeriodicMetricsCollector(parent=self, db=self.db)
+        metrics_updater.start()
 
     async def cleanup(self):
         """Shutdown managed services and various subprocesses. Cleanup runtime files."""

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 
 from prometheus_client import Gauge, Histogram
-from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.ioloop import PeriodicCallback
 from traitlets import Any, Bool, Integer
 from traitlets.config import LoggingConfigurable
 

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -221,7 +221,7 @@ class PeriodicMetricsCollector(LoggingConfigurable):
     Collect metrics to be calculated periodically
     """
 
-    active_users_enabled = Bool(
+    active_users_metrics_enabled = Bool(
         True,
         help="""
         Enable daily_active_users and monthly_active_users prometheus metric.
@@ -232,7 +232,7 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         config=True,
     )
 
-    active_users_update_period = Integer(
+    active_users_metrics_update_period = Integer(
         60 * 60,
         help="""
         Number of seconds between updating daily_active_users and monthly_active_users metric.
@@ -276,10 +276,10 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         """
         Start the periodic update process
         """
-        if self.active_users_metric_enabled:
+        if self.active_users_metrics_enabled:
             # Setup periodic refresh of the metric
             pc = PeriodicCallback(
-                self.update, self.active_users_update_period * 1000, jitter=0.01
+                self.update, self.active_users_metrics_update_period * 1000, jitter=0.01
             )
             pc.start()
 

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -56,10 +56,6 @@ ACTIVE_USERS = Gauge(
     ['period'],
 )
 
-MONTHLY_ACTIVE_USERS = Gauge(
-    'jupyterhub_monthly_active_users', 'number of users who were active in the last 30d'
-)
-
 CHECK_ROUTES_DURATION_SECONDS = Histogram(
     'jupyterhub_check_routes_duration_seconds',
     'Time taken to validate all routes in proxy',

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -266,6 +266,9 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         Update all these metrics!
         """
 
+        # All the metrics should be based off a cutoff from a *fixed* point, so we calculate
+        # the fixed point here - and then calculate the individual cutoffs in relation to this
+        # fixed point.
         now = datetime.utcnow()
         cutoffs = {
             ActiveUserPeriods.twenty_four_hours: now - timedelta(hours=24),

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -19,7 +19,7 @@ them manually here.
 
     added ``jupyterhub_`` prefix to metric names.
 """
-from datetime import datetime, timedelta
+from datetime import timedelta
 from enum import Enum
 
 from prometheus_client import Gauge, Histogram
@@ -28,6 +28,7 @@ from traitlets import Any, Bool, Integer
 from traitlets.config import LoggingConfigurable
 
 from . import orm
+from .utils import utcnow
 
 REQUEST_DURATION_SECONDS = Histogram(
     'jupyterhub_request_duration_seconds',
@@ -265,7 +266,7 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         # All the metrics should be based off a cutoff from a *fixed* point, so we calculate
         # the fixed point here - and then calculate the individual cutoffs in relation to this
         # fixed point.
-        now = datetime.utcnow()
+        now = utcnow()
         cutoffs = {
             ActiveUserPeriods.twenty_four_hours: now - timedelta(hours=24),
             ActiveUserPeriods.seven_days: now - timedelta(days=7),

--- a/jupyterhub/tests/test_metrics.py
+++ b/jupyterhub/tests/test_metrics.py
@@ -1,11 +1,13 @@
 import json
+from datetime import timedelta
 from unittest import mock
 
 import pytest
 
 from jupyterhub import metrics, orm, roles
 
-from .utils import api_request, get_page
+from ..utils import utcnow
+from .utils import add_user, api_request, get_page
 
 
 async def test_total_users(app):
@@ -73,3 +75,65 @@ async def test_metrics_auth(
     else:
         assert r.status_code == 403
         assert 'read:metrics' in r.text
+
+
+async def test_active_users(app):
+    db = app.db
+    collector = metrics.PeriodicMetricsCollector(db=db)
+    collector.update()
+    now = utcnow()
+
+    def collect():
+        samples = metrics.ACTIVE_USERS.collect()[0].samples
+        by_period = {
+            metrics.ActiveUserPeriods(sample.labels["period"]): sample.value
+            for sample in samples
+        }
+        print(by_period)
+        return by_period
+
+    baseline = collect()
+
+    for i, offset in enumerate(
+        [
+            None,
+            # in 24h
+            timedelta(hours=23, minutes=30),
+            # in 7d
+            timedelta(hours=24, minutes=1),
+            timedelta(days=6, hours=23, minutes=30),
+            # in 30d
+            timedelta(days=7, minutes=1),
+            timedelta(days=29, hours=23, minutes=30),
+            # not in any
+            timedelta(days=30, minutes=1),
+        ]
+    ):
+        user = add_user(db, name=f"active-{i}")
+        if offset:
+            user.last_activity = now - offset
+        else:
+            user.last_activity = None
+        db.commit()
+
+    # collect before update is called, don't include new users
+    counts = collect()
+    for period in metrics.ActiveUserPeriods:
+        assert period in counts
+        assert counts[period] == baseline[period]
+
+    # collect after updates, check updated counts
+    collector.update()
+    counts = collect()
+    assert (
+        counts[metrics.ActiveUserPeriods.twenty_four_hours]
+        == baseline[metrics.ActiveUserPeriods.twenty_four_hours] + 1
+    )
+    assert (
+        counts[metrics.ActiveUserPeriods.seven_days]
+        == baseline[metrics.ActiveUserPeriods.seven_days] + 3
+    )
+    assert (
+        counts[metrics.ActiveUserPeriods.thirty_days]
+        == baseline[metrics.ActiveUserPeriods.thirty_days] + 5
+    )

--- a/jupyterhub/tests/test_metrics.py
+++ b/jupyterhub/tests/test_metrics.py
@@ -80,7 +80,7 @@ async def test_metrics_auth(
 async def test_active_users(app):
     db = app.db
     collector = metrics.PeriodicMetricsCollector(db=db)
-    collector.update()
+    collector.update_active_users()
     now = utcnow()
 
     def collect():
@@ -123,7 +123,7 @@ async def test_active_users(app):
         assert counts[period] == baseline[period]
 
     # collect after updates, check updated counts
-    collector.update()
+    collector.update_active_users()
     counts = collect()
     assert (
         counts[metrics.ActiveUserPeriods.twenty_four_hours]


### PR DESCRIPTION
These are *extremely useful* for people advocating for more resources for their JupyterHubs, but a little difficult to calculate without a full scale log ingestion and analytics pipeline (such as ELK or equivalent). However, these are easy to calculate on the JupyterHub side at any given instance - these are fairly quick SQL queries. Prometheus can capture and store this as a timeseries, and provide valuble advocacy data that is hard to get otherwise.

This turns the metrics on by default, but only updates them every hour - which seems fine for metrics that don't change that often. This should reduce performance impact. Admins can also turn this off if needed.

I've had to implement this in many different ways in many different contexts, and it's also important to be able to *trust* these. Getting this from other grafana data can be tricky to validate - we had an experimental one in our grafana dashboards at some point in the past that we had to kill due to it being hard to validate (https://github.com/jupyterhub/grafana-dashboards/pull/45). This metric will provide an authoritative source of truth for this.

There is a `period` parameter to `active_users` that provides the time period for which the active users are calculated. It provides '24h', '7d', '30d' - accurate, matches other time descriptors used in prometheus, and far more accurate than 'daily' or 'monthly'.

Ref https://github.com/2i2c-org/infrastructure/issues/1888