### PR TITLE
ci: flake8, cleanup unused/redundant config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,11 +3,12 @@
 # E: style errors
 # W: style warnings
 # C: complexity
+# D: docstring warnings (unused pydocstyle extension)
 # F401: module imported but unused
 # F403: import *
 # F811: redefinition of unused `name` from line `N`
 # F841: local variable assigned but never used
-ignore = E, C, W, F401, F403, F811, F841
+ignore = E, C, W, D, F401, F403, F811, F841
 builtins = c, get_config
 exclude =
     .cache,

--- a/.flake8
+++ b/.flake8
@@ -7,10 +7,7 @@
 # F403: import *
 # F811: redefinition of unused `name` from line `N`
 # F841: local variable assigned but never used
-# E402: module level import not at top of file
-# I100: Import statements are in the wrong order
-# I101: Imported names are in the wrong order. Should be
-ignore = E, C, W, F401, F403, F811, F841, E402, I100, I101, D400
+ignore = E, C, W, F401, F403, F811, F841
 builtins = c, get_config
 exclude =
     .cache,


### PR DESCRIPTION
- `E###` warnings were already ignored by E
- Sorting of import warnings won't matter as we have black and isort
- D400: First line should end with a period

  This is not flake8 configuration, but related to `pydocstyle`, which
  isn't used.