### PR TITLE
make current_user available to handle_logout hook

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -542,8 +542,6 @@ class BaseHandler(RequestHandler):
             '_xsrf',
             **clear_xsrf_cookie_kwargs,
         )
-        # Reset _jupyterhub_user
-        self._jupyterhub_user = None
 
     def _set_cookie(self, key, value, encrypted=True, **overrides):
         """Setting any cookie should go through here

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -84,6 +84,9 @@ class LogoutHandler(BaseHandler):
         """
         await self.default_handle_logout()
         await self.handle_logout()
+        # clear jupyterhub user before rendering logout page
+        # ensures the login button is shown instead of logout
+        self._jupyterhub_user = None
         await self.render_logout_page()
 
 

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -942,6 +942,14 @@ async def test_auto_login_logout(app):
     logout_url = public_host(app) + app.tornado_settings['logout_url']
     assert r.url == logout_url
     assert r.cookies == {}
+    # don't include logged-out user in page:
+    try:
+        idx = r.text.index(name)
+    except ValueError:
+        # not found, good!
+        pass
+    else:
+        assert name not in r.text[idx - 100 : idx + 100]
 
 
 async def test_logout(app):


### PR DESCRIPTION
Clear the user prior to rendering the logout page, rather than in clear_login_cookie. ensures current_user is accessible in `handle_logout` hook, so the hook can take the user into account.

closes #4202