### PR TITLE
deprecate JupyterHub.extra_handlers

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1159,7 +1159,7 @@ class JupyterHub(Application):
         Setting this can limit the total resources a user can consume.
 
         If set to 0, no limit is enforced.
-        
+
         Can be an integer or a callable/awaitable based on the handler object:
 
         ::
@@ -1505,13 +1505,20 @@ class JupyterHub(Application):
 
     extra_handlers = List(
         help="""
-        Register extra tornado Handlers for jupyterhub.
+        DEPRECATED.
 
-        Should be of the form ``("<regex>", Handler)``
-
-        The Hub prefix will be added, so `/my-page` will be served at `/hub/my-page`.
+        If you need to register additional HTTP endpoints
+        please use services instead.
         """
     ).tag(config=True)
+
+    @observe("extra_handlers")
+    def _extra_handlers_changed(self, change):
+        if change.new:
+            self.log.warning(
+                "JupyterHub.extra_handlers is deprecated in JupyterHub 3.1."
+                " Please use JupyterHub services to register additional HTTP endpoints."
+            )
 
     default_url = Union(
         [Unicode(), Callable()],


### PR DESCRIPTION
I don't think we should encourage or support in-process extensions for JupyterHub. Point to services, instead.

I think we've gently discouraged this for a long time, but haven't had an official deprecation/warning. I've no plans to remove the feature, but I think it's appropriate to have a "please don't do this" message, and keep it out of the documentation.

closes #3053 because I don't think we should add docs encouraging something I don't think folks should do.