### PR TITLE
Remove remnants of unused jupyterhub-services cookie

### DIFF
--- a/examples/service-fastapi/README.md
+++ b/examples/service-fastapi/README.md
@@ -72,7 +72,7 @@ To solve that problem, the `oauth_redirect_uri` value in the service initializat
 
 FastAPI has a concept of a [dependency injection](https://fastapi.tiangolo.com/tutorial/dependencies) using a `Depends` object (and a subclass `Security`) that is automatically instantiated/executed when it is a parameter for your endpoint routes. You can utilize a `Depends` object for re-useable common parameters or authentication mechanisms like the [`get_user`](https://fastapi.tiangolo.com/tutorial/security/get-current-user) pattern.
 
-JupyterHub OAuth has three ways to authenticate: a `token` url parameter; a `Authorization: Bearer <token>` header; and a (deprecated) `jupyterhub-services` cookie. FastAPI has helper functions that let us create `Security` (dependency injection) objects for each of those. When you need to allow multiple / optional authentication dependencies (`Security` objects), then you can use the argument `auto_error=False` and it will return `None` instead of raising an `HTTPException`.
+JupyterHub OAuth uses a token, which can be passed in two places: a `token` url parameter, or an `Authorization: Bearer <token>` header. FastAPI has helper functions that let us create `Security` (dependency injection) objects for each of those. When you need to allow multiple / optional authentication dependencies (`Security` objects), then you can use the argument `auto_error=False` and it will return `None` instead of raising an `HTTPException`.
 
 Endpoints that need authentication (`/me` and `/debug` in this example) can leverage the `get_user` pattern and effectively pull the user model from the Hub API when a request has authenticated with cookie / token / header all using the simple syntax,
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2393,7 +2393,7 @@ class JupyterHub(Application):
                     proto=parsed.scheme,
                     ip=parsed.hostname,
                     port=port,
-                    cookie_name='jupyterhub-services',
+                    cookie_name=service.oauth_client_id,
                     base_url=service.prefix,
                 )
                 self.db.add(server)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -9,6 +9,7 @@ import random
 import re
 import time
 import uuid
+import warnings
 from datetime import datetime, timedelta
 from http.client import responses
 from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
@@ -526,6 +527,8 @@ class BaseHandler(RequestHandler):
         # clear hub cookie
         self.clear_cookie(self.hub.cookie_name, path=self.hub.base_url, **kwargs)
         # clear services cookie
+        # FIXME: remove when we haven't been setting this in a while
+        # (stopped setting it in 3.2)
         self.clear_cookie(
             'jupyterhub-services',
             path=url_path_join(self.base_url, 'services'),
@@ -597,12 +600,10 @@ class BaseHandler(RequestHandler):
 
     def set_service_cookie(self, user):
         """set the login cookie for services"""
-        self._set_user_cookie(
-            user,
-            orm.Server(
-                cookie_name='jupyterhub-services',
-                base_url=url_path_join(self.base_url, 'services'),
-            ),
+        warnings.warn(
+            "set_service_cookie is deprecated in JupyterHub 2.0. Not setting jupyterhub-services cookie.",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
     def set_hub_cookie(self, user):
@@ -617,10 +618,6 @@ class BaseHandler(RequestHandler):
                 self.request.host,
                 self.domain,
             )
-
-        # set single cookie for services
-        if self.db.query(orm.Service).filter(orm.Service.server != None).first():
-            self.set_service_cookie(user)
 
         if not self.get_session_cookie():
             self.set_session_cookie()


### PR DESCRIPTION
We stopped being able to use it in 2.0, but we didn't stop setting it.