### PR TITLE
set max depth on api/index toctree

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -23,6 +23,8 @@ information on:
 JupyterHub API Reference:
 
 ```{toctree}
+:maxdepth: 3
+
 app
 auth
 spawner


### PR DESCRIPTION
default maxdepth seems to have changed?

closes #4254