### PR TITLE
remove unnecessary actions for firefox/geckodriver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,15 +206,6 @@ jobs:
               DB=postgres bash ci/docker-db.sh
               DB=postgres bash ci/init-db.sh
           fi
-      - name: Setup Firefox
-        if: matrix.selenium
-        uses: browser-actions/setup-firefox@latest
-        with:
-          firefox-version: latest
-
-      - name: Setup Geckodriver
-        if: matrix.selenium
-        uses: browser-actions/setup-geckodriver@latest
 
       - name: Configure selenium tests
         if: matrix.selenium


### PR DESCRIPTION
geckodriver is already set up in the default GHA environment!

These actions are only needed if you want to specify a particular version, and I don't think we care. They also appear to be unmaintained.