### PR TITLE
remove deprecated import of pipes.quote

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -2,8 +2,8 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 import inspect
-import pipes
 import re
+import shlex
 import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -958,7 +958,7 @@ class LocalAuthenticator(Authenticator):
         except KeyError:
             self.log.debug("No UID for user %s" % name)
         cmd += [name]
-        self.log.info("Creating user: %s", ' '.join(map(pipes.quote, cmd)))
+        self.log.info("Creating user: %s", ' '.join(map(shlex.quote, cmd)))
         p = Popen(cmd, stdout=PIPE, stderr=STDOUT)
         p.wait()
         if p.returncode:

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -41,7 +41,7 @@ A hub-managed service with no URL::
 import asyncio
 import copy
 import os
-import pipes
+import shlex
 import shutil
 from subprocess import Popen
 
@@ -130,7 +130,7 @@ class _ServiceSpawner(LocalProcessSpawner):
             env['SYSTEMROOT'] = os.environ['SYSTEMROOT']
         cmd = self.cmd
 
-        self.log.info("Spawning %s", ' '.join(pipes.quote(s) for s in cmd))
+        self.log.info("Spawning %s", ' '.join(shlex.quote(s) for s in cmd))
         try:
             self.proc = Popen(
                 self.cmd,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -6,7 +6,7 @@ Contains base Spawner class & default implementation
 import ast
 import json
 import os
-import pipes
+import shlex
 import shutil
 import signal
 import sys
@@ -1667,9 +1667,9 @@ class LocalProcessSpawner(Spawner):
         if self.shell_cmd:
             # using shell_cmd (e.g. bash -c),
             # add our cmd list as the last (single) argument:
-            cmd = self.shell_cmd + [' '.join(pipes.quote(s) for s in cmd)]
+            cmd = self.shell_cmd + [' '.join(shlex.quote(s) for s in cmd)]
 
-        self.log.info("Spawning %s", ' '.join(pipes.quote(s) for s in cmd))
+        self.log.info("Spawning %s", ' '.join(shlex.quote(s) for s in cmd))
 
         popen_kwargs = dict(
             preexec_fn=self.make_preexec_fn(self.user.name),


### PR DESCRIPTION
This function has been shlex.quote since 3.3, and pipes is set to be removed in Python 3.13.