### PR TITLE
Fix reoccurring accessibility issues in JupyterHub's pages

### DIFF
--- a/share/jupyterhub/static/less/login.less
+++ b/share/jupyterhub/static/less/login.less
@@ -19,7 +19,6 @@
     vertical-align: middle;
     margin: auto auto 20% auto;
     width: 350px;
-    font-size: large;
   }
 
   .input-group,
@@ -50,11 +49,17 @@
     color: #fff;
     background: @jupyter-orange;
     border-radius: @border-radius-large @border-radius-large 0 0;
+    font-size: large;
+  }
+
+  .auth-form-header > h1 {
+    font-size: inherit;
+    font-weight: inherit;
+    margin: 0;
   }
 
   .auth-form-body {
     padding: 20px;
-    font-size: 14px;
     border: thin silver solid;
     border-top: none;
     border-radius: 0 0 @border-radius-large @border-radius-large;

--- a/share/jupyterhub/static/less/variables.less
+++ b/share/jupyterhub/static/less/variables.less
@@ -4,7 +4,14 @@
 @navbar-height: 40px;
 @grid-float-breakpoint: @screen-xs-min;
 
+@navbar-default-color: #222;
+@navbar-default-link-color: @navbar-default-color;
+// darken background on hover, no change to text
+@navbar-default-link-hover-color: @navbar-default-color;
+@navbar-default-link-hover-bg: darken(@navbar-default-bg, 10%);
+
 @jupyter-orange: #f37524;
+
 @jupyter-red: #e34f21;
 // color blind-friendly alternative to red/green
 // from 5-class RdYlBu via colorbrewer.org

--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -5,6 +5,7 @@
 
 {% block main %}
 <div class="container">
+  <h1 class="sr-only">JupyterHub home page</h1>
   <div class="row">
     <div class="text-center">
       {% if default_server.active %}

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -27,7 +27,7 @@
 {% else %}
 <form action="{{authenticator_login_url}}" method="post" role="form">
   <div class="auth-form-header">
-    Sign in
+    <h1>Sign in</h1>
   </div>
   <div class='auth-form-body'>
 

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -22,7 +22,7 @@
 
 
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8">
@@ -103,7 +103,7 @@
       <div class="navbar-header">
         {% block logo %}
         <span id="jupyterhub-logo" class="pull-left">
-            <a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub' class='jpy-logo' title='Home'/></a>
+            <a href="{{logo_url or base_url}}"><img src='{{base_url}}logo' alt='JupyterHub logo' class='jpy-logo' title='Home'/></a>
         </span>
         {% endblock %}
         {% if user %}

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -3,6 +3,7 @@
 {% block main %}
 
 <div class="container">
+  <h1 class="sr-only">Manage JupyterHub Tokens</h1>
   <div class="row">
     <form id="request-token-form" class="col-md-offset-3 col-md-6">
       <div class="text-center">


### PR DESCRIPTION
After reviewing the accessibility of some of JupyterHub's pages, a few accessibility issues have been reoccurring. They can be seen here:

- Login page: #4260

- Home page: #4262

- Token page: #4265

- 404 page: #4270

With this PR, solutions to a few of them like **Lang missing or invalid** and **Missing first level heading** which were discussed earlier in the issues are implemented. Also the logo's **Alt text** is renamed from _jupyterhub_ to _jupyterhub logo_ so it clearly states the purpose of the image to people who rely on screen readers.

### Report: 

The report below shows the Login page with the changes above implemented

<img width="1266" alt="Screenshot 2022-12-16 at 14 17 01" src="https://user-images.githubusercontent.com/84882370/208118683-39607460-b993-4baf-b686-2dde21f6fa57.png">

@minrk 

