### PR TITLE
added note on `Spawner.name_template` setting

### DIFF
--- a/docs/source/reference/config-user-env.md
+++ b/docs/source/reference/config-user-env.md
@@ -202,7 +202,7 @@ This can be useful for quota service implementations. The example above limits t
 
 If `named_server_limit_per_user` is set to `0`, no limit is enforced.
 
-When using a spawner such as `DockerSpawner`, it is necessary to customize the name template to include the server name. Failing to do so can result in server errors when attempting to launch subsequent servers. 
+When using a spawner such as `DockerSpawner`, it is necessary to customize the name template to include the server name. Failing to do so can result in server errors when attempting to launch subsequent servers.
 
 The following configuration should be added to address this:
 

--- a/docs/source/reference/config-user-env.md
+++ b/docs/source/reference/config-user-env.md
@@ -202,6 +202,14 @@ This can be useful for quota service implementations. The example above limits t
 
 If `named_server_limit_per_user` is set to `0`, no limit is enforced.
 
+When using a spawner such as `DockerSpawner`, it is necessary to customize the name template to include the server name. Failing to do so can result in server errors when attempting to launch subsequent servers. 
+
+The following configuration should be added to address this:
+
+```python
+c.DockerSpawner.name_template = '{prefix}-{username}-{servername}'
+```
+
 (classic-notebook-ui)=
 
 ## Switching back to the classic notebook

--- a/docs/source/reference/config-user-env.md
+++ b/docs/source/reference/config-user-env.md
@@ -202,13 +202,7 @@ This can be useful for quota service implementations. The example above limits t
 
 If `named_server_limit_per_user` is set to `0`, no limit is enforced.
 
-When using a spawner such as `DockerSpawner`, it is necessary to customize the name template to include the server name. Failing to do so can result in server errors when attempting to launch subsequent servers.
-
-The following configuration should be added to address this:
-
-```python
-c.DockerSpawner.name_template = '{prefix}-{username}-{servername}'
-```
+When using named servers, Spawners may need additional configuration to take the `servername` into account. Whilst `KubeSpawner` takes the `servername` into account by default in [`pod_name_template`](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.pod_name_template), other Spawners may not. Check the documentation for the specific Spawner to see how singleuser servers are named, for example in `DockerSpawner` this involves modifying the [`name_template`](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/api/index.html) setting to include `servername`, eg. `"{prefix}-{username}-{servername}"`.
 
 (classic-notebook-ui)=
 


### PR DESCRIPTION
Addresses issue jupyterhub/dockerspawner#475

Adds a note to the docs to mention setting the `name_template` on the spawner to include the server name when named servers are enabled.

In my TLJH deployment this was necessary to be able to launch more than 1 server. I'm assuming this is a necessary step?

I arrived at this fix based on this discussion here: https://discourse.jupyter.org/t/multiple-jupyterhub-servers-per-user-named-servers-does-not-work/2357/5