### PR TITLE
Fix skipped heading level across pages

### DIFF
--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -6,7 +6,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-        <h4 class="modal-title" id="{{key}}-label">{{title}}</h4>
+        <h1 class="modal-title" id="{{key}}-label" aria-hidden="true">{{title}}</h1>
       </div>
       <div class="modal-body">
         {{ caller() }}

--- a/share/jupyterhub/templates/page.html
+++ b/share/jupyterhub/templates/page.html
@@ -6,7 +6,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-        <h1 class="modal-title" id="{{key}}-label" aria-hidden="true">{{title}}</h1>
+        <h1 class="modal-title" id="{{key}}-label">{{title}}</h1>
       </div>
       <div class="modal-body">
         {{ caller() }}

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -69,10 +69,10 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <td>Note</td>
-          <td>Last used</td>
-          <td>Created</td>
-          <td>Expires at</td>
+          <th>Note</th>
+          <th>Last used</th>
+          <th>Created</th>
+          <th>Expires at</th>
         </tr>
       </thead>
       <tbody>
@@ -125,9 +125,9 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <td>Application</td>
-          <td>Last used</td>
-          <td>First authorized</td>
+          <th>Application</th>
+          <th>Last used</th>
+          <th>First authorized</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
This fixes the skipped heading level accessibility issue across JupyterHub pages. 

It also adds `<th>` cells to the tables in the Token page so screen readers will interpret them as data tables(i.e., announcing column and row numbers) and not layout tables as stated in #4265

@minrk 