### PR TITLE
test and fix deprecated load_groups list

### DIFF
--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -233,15 +233,16 @@ def test_cookie_secret_string_():
 
 
 async def test_load_groups(tmpdir, request):
+
     to_load = {
         'blue': {
             'users': ['cyclops', 'rogue', 'wolverine'],
-            'properties': {'setting1': 'one', 'setting2': 'two'},
         },
         'gold': {
             'users': ['storm', 'jean-grey', 'colossus'],
             'properties': {'setting3': 'three', 'setting4': 'four'},
         },
+        'deprecated_list': ['jubilee', 'magik'],
     }
     kwargs = {'load_groups': to_load}
     ssl_enabled = getattr(request.module, "ssl_enabled", False)
@@ -258,11 +259,17 @@ async def test_load_groups(tmpdir, request):
     blue = orm.Group.find(db, name='blue')
     assert blue is not None
     assert sorted(u.name for u in blue.users) == sorted(to_load['blue']['users'])
-    assert sorted(u for u in blue.properties) == sorted(to_load['blue']['properties'])
+    assert blue.properties == {}
     gold = orm.Group.find(db, name='gold')
     assert gold is not None
     assert sorted(u.name for u in gold.users) == sorted(to_load['gold']['users'])
-    assert sorted(u for u in gold.properties) == sorted(to_load['gold']['properties'])
+    assert gold.properties == to_load['gold']['properties']
+    deprecated_list = orm.Group.find(db, name='deprecated_list')
+    assert deprecated_list is not None
+    assert deprecated_list.properties == {}
+    assert sorted(u.name for u in deprecated_list.users) == sorted(
+        to_load['deprecated_list']
+    )
 
 
 async def test_resume_spawners(tmpdir, request):


### PR DESCRIPTION
This is a follow-up to #3651. I thought I had pushed this commit before landing that PR, but apparently not.

The preferred format of `load_groups`  is changed, but the old format is still allowed. This adds a test to ensure the old format still works.