### PR TITLE
Verify port number in JUPYTERHUB_SERVICE_URL

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -994,6 +994,9 @@ class Spawner(LoggingConfigurable):
             # this should only occur in mock/testing scenarios
             base_url = '/'
 
+        if self.port < 1 or self.port > 65535:
+            raise ValueError("Port must be between 1 and 65535")
+
         proto = 'https' if self.internal_ssl else 'http'
         bind_url = f"{proto}://{self.ip}:{self.port}{base_url}"
         env["JUPYTERHUB_SERVICE_URL"] = bind_url


### PR DESCRIPTION
When implementing a custom spawner, a sneaky bug can appear when Spawner.port is not implemented: when calling `def get_env()` the `JUPYTERHUB_SERVICE_URL` is generated with port number 0. While this was ignored by _nbviewer_ in the past, it now results in difficult to diagnose behavior where the URL on which the Jupyter server starts defaults to port 80 ( See https://github.com/jupyter/docker-stacks/issues/1862).

I think it is preferable that the Spawner crashes instead.

Instructions to solve the issue: either define a static port in your Spawner:

```python
    @default("port")
    def _default_port(self):
        return 8888
```

or initialize the port to a random port number, as happens in `LocalProcessSpawner.start`: https://github.com/twalcari/jupyterhub/blob/cbce162e7cfa7da7997df6a6c2c37248d06ac527/jupyterhub/spawner.py#L1662-L1663