### PR TITLE
require sqlalchemy 1.4

### DIFF
--- a/jupyterhub/tests/test_db.py
+++ b/jupyterhub/tests/test_db.py
@@ -5,6 +5,7 @@ from glob import glob
 from subprocess import check_call
 
 import pytest
+from packaging.version import parse as V
 from pytest import raises
 from traitlets.config import Config
 
@@ -25,8 +26,14 @@ def generate_old_db(env_dir, hub_version, db_url):
     env_pip = os.path.join(env_dir, 'bin', 'pip')
     env_py = os.path.join(env_dir, 'bin', 'python')
     check_call([sys.executable, '-m', 'virtualenv', env_dir])
+    pkgs = ['jupyterhub==' + hub_version]
+
     # older jupyterhub needs older sqlachemy version
-    pkgs = ['jupyterhub==' + hub_version, 'sqlalchemy<1.4']
+    if V(hub_version) < V("2"):
+        pkgs.append('sqlalchemy<1.4')
+    elif V(hub_version) < V("3.1.1"):
+        pkgs.append('sqlalchemy<2')
+
     if 'mysql' in db_url:
         pkgs.append('mysql-connector-python')
     elif 'postgres' in db_url:

--- a/jupyterhub/tests/utils.py
+++ b/jupyterhub/tests/utils.py
@@ -14,20 +14,6 @@ from jupyterhub.objects import Server
 from jupyterhub.roles import assign_default_roles, update_roles
 from jupyterhub.utils import url_path_join as ujoin
 
-try:
-    from sqlalchemy.exc import RemovedIn20Warning
-except ImportError:
-
-    class RemovedIn20Warning(DeprecationWarning):
-        """
-        I only exist so I can be used in warnings filters in pytest.ini
-
-        I will never be displayed.
-
-        sqlalchemy 1.4 introduces RemovedIn20Warning,
-        but we still test against older sqlalchemy.
-        """
-
 
 class _AsyncRequests:
     """Wrapper around requests to return a Future from request methods

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,5 +20,5 @@ markers =
     selenium: web tests that run with selenium
 
 filterwarnings =
-    error:.*:jupyterhub.tests.utils.RemovedIn20Warning
-    ignore:.*event listener has changed as of version 2.0.*:sqlalchemy.exc.SADeprecationWarning
+    ignore:.*The new signature is "def engine_connect\(conn\)"*:sqlalchemy.exc.SADeprecationWarning
+    ignore:.*The new signature is "def engine_connect\(conn\)"*:sqlalchemy.exc.SAWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ prometheus_client>=0.4.0
 psutil>=5.6.5; sys_platform == 'win32'
 python-dateutil
 requests
-SQLAlchemy>=1.1
+SQLAlchemy>=1.4
 tornado>=5.1
 traitlets>=4.3.2


### PR DESCRIPTION
removes some workarounds needed for sqlalchemy 1.1 + 2.0 support

1.4 backports most 2.0 behavior, keeping it off-by-default for an easier opt-in transition. #4302 needed several conditionals to avoid bumping the dependency version, which I didn't want to do in the same PR to make backporting easier.

There doesn't appear to be a great way to avoid the SADeprecationWarning on the engine_connect signature until we require sqla 2, even though our callback accepts the new signature. This is because the warning condition only checks if we accept the _old_ signature and takes that path, it doesn't seem to allow us to opt-in to the new signature while still accepting the old signature.