### PR TITLE
Remove no longer relevant notice in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,6 @@
 
 ---
 
-Please note that this repository is participating in a study into the sustainability of open source projects. Data will be gathered about this repository for approximately the next 12 months, starting from 2021-06-11.
-
-Data collected will include the number of contributors, number of PRs, time taken to close/merge these PRs, and issues closed.
-
-For more information, please visit
-[our informational page](https://sustainable-open-science-and-software.github.io/) or download our [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).
-
----
-
 # [JupyterHub](https://github.com/jupyterhub/jupyterhub)
 
 [![Latest PyPI version](https://img.shields.io/pypi/v/jupyterhub?logo=pypi)](https://pypi.python.org/pypi/jupyterhub)


### PR DESCRIPTION
- Reverts #3506 as I think its no longer needed.

Note the pre-commit.ci failure can be resolved by bumping isort, something that needs doing across all our repos to resolve :'(