### PR TITLE
Improve contrast on muted text

### DIFF
--- a/share/jupyterhub/static/less/variables.less
+++ b/share/jupyterhub/static/less/variables.less
@@ -20,6 +20,8 @@
 @brand-success: @brand-primary;
 @brand-danger: #d7191c;
 
+@text-muted: #222;
+
 .btn-jupyter {
   .button-variant(#fff; @jupyter-orange; @jupyter-red);
 }


### PR DESCRIPTION
On accessing the pages with axe DevTools again, I found text that had a low contrast which I did not notice previously.

This PR increases the contrast of muted text on the Token page.

**Before:**

<img width="1280" alt="Screenshot 2023-01-30 at 13 18 17" src="https://user-images.githubusercontent.com/84882370/215489550-37247d50-3846-416c-90df-880b6155cbba.png">


**After:**

<img width="1280" alt="Screenshot 2023-01-30 at 12 16 18" src="https://user-images.githubusercontent.com/84882370/215489562-8ee5b626-e246-455b-a038-6bfbec3e0015.png">



@minrk 