### PR TITLE
also ignore sqlite backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ jsx/build/
 /jupyterhub_config.py
 jupyterhub_cookie_secret
 jupyterhub.sqlite
+jupyterhub.sqlite*
 package-lock.json
 share/jupyterhub/static/components
 share/jupyterhub/static/css/style.min.css


### PR DESCRIPTION
not just the rename (in case of `jupyterhub upgrade-db`). For example in #4321