### PR TITLE
add a few more buckets for server_spawn_duration_seconds

### DIFF
--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -42,7 +42,7 @@ SERVER_SPAWN_DURATION_SECONDS = Histogram(
     ['status'],
     # Use custom bucket sizes, since the default bucket ranges
     # are meant for quick running processes. Spawns can take a while!
-    buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, float("inf")],
+    buckets=[0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, 180, 300, 600, float("inf")],
 )
 
 RUNNING_SERVERS = Gauge(


### PR DESCRIPTION
this addresses https://github.com/jupyterhub/jupyterhub/issues/4351

added buckets for 3, 5 and 10 minutes.  default server spawn timeout is 10 minutes.

