### PR TITLE
[DO NOT MERGE] add example metric for asyncio loop duration

### DIFF
--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -75,6 +75,12 @@ PROXY_POLL_DURATION_SECONDS = Histogram(
     'duration for polling all routes from proxy',
 )
 
+EVENT_LOOP_TICK_DURATION_SECONDS = Histogram(
+    'jupyterhub_event_loop_tick_duration_seconds',
+    'Duration of individual asyncio event loop iterations',
+    buckets=[1e-4, 1e-3, 1e-2, 1e-1, 1, 10, float('inf')],
+)
+
 
 class ServerSpawnStatus(Enum):
     """

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -484,3 +484,16 @@ def preserve_scopes():
     scope_definitions = copy.deepcopy(scopes.scope_definitions)
     yield scope_definitions
     scopes.scope_definitions = scope_definitions
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    # FIXME: not for real
+    # include event-loop tick durations metric in test output
+    # so we can get a sense of its range (on a very slow CI VM)
+    from jupyterhub.metrics import EVENT_LOOP_TICK_DURATION_SECONDS
+
+    terminalreporter.ensure_newline()
+    terminalreporter.section("event loop durations", sep="-")
+    for metric in EVENT_LOOP_TICK_DURATION_SECONDS.collect():
+        for sample in metric.samples:
+            terminalreporter.line(f"{sample.name}[{sample.labels}]: {sample.value:.0f}")


### PR DESCRIPTION
Not a real proposal as-is, but this is what a metric for #4353 could look like.

https://github.com/python/cpython/issues/101946 includes proposals for two possibly more useful metrics, which could show _which_ coroutines are slow (rather than merely _that_ something is slow).

Notably, this does _not_ directly indicate that a Hub is CPU-bound, merely a measure of 'how blocking it is', which is perhaps more relevant, but less directly actionable as it measures a directly user-experienced property of the Hub (responsiveness), but doesn't include any information about the cause beyond what may be in the surrounding logs.

Also of note: you can actually define and enable this metric _purely from jupyterhub_config.py_ if someone wants to experiment with it.