### PR TITLE
admin panel: fix condition for start/stop buttons on user servers

### DIFF
--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -298,7 +298,7 @@ const ServerDashboard = (props) => {
           {server.last_activity ? timeSince(server.last_activity) : "Never"}
         </td>
         <td data-testid="user-row-server-activity">
-          {server.started ? (
+          {server.ready ? (
             // Stop Single-user server
             <>
               <StopServerButton serverName={server.name} userName={user.name} />

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -78,7 +78,19 @@ var mockAppState = () =>
         pending: null,
         created: "2020-12-07T18:46:27.115528Z",
         last_activity: "2020-12-07T20:43:51.013613Z",
-        servers: {},
+        servers: {
+          "": {
+            name: "",
+            last_activity: "2020-12-07T20:58:02.437408Z",
+            started: "2020-12-07T20:58:01.508266Z",
+            pending: null,
+            ready: false,
+            state: { pid: 12345 },
+            url: "/user/bar/",
+            user_options: {},
+            progress_url: "/hub/api/users/bar/progress",
+          },
+        },
       },
     ],
     user_page: {

--- a/jupyterhub/tests/selenium/conftest.py
+++ b/jupyterhub/tests/selenium/conftest.py
@@ -6,7 +6,7 @@ from selenium import webdriver
 def browser_session():
     """Re-use one browser instance for the test session"""
     options = webdriver.FirefoxOptions()
-    options.headless = True
+    options.add_argument("-headless")
     driver = webdriver.Firefox(options=options)
     yield driver
     driver.close()


### PR DESCRIPTION
`.ready` is the right switch for the links, not `.started` which can be defined even after they stop

closes #4361