### PR TITLE
Getting started link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ more configuration of the system.
 
 ## Configuration
 
-The [Getting Started](https://jupyterhub.readthedocs.io/en/latest/getting-started/index.html) section of the
+The [Getting Started](https://jupyterhub.readthedocs.io/en/latest/tutorial/index.html#getting-started) section of the
 documentation explains the common steps in setting up JupyterHub.
 
 The [**JupyterHub tutorial**](https://github.com/jupyterhub/jupyterhub-tutorial)


### PR DESCRIPTION
Current getting started link in README is broken.

<img width="1142" alt="Screen Shot 2023-02-24 at 4 18 02 PM" src="https://user-images.githubusercontent.com/289369/221324382-8f6e843f-ba34-4709-9500-4ccf9db1530f.png">
