### PR TITLE
exponential_backoff: preserve jitter when max_wait is reached

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -229,9 +229,10 @@ async def exponential_backoff(
         # add some random jitter to improve performance
         # this prevents overloading any single tornado loop iteration with
         # too many things
-        dt = min(max_wait, remaining, random.uniform(0, start_wait * scale))
-        if dt < max_wait:
+        limit = min(max_wait, start_wait * scale)
+        if limit < max_wait:
             scale *= scale_factor
+        dt = min(remaining, random.uniform(0, limit))
         await asyncio.sleep(dt)
     raise asyncio.TimeoutError(fail_message)
 


### PR DESCRIPTION
Previously, the sleep would be a random time on the range `[0, limit]` _until_ max_wait was reached, at which point it would always be exactly max_wait, stopping the jitter when the max scale was reached. This keeps the jitter applied to every sleep.
