### PR TITLE
Re-enable links to REST API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ myst_heading_anchors = 2
 
 myst_enable_extensions = [
     # available extensions: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
+    "attrs_inline",
     "colon_fence",
     "deflist",
     "fieldlist",
@@ -185,6 +186,7 @@ linkcheck_ignore = [
     "https://github.com/jupyterhub/jupyterhub/pull/",  # too many PRs in changelog
     "https://github.com/jupyterhub/jupyterhub/compare/",  # too many comparisons in changelog
     r"https?://(localhost|127.0.0.1).*",  # ignore localhost references in auto-links
+    r".*/rest-api.html#.*",  # ignore javascript-resolved internal rest-api links
     r"https://jupyter.chameleoncloud.org",  # FIXME: ignore (presumably) short-term SSL issue
 ]
 linkcheck_anchors_ignore = [

--- a/docs/source/explanation/database.md
+++ b/docs/source/explanation/database.md
@@ -82,7 +82,7 @@ Additionally, there is usually _very_ little load on the database itself.
 By far the most taxing activity on the database is the 'list all users' endpoint, primarily used by the [idle-culling service](https://github.com/jupyterhub/jupyterhub-idle-culler).
 Database-based optimizations have been added to make even these operations feasible for large numbers of users:
 
-1. State filtering on [GET /users](jupyterhub-rest-API) with `?state=active`,
+1. State filtering on [GET /hub/api/users?state=active](../reference/rest-api.html#/default/get_users){.external},
    which limits the number of results in the query to only the relevant subset (added in JupyterHub 1.3), rather than all users.
 2. [Pagination](api-pagination) of all list endpoints, allowing the request of a large number of resources to be more fairly balanced with other Hub activities across multiple requests (added in 2.0).
 


### PR DESCRIPTION
- fix path to oauth spec
- enable attrs_inline for external link handling to internal targets

This lets us link directly to fields in the openapi REST spec page.

I tried to do this [in #4292](https://github.com/jupyterhub/jupyterhub/pull/4292#discussion_r1064714153), but couldn't figure it out. Appears to be possible in myst-parser 0.19: https://github.com/executablebooks/MyST-Parser/discussions/677#discussioncomment-5214070