### PR TITLE
make sure named server URLs include trailing slash

### DIFF
--- a/jupyterhub/tests/test_user.py
+++ b/jupyterhub/tests/test_user.py
@@ -53,3 +53,16 @@ def test_sync_groups(app, user, group_names):
             assert user.orm_user in group.users
         else:
             assert user.orm_user not in group.users
+
+
+@pytest.mark.parametrize(
+    "server_name, path",
+    [
+        ("", ""),
+        ("name", "name/"),
+        ("næme", "n%C3%A6me/"),
+    ],
+)
+def test_server_url(app, user, server_name, path):
+    user_url = user.url
+    assert user.server_url(server_name) == user_url + path

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -588,7 +588,7 @@ class User:
         if not server_name:
             return self.url
         else:
-            return url_path_join(self.url, url_escape_path(server_name))
+            return url_path_join(self.url, url_escape_path(server_name), "/")
 
     def progress_url(self, server_name=''):
         """API URL for progress endpoint for a server with a given name"""


### PR DESCRIPTION
identified in https://github.com/jupyterhub/traefik-proxy/issues/195

it was a bug in the traefik proxy that it didn't handle `/user/name/named-server` the same as `/user/name/named-server/`, but we should still be consistent about computing URLs with the full routing prefix (we already use `/user/name/`, so this makes named servers consistent with the default server)