### PR TITLE
dependabot: fix syntax error of not using quotes for ##:##

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
     labels: [ci]
     schedule:
       interval: monthly
-      time: 05:00
+      time: "05:00"
       timezone: Etc/UTC


### PR DESCRIPTION
- Followup on #4403 that got a syntax error:
  ![image](https://user-images.githubusercontent.com/3837114/229914684-83a5927e-7c74-42f7-942f-f6ab6178f9e8.png)