### PR TITLE
dependabot: rename to .yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Notes:
 # - Status and logs from dependabot are provided at


### PR DESCRIPTION
This is a followup to #4403 and https://github.com/jupyterhub/team-compass/issues/636 where I also proposed systematic naming of this file to `dependabot.yaml`. I've bundled all currently open PRs with such rename as well now.

There is no real benefit to having either `.yaml` or `.yml`, both works - I have a preference of sticking to one option, and preferably also with `.yaml` because thats what almost all other YAML files are in helm charts etc. I believe @sgibson91 also has a preference towards .yaml over .yml.