### PR TITLE
Begin setup of playwright tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,6 +233,10 @@ jobs:
         if: matrix.selenium
         run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m selenium" >> "${GITHUB_ENV}"
 
+      - name: Install playwright module
+        run: |
+          pip install playwright
+
       - name: Ensure browsers are installed
         run: python -m playwright install --with-deps
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,9 +99,7 @@ jobs:
             noextension: noextension
             subset: singleuser
           - python: "3.11"
-            selenium: selenium
-          - python: "3.11"
-            playwright: playwright
+            browser: browser
           - python: "3.11"
             main_dependencies: main_dependencies
 
@@ -231,21 +229,17 @@ jobs:
               DB=postgres bash ci/init-db.sh
           fi
 
-      - name: Configure selenium tests
-        if: matrix.selenium
-        run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m selenium" >> "${GITHUB_ENV}"
+      - name: Configure browser tests
+        if: matrix.browser
+        run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m browser" >> "${GITHUB_ENV}"
 
       - name: Install playwright module
         run: |
           pip install playwright
 
       - name: Ensure browsers are installed for playwright
-        if: matrix.playwright
+        if: matrix.browser
         run: python -m playwright install --with-deps
-
-      - name: Configure playwright tests
-        if: matrix.playwright
-        run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m playwright" >> "${GITHUB_ENV}"
 
       - name: Run pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,10 @@ jobs:
       - name: Ensure browsers are installed
         run: python -m playwright install --with-deps
 
+      - name: Configure playwright tests
+        if: matrix.playwright
+        run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m playwright" >> "${GITHUB_ENV}"
+
       - name: Run pytest
         run: |
           pytest -k "${{ matrix.subset }}" --maxfail=2 --cov=jupyterhub jupyterhub/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
           - python: "3.11"
             selenium: selenium
           - python: "3.11"
-            selenium: playwright
+            playwright: playwright
           - python: "3.11"
             main_dependencies: main_dependencies
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
           - python: "3.11"
             selenium: selenium
           - python: "3.11"
+            selenium: playwright
+          - python: "3.11"
             main_dependencies: main_dependencies
 
     steps:
@@ -230,6 +232,9 @@ jobs:
       - name: Configure selenium tests
         if: matrix.selenium
         run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m selenium" >> "${GITHUB_ENV}"
+
+      - name: Ensure browsers are installed
+        run: python -m playwright install --with-deps
 
       - name: Run pytest
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,10 +236,12 @@ jobs:
         run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m selenium" >> "${GITHUB_ENV}"
 
       - name: Install playwright module
+        if: matrix.playwright
         run: |
           pip install playwright
 
-      - name: Ensure browsers are installed
+      - name: Ensure browsers are installed for playwright
+        if: matrix.playwright
         run: python -m playwright install --with-deps
 
       - name: Configure playwright tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,10 +233,6 @@ jobs:
         if: matrix.browser
         run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m browser" >> "${GITHUB_ENV}"
 
-      - name: Install playwright module
-        run: |
-          pip install playwright
-
       - name: Ensure browsers are installed for playwright
         if: matrix.browser
         run: python -m playwright install --with-deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,6 @@ jobs:
         run: echo "PYTEST_ADDOPTS=$PYTEST_ADDOPTS -m selenium" >> "${GITHUB_ENV}"
 
       - name: Install playwright module
-        if: matrix.playwright
         run: |
           pip install playwright
 

--- a/jupyterhub/tests/browser/conftest.py
+++ b/jupyterhub/tests/browser/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from playwright.async_api import async_playwright
+
+
+@pytest.fixture()
+async def browser():
+    # browser_type in ["chromium", "firefox", "webkit"]
+    async with async_playwright() as playwright:
+        browser = await playwright.firefox.launch(headless=True)
+        context = await browser.new_context()
+        page = await context.new_page()
+        yield page
+        await context.clear_cookies()
+        await browser.close()

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -8,7 +8,7 @@ from playwright.async_api import expect
 from jupyterhub.tests.utils import public_host
 from jupyterhub.utils import url_path_join
 
-pytestmark = pytest.mark.playwright
+pytestmark = pytest.mark.browser
 
 
 async def login(browser, username, password):

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -1,0 +1,31 @@
+"""Tests for the Playwright Python"""
+
+import re
+
+import pytest
+from playwright.async_api import expect
+
+from jupyterhub.tests.utils import public_host
+from jupyterhub.utils import url_path_join
+
+pytestmark = pytest.mark.playwright
+
+
+async def login(browser, username, password):
+    """filling the login form by user and pass_w parameters and iniate the login"""
+
+    await browser.get_by_label("Username:").click()
+    await browser.get_by_label("Username:").fill(username)
+    await browser.get_by_label("Password:").click()
+    await browser.get_by_label("Password:").fill(password)
+    await browser.get_by_role("button", name="Sign in").click()
+
+
+async def test_open_login_page(app, browser):
+    login_url = url_path_join(public_host(app), app.hub.base_url, "login")
+    await browser.goto(login_url)
+    await expect(browser).to_have_url(re.compile(r".*/login"))
+    await expect(browser).to_have_title("JupyterHub")
+    form = browser.locator('//*[@id="login-main"]/form')
+    await expect(form).to_be_visible()
+    await expect(form.locator('//h1')).to_have_text("Sign in")

--- a/jupyterhub/tests/selenium/test_browser.py
+++ b/jupyterhub/tests/selenium/test_browser.py
@@ -31,7 +31,7 @@ from ... import orm, roles
 from ...utils import url_path_join
 from ..utils import api_request, public_host, public_url, ujoin
 
-pytestmark = pytest.mark.selenium
+pytestmark = pytest.mark.browser
 
 
 async def webdriver_wait(driver, condition, timeout=30):

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@
 asyncio_mode = auto
 
 # jupyter_server plugin is incompatible with notebook imports
-addopts = -p no:jupyter_server -m 'not selenium' --color yes --durations 10 --verbose
+addopts = -p no:jupyter_server -m 'not selenium and not playwright' --color yes --durations 10 --verbose
 
 python_files = test_*.py
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@
 asyncio_mode = auto
 
 # jupyter_server plugin is incompatible with notebook imports
-addopts = -p no:jupyter_server -m 'not selenium and not playwright' --color yes --durations 10 --verbose
+addopts = -p no:jupyter_server -m 'not browser' --color yes --durations 10 --verbose
 
 python_files = test_*.py
 markers =
@@ -17,8 +17,7 @@ markers =
     user: mark as a test for a user
     slow: mark a test as slow
     role: mark as a test for roles
-    selenium: web tests that run with selenium
-    playwright: web tests that run with playwright
+    browser: web tests that run with selenium/playwright
 
 filterwarnings =
     ignore:.*The new signature is "def engine_connect\(conn\)"*:sqlalchemy.exc.SADeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
     slow: mark a test as slow
     role: mark as a test for roles
     selenium: web tests that run with selenium
+    playwright: web tests that run with playwright
 
 filterwarnings =
     ignore:.*The new signature is "def engine_connect\(conn\)"*:sqlalchemy.exc.SADeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup_args = dict(
             "pytest-cov",
             "requests-mock",
             "selenium",
-            "virtualenv",
+            "playwright" "virtualenv",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,8 @@ setup_args = dict(
             "pytest-cov",
             "requests-mock",
             "selenium",
-            "playwright" "virtualenv",
+            "playwright",
+            "virtualenv",
         ],
     },
 )


### PR DESCRIPTION
To simplify web testing and avoid a problem with async waiting of web elements as Playwright has own async API.

The next files are changed:
test.yml - added a configuration for Playwright, rename selenium to browser
pytest.ini - rename marker for browser testing to "browser"
setup.py - added "playwright"

New files:
tests/browser/conftest.py
tests/browser/test_browser.py