### PR TITLE
docs: fix missing redirects for api to reference/api

### DIFF
--- a/docs/source/redirects.txt
+++ b/docs/source/redirects.txt
@@ -39,6 +39,15 @@
 "reference/server-api.md" "tutorial/server-api.md"
 "reference/websecurity.md" "explanation/websecurity.md"
 
+"api/app.md" "reference/api/app.md"
+"api/auth.md" "reference/api/auth.md"
+"api/index.md" "reference/api/index.md"
+"api/proxy.md" "reference/api/proxy.md"
+"api/service.md" "reference/api/service.md"
+"api/services.auth.md" "reference/api/services.auth.md"
+"api/spawner.md" "reference/api/spawner.md"
+"api/user.md" "reference/api/user.md"
+
 #  -- JupyterHub 4.0 --
 # redirects above are up-to-date as of JupyterHub 4.0
 # add future redirects below


### PR DESCRIPTION
I saw a broken link in oauthenticators documentation:

![image](https://user-images.githubusercontent.com/3837114/233822505-70dc9956-d04d-43a3-b075-c923fc710bf3.png)