### PR TITLE
Fix docs on setting named_server_limit_per_user config

### DIFF
--- a/docs/source/howto/configuration/config-user-env.md
+++ b/docs/source/howto/configuration/config-user-env.md
@@ -195,7 +195,7 @@ def named_server_limit_per_user_fn(handler):
         return 0
     return 5
 
-c.JupyterHub.named_server_limit_per_user = named_server_limit_per_user_fn
+c.JupyterHub.named_server_limit_per_user = property(named_server_limit_per_user_fn)
 ```
 
 This can be useful for quota service implementations. The example above limits the number of named servers for non-admin users only.


### PR DESCRIPTION
Since the value is a property, it should be patched as a property.