### PR TITLE
Config reference: link to nicer(?) API docs first

### DIFF
--- a/docs/source/reference/config-reference.md
+++ b/docs/source/reference/config-reference.md
@@ -14,6 +14,12 @@ section, the `jupyterhub_config.py` can be automatically generated via
 > jupyterhub --generate-config
 > ```
 
+Most of this information is available in a nicer format in:
+
+- [](./api/app.md)
+- [](./api/auth.md)
+- [](./api/spawner.md)
+
 The following contains the output of that command for reference.
 
 ```{eval-rst}


### PR DESCRIPTION
`Configuration Reference` sounds like it's the place to go to see the full list of JupyterHub config options. However it's not very readable as it's a plain-text commented-out dump of `jupyterhub --generate-config`:
https://jupyterhub.readthedocs.io/en/stable/reference/config-reference.html

This PR links to some of the API doc pages instead, which present most of the information in an easier to read format. Unfortunately it also includes a lot of non-traitlets documentation. Ideally we'd replace the `jupyterhub --generate-config` output with the autogenerated docs for the configurable traitlets only.