### PR TITLE
Delete server button on admin page

### DIFF
--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -45,11 +45,11 @@ const ServerDashboard = (props) => {
     adminAsc = (e) => e.sort((a) => (a.admin ? 1 : -1)),
     dateDesc = (e) =>
       e.sort((a, b) =>
-        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? -1 : 1
+        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? -1 : 1,
       ),
     dateAsc = (e) =>
       e.sort((a, b) =>
-        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? 1 : -1
+        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? 1 : -1,
       ),
     runningAsc = (e) => e.sort((a) => (a.server == null ? -1 : 1)),
     runningDesc = (e) => e.sort((a) => (a.server == null ? 1 : -1));
@@ -144,7 +144,7 @@ const ServerDashboard = (props) => {
                     dispatchPageUpdate(
                       data.items,
                       data._pagination,
-                      name_filter
+                      name_filter,
                     );
                   })
                   .catch(() => {
@@ -188,7 +188,7 @@ const ServerDashboard = (props) => {
                     dispatchPageUpdate(
                       data.items,
                       data._pagination,
-                      name_filter
+                      name_filter,
                     );
                   })
                   .catch(() => {
@@ -228,7 +228,7 @@ const ServerDashboard = (props) => {
                     dispatchPageUpdate(
                       data.items,
                       data._pagination,
-                      name_filter
+                      name_filter,
                     );
                   })
                   .catch(() => {
@@ -536,7 +536,7 @@ const ServerDashboard = (props) => {
                               failedServers.length > 1 ? "servers" : "server"
                             }. ${
                               failedServers.length > 1 ? "Are they " : "Is it "
-                            } already running?`
+                            } already running?`,
                           );
                         }
                         return res;
@@ -547,11 +547,11 @@ const ServerDashboard = (props) => {
                             dispatchPageUpdate(
                               data.items,
                               data._pagination,
-                              name_filter
+                              name_filter,
                             );
                           })
                           .catch(() =>
-                            setErrorAlert(`Failed to update users list.`)
+                            setErrorAlert(`Failed to update users list.`),
                           );
                         return res;
                       })
@@ -576,7 +576,7 @@ const ServerDashboard = (props) => {
                               failedServers.length > 1 ? "servers" : "server"
                             }. ${
                               failedServers.length > 1 ? "Are they " : "Is it "
-                            } already stopped?`
+                            } already stopped?`,
                           );
                         }
                         return res;
@@ -587,11 +587,11 @@ const ServerDashboard = (props) => {
                             dispatchPageUpdate(
                               data.items,
                               data._pagination,
-                              name_filter
+                              name_filter,
                             );
                           })
                           .catch(() =>
-                            setErrorAlert(`Failed to update users list.`)
+                            setErrorAlert(`Failed to update users list.`),
                           );
                         return res;
                       })

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -45,11 +45,11 @@ const ServerDashboard = (props) => {
     adminAsc = (e) => e.sort((a) => (a.admin ? 1 : -1)),
     dateDesc = (e) =>
       e.sort((a, b) =>
-        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? -1 : 1,
+        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? -1 : 1
       ),
     dateAsc = (e) =>
       e.sort((a, b) =>
-        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? 1 : -1,
+        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? 1 : -1
       ),
     runningAsc = (e) => e.sort((a) => (a.server == null ? -1 : 1)),
     runningDesc = (e) => e.sort((a) => (a.server == null ? 1 : -1));
@@ -74,6 +74,7 @@ const ServerDashboard = (props) => {
     shutdownHub,
     startServer,
     stopServer,
+    deleteServer,
     startAll,
     stopAll,
     history,
@@ -143,7 +144,7 @@ const ServerDashboard = (props) => {
                     dispatchPageUpdate(
                       data.items,
                       data._pagination,
-                      name_filter,
+                      name_filter
                     );
                   })
                   .catch(() => {
@@ -167,6 +168,50 @@ const ServerDashboard = (props) => {
     );
   };
 
+  const DeleteServerButton = ({ serverName, userName }) => {
+    if (serverName === "") {
+      return null;
+    }
+    var [isDisabled, setIsDisabled] = useState(false);
+    return (
+      <button
+        className="btn btn-danger btn-xs stop-button"
+        // It's not possible to delete unnamed servers
+        disabled={isDisabled}
+        onClick={() => {
+          setIsDisabled(true);
+          deleteServer(userName, serverName)
+            .then((res) => {
+              if (res.status < 300) {
+                updateUsers(...slice)
+                  .then((data) => {
+                    dispatchPageUpdate(
+                      data.items,
+                      data._pagination,
+                      name_filter
+                    );
+                  })
+                  .catch(() => {
+                    setIsDisabled(false);
+                    setErrorAlert(`Failed to update users list.`);
+                  });
+              } else {
+                setErrorAlert(`Failed to delete server.`);
+                setIsDisabled(false);
+              }
+              return res;
+            })
+            .catch(() => {
+              setErrorAlert(`Failed to delete server.`);
+              setIsDisabled(false);
+            });
+        }}
+      >
+        Delete Server
+      </button>
+    );
+  };
+
   const StartServerButton = ({ serverName, userName }) => {
     var [isDisabled, setIsDisabled] = useState(false);
     return (
@@ -183,7 +228,7 @@ const ServerDashboard = (props) => {
                     dispatchPageUpdate(
                       data.items,
                       data._pagination,
-                      name_filter,
+                      name_filter
                     );
                   })
                   .catch(() => {
@@ -323,6 +368,10 @@ const ServerDashboard = (props) => {
                 serverName={server.name}
                 userName={user.name}
                 style={{ marginRight: 20 }}
+              />
+              <DeleteServerButton
+                serverName={server.name}
+                userName={user.name}
               />
               <a
                 href={`${base_url}spawn/${user.name}${
@@ -483,7 +532,7 @@ const ServerDashboard = (props) => {
                               failedServers.length > 1 ? "servers" : "server"
                             }. ${
                               failedServers.length > 1 ? "Are they " : "Is it "
-                            } already running?`,
+                            } already running?`
                           );
                         }
                         return res;
@@ -494,11 +543,11 @@ const ServerDashboard = (props) => {
                             dispatchPageUpdate(
                               data.items,
                               data._pagination,
-                              name_filter,
+                              name_filter
                             );
                           })
                           .catch(() =>
-                            setErrorAlert(`Failed to update users list.`),
+                            setErrorAlert(`Failed to update users list.`)
                           );
                         return res;
                       })
@@ -523,7 +572,7 @@ const ServerDashboard = (props) => {
                               failedServers.length > 1 ? "servers" : "server"
                             }. ${
                               failedServers.length > 1 ? "Are they " : "Is it "
-                            } already stopped?`,
+                            } already stopped?`
                           );
                         }
                         return res;
@@ -534,11 +583,11 @@ const ServerDashboard = (props) => {
                             dispatchPageUpdate(
                               data.items,
                               data._pagination,
-                              name_filter,
+                              name_filter
                             );
                           })
                           .catch(() =>
-                            setErrorAlert(`Failed to update users list.`),
+                            setErrorAlert(`Failed to update users list.`)
                           );
                         return res;
                       })
@@ -582,6 +631,7 @@ ServerDashboard.propTypes = {
   shutdownHub: PropTypes.func,
   startServer: PropTypes.func,
   stopServer: PropTypes.func,
+  deleteServer: PropTypes.func,
   startAll: PropTypes.func,
   stopAll: PropTypes.func,
   dispatch: PropTypes.func,

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -323,7 +323,11 @@ const ServerDashboard = (props) => {
     const userServerName = user.name + serverNameDash;
     const open = collapseStates[userServerName] || false;
     return [
-      <tr key={`${userServerName}-row`} className="user-row">
+      <tr
+        key={`${userServerName}-row`}
+        data-testid={`user-row-${userServerName}`}
+        className="user-row"
+      >
         <td data-testid="user-row-name">
           <span>
             <Button

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -403,7 +403,7 @@ test("Shows a UI error dialogue when start all servers fails", async () => {
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 
@@ -437,7 +437,7 @@ test("Shows a UI error dialogue when stop all servers fails", async () => {
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 
@@ -471,7 +471,7 @@ test("Shows a UI error dialogue when start user server fails", async () => {
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 
@@ -506,7 +506,7 @@ test("Shows a UI error dialogue when start user server returns an improper statu
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 
@@ -541,7 +541,7 @@ test("Shows a UI error dialogue when stop user servers fails", async () => {
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 
@@ -575,7 +575,7 @@ test("Shows a UI error dialogue when stop user server returns an improper status
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 
@@ -621,7 +621,7 @@ test("Search for user calls updateUsers with name filter", async () => {
             />
           </Switch>
         </HashRouter>
-      </Provider>
+      </Provider>,
     );
   });
 

--- a/jsx/src/util/withAPI.js
+++ b/jsx/src/util/withAPI.js
@@ -7,17 +7,23 @@ const withAPI = withProps(() => ({
       `/users?include_stopped_servers&offset=${offset}&limit=${limit}&name_filter=${
         name_filter || ""
       }`,
-      "GET",
+      "GET"
     ).then((data) => data.json()),
   updateGroups: (offset, limit) =>
     jhapiRequest(`/groups?offset=${offset}&limit=${limit}`, "GET").then(
-      (data) => data.json(),
+      (data) => data.json()
     ),
   shutdownHub: () => jhapiRequest("/shutdown", "POST"),
   startServer: (name, serverName = "") =>
     jhapiRequest("/users/" + name + "/servers/" + (serverName || ""), "POST"),
   stopServer: (name, serverName = "") =>
     jhapiRequest("/users/" + name + "/servers/" + (serverName || ""), "DELETE"),
+  deleteServer: (name, serverName = "") =>
+    jhapiRequest(
+      "/users/" + name + "/servers/" + (serverName || ""),
+      "DELETE",
+      { remove: true }
+    ),
   startAll: (names) =>
     names.map((e) => jhapiRequest("/users/" + e + "/server", "POST")),
   stopAll: (names) =>

--- a/jsx/src/util/withAPI.js
+++ b/jsx/src/util/withAPI.js
@@ -7,11 +7,11 @@ const withAPI = withProps(() => ({
       `/users?include_stopped_servers&offset=${offset}&limit=${limit}&name_filter=${
         name_filter || ""
       }`,
-      "GET"
+      "GET",
     ).then((data) => data.json()),
   updateGroups: (offset, limit) =>
     jhapiRequest(`/groups?offset=${offset}&limit=${limit}`, "GET").then(
-      (data) => data.json()
+      (data) => data.json(),
     ),
   shutdownHub: () => jhapiRequest("/shutdown", "POST"),
   startServer: (name, serverName = "") =>
@@ -22,7 +22,7 @@ const withAPI = withProps(() => ({
     jhapiRequest(
       "/users/" + name + "/servers/" + (serverName || ""),
       "DELETE",
-      { remove: true }
+      { remove: true },
     ),
   startAll: (names) =>
     names.map((e) => jhapiRequest("/users/" + e + "/server", "POST")),


### PR DESCRIPTION
Fixes #4174 

Hi, I was in the Jupytercon Sprints last week, with no clear fix to contribute, so decided to start with a "good first issue".

This PR adds a "delete server" button to named servers (personal servers cannot be deleted, according to the API) + basic tests. ~~The button is always visible but enabled/disabled depending on the case.~~

<img width="1118" alt="Screenshot 2023-05-19 at 16 40 56" src="https://github.com/jupyterhub/jupyterhub/assets/2589871/f2b8d1f0-c523-4d4e-8a9e-daf4af5a39b4">

Let me know if this is ok. Tried linting and fixing the tests, hope I didn't mess up the local configuration.