### PR TITLE
'servers' should be a dict of dicts, not a list of dicts in rest-api.yml

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1202,13 +1202,13 @@ components:
           description: Timestamp of last-seen activity from the user
           format: date-time
         servers:
-          type: array
+          type: object
           description: |
             The servers for this user.
             By default: only includes _active_ servers.
             Changed in 3.0: if `?include_stopped_servers` parameter is specified,
             stopped servers will be included as well.
-          items:
+          additionalProperties:
             $ref: "#/components/schemas/Server"
         auth_state:
           type: object


### PR DESCRIPTION
Closes #4036.

It seems that the only way to override the `additionalProp1` would be to provide a full example. Based on https://swagger.io/docs/specification/data-models/dictionaries/. 

![image](https://github.com/jupyterhub/jupyterhub/assets/80677094/ef8bd0a5-43b6-49f2-abbc-4c048b474493)
