### PR TITLE
Add xsrf to custom_html template context

### DIFF
--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -105,6 +105,7 @@ class LoginHandler(BaseHandler):
                     'next': self.get_argument('next', ''),
                 },
             ),
+            "xsrf": self.xsrf_token.decode('ascii'),
         }
         custom_html = Template(
             self.authenticator.get_custom_html(self.hub.base_url)


### PR DESCRIPTION
If you are implementing an alternative login form in custom_html, you need the xsrf token.