### PR TITLE
Allow setting custom log_function in tornado_settings in SingleUserServer

### DIFF
--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -617,8 +617,8 @@ class JupyterHubSingleUser(ExtensionApp):
         app.web_app.settings[
             "page_config_hook"
         ] = app.identity_provider.page_config_hook
-        # allow to override log_function with tornado_settings set in user config
-        if not app.web_app.settings.get("log_function"):
+        # if the user has configured a log function in the tornado settings, do not override it
+        if not 'log_function' in app.config.ServerApp.get('tornado_settings', {}):
             app.web_app.settings["log_function"] = log_request
         # add jupyterhub version header
         headers = app.web_app.settings.setdefault("headers", {})

--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -617,7 +617,9 @@ class JupyterHubSingleUser(ExtensionApp):
         app.web_app.settings[
             "page_config_hook"
         ] = app.identity_provider.page_config_hook
-        app.web_app.settings["log_function"] = log_request
+        # allow to override log_function with tornado_settings set in user config
+        if not app.web_app.settings.get("log_function"):
+            app.web_app.settings["log_function"] = log_request
         # add jupyterhub version header
         headers = app.web_app.settings.setdefault("headers", {})
         headers["X-JupyterHub-Version"] = __version__

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -669,7 +669,9 @@ class SingleUserNotebookAppMixin(Configurable):
         # load the hub-related settings into the tornado settings dict
         self.init_hub_auth()
         s = self.tornado_settings
-        s['log_function'] = log_request
+        # allow to override log_function with tornado_settings set in user config
+        if not s.get('log_function'):
+            s['log_function'] = log_request
         s['user'] = self.user
         s['group'] = self.group
         s['hub_prefix'] = self.hub_prefix

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -669,9 +669,8 @@ class SingleUserNotebookAppMixin(Configurable):
         # load the hub-related settings into the tornado settings dict
         self.init_hub_auth()
         s = self.tornado_settings
-        # allow to override log_function with tornado_settings set in user config
-        if not s.get('log_function'):
-            s['log_function'] = log_request
+        # if the user has configured a log function in the tornado settings, do not override it
+        s.setdefault('log_function', log_request)
         s['user'] = self.user
         s['group'] = self.group
         s['hub_prefix'] = self.hub_prefix


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/jupyterhub/issues/4473. 

The problem there was that setting a custom log_function for the singleUserServer in the tornado_settings in the jupyter_server_config.py had no effect since it was overwritten during singleUserServer initialization. This PR fixes that by checking if the log_function in the settings is already defined before setting it.