### PR TITLE
Move most package config to declarative pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,29 +1,13 @@
-include README.md
-include COPYING.md
-include setupegg.py
-include bower-lite
-include package.json
+# using setuptools-scm means we only need to handle _non-tracked files here_
+
 include package-lock.json
-include *requirements.txt
-include Dockerfile
 
-graft onbuild
-graft jsx
-graft jupyterhub
-graft scripts
+# include untracked js/css artifacts, components
 graft share
-graft singleuser
-graft ci
 
-# Documentation
-graft docs
-prune docs/node_modules
-
-# Intermediate javascript files
-prune jsx/node_modules
-prune jsx/build
-
-# prune some large unused files from components
+# prune some large unused files from components.
+# these patterns affect source distributions (sdists)
+# we have stricter exclusions from installation in setup.py:get_data_files
 prune share/jupyterhub/static/components/bootstrap/dist/css
 exclude share/jupyterhub/static/components/bootstrap/dist/fonts/*.svg
 prune share/jupyterhub/static/components/font-awesome/css
@@ -33,11 +17,3 @@ prune share/jupyterhub/static/components/jquery/external
 prune share/jupyterhub/static/components/jquery/src
 prune share/jupyterhub/static/components/moment/lang
 prune share/jupyterhub/static/components/moment/min
-
-# Patterns to exclude from any directory
-global-exclude *~
-global-exclude *.pyc
-global-exclude *.pyo
-global-exclude .git
-global-exclude .ipynb_checkpoints
-global-exclude .bower.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,100 @@
+# PEP 621 build info
+[build-system]
+requires = ["setuptools>=61", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+# Project metadata
+# ref: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+[project]
+name = "jupyterhub"
+version = "4.1.0.dev"
+dynamic = ["readme", "dependencies"]
+description = "JupyterHub: A multi-user server for Jupyter notebooks"
+authors = [
+  { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
+]
+keywords = ["Interactive", "Interpreter", "Shell", "Web", "Jupyter"]
+license = { text = "BSD-3-Clause" }
+requires-python = ">=3.7"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Operating System :: POSIX",
+  "Framework :: Jupyter",
+]
+
+[project.urls]
+Homepage = "https://hub.jupyter.org"
+Documentation = "https://jupyterhub.readthedocs.io"
+Funding = "https://jupyter.org/about"
+Source = "https://github.com/jupyterhub/jupyterhub"
+Tracker = "https://github.com/jupyterhub/jupyterhub/issues"
+
+[project.optional-dependencies]
+test = [
+  "beautifulsoup4[html5lib]",
+  "coverage",
+  # cryptography is an optional dependency for jupyterhub that we test
+  # against by default
+  "cryptography",
+  "jsonschema",
+  "jupyterlab>=3",
+  "mock",
+  # nbclassic provides the '/tree/' handler that we tests against in
+  # the test test_nbclassic_control_panel.
+  "nbclassic",
+  "pytest>=3.3",
+  "pytest-asyncio>=0.17",
+  "pytest-cov",
+  "requests-mock",
+  "playwright",
+  "virtualenv",
+]
+
+[project.scripts]
+jupyterhub = "jupyterhub.app:main"
+jupyterhub-singleuser = "jupyterhub.singleuser:main"
+
+[project.entry-points."jupyterhub.authenticators"]
+default = "jupyterhub.auth:PAMAuthenticator"
+pam = "jupyterhub.auth:PAMAuthenticator"
+dummy = "jupyterhub.auth:DummyAuthenticator"
+null = "jupyterhub.auth:NullAuthenticator"
+
+[project.entry-points."jupyterhub.proxies"]
+default = "jupyterhub.proxy:ConfigurableHTTPProxy"
+configurable-http-proxy = "jupyterhub.proxy:ConfigurableHTTPProxy"
+
+[project.entry-points."jupyterhub.spawners"]
+default = "jupyterhub.spawner:LocalProcessSpawner"
+localprocess = "jupyterhub.spawner:LocalProcessSpawner"
+simple = "jupyterhub.spawner:SimpleLocalProcessSpawner"
+
+[tool.setuptools]
+zip-safe = false
+license-files = ["COPYING.md"]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = [""]
+include = ["jupyterhub*"]
+
+# dynamic sources of metadata in other files
+[tool.setuptools.dynamic]
+readme = { file = "README.md", content-type = "text/markdown" }
+dependencies = { file = "requirements.txt" }
+
+# declarative data-files doesn't quite work right
+# this is still in setup.py:get_data_files
+# [tool.setuptools.data-files]
+# "share/jupyterhub" = ["share/jupyterhub/**"]
+
+
 # autoflake is used for autoformatting Python code
 #
 # ref: https://github.com/PyCQA/autoflake#readme
@@ -66,6 +163,10 @@ tag_template = "{new_version}"
 # For each file to patch, add a [[tool.tbump.file]] config
 # section containing the path of the file, relative to the
 # pyproject.toml location.
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'version = "{current_version}"'
 
 [[tool.tbump.file]]
 src = "jupyterhub/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-# -----------------------------------------------------------------------------
-# Minimal Python version sanity check (from IPython)
-# -----------------------------------------------------------------------------
+
 import os
 import shutil
 import sys
@@ -12,6 +10,7 @@ from subprocess import check_call
 from setuptools import Command, setup
 from setuptools.command.bdist_egg import bdist_egg
 from setuptools.command.build_py import build_py
+from setuptools.command.develop import develop
 from setuptools.command.sdist import sdist
 
 shell = False
@@ -29,9 +28,7 @@ static = pjoin(share_jupyterhub, 'static')
 
 is_repo = os.path.exists(pjoin(here, '.git'))
 
-# ---------------------------------------------------------------------------
 # Build basic package data, etc.
-# ---------------------------------------------------------------------------
 
 
 def get_data_files():
@@ -42,113 +39,6 @@ def get_data_files():
         rel_d = os.path.relpath(d, here)
         data_files.append((rel_d, [os.path.join(rel_d, f) for f in filenames]))
     return data_files
-
-
-def get_package_data():
-    """Get package data
-
-    (mostly alembic config)
-    """
-    package_data = {}
-    package_data['jupyterhub'] = [
-        'alembic.ini',
-        'alembic/*',
-        'alembic/versions/*',
-        'event-schemas/*/*.yaml',
-        'singleuser/templates/*.html',
-    ]
-    return package_data
-
-
-ns = {}
-with open(pjoin(here, 'jupyterhub', '_version.py')) as f:
-    exec(f.read(), {}, ns)
-
-
-packages = []
-for d, _, _ in os.walk('jupyterhub'):
-    if os.path.exists(pjoin(d, '__init__.py')):
-        packages.append(d.replace(os.path.sep, '.'))
-
-with open('README.md', encoding="utf8") as f:
-    readme = f.read()
-
-
-setup_args = dict(
-    name='jupyterhub',
-    packages=packages,
-    # dummy, so that install_data doesn't get skipped
-    # this will be overridden when bower is run anyway
-    data_files=get_data_files() or ['dummy'],
-    package_data=get_package_data(),
-    version=ns['__version__'],
-    description="JupyterHub: A multi-user server for Jupyter notebooks",
-    long_description=readme,
-    long_description_content_type='text/markdown',
-    author="Jupyter Development Team",
-    author_email="jupyter@googlegroups.com",
-    url="https://jupyter.org",
-    license="BSD",
-    platforms="Linux, Mac OS X",
-    keywords=['Interactive', 'Interpreter', 'Shell', 'Web'],
-    python_requires=">=3.7",
-    entry_points={
-        'jupyterhub.authenticators': [
-            'default = jupyterhub.auth:PAMAuthenticator',
-            'pam = jupyterhub.auth:PAMAuthenticator',
-            'dummy = jupyterhub.auth:DummyAuthenticator',
-            'null = jupyterhub.auth:NullAuthenticator',
-        ],
-        'jupyterhub.proxies': [
-            'default = jupyterhub.proxy:ConfigurableHTTPProxy',
-            'configurable-http-proxy = jupyterhub.proxy:ConfigurableHTTPProxy',
-        ],
-        'jupyterhub.spawners': [
-            'default = jupyterhub.spawner:LocalProcessSpawner',
-            'localprocess = jupyterhub.spawner:LocalProcessSpawner',
-            'simple = jupyterhub.spawner:SimpleLocalProcessSpawner',
-        ],
-        'console_scripts': [
-            'jupyterhub = jupyterhub.app:main',
-            'jupyterhub-singleuser = jupyterhub.singleuser:main',
-        ],
-    },
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-    ],
-    project_urls={
-        'Documentation': 'https://jupyterhub.readthedocs.io',
-        'Funding': 'https://jupyter.org/about',
-        'Source': 'https://github.com/jupyterhub/jupyterhub/',
-        'Tracker': 'https://github.com/jupyterhub/jupyterhub/issues',
-    },
-    extras_require={
-        "test": [
-            "beautifulsoup4[html5lib]",
-            "coverage",
-            # cryptography is an optional dependency for jupyterhub that we test
-            # against by default
-            "cryptography",
-            "jsonschema",
-            "jupyterlab>=3",
-            "mock",
-            # nbclassic provides the '/tree/' handler that we tests against in
-            # the test test_nbclassic_control_panel.
-            "nbclassic",
-            "pytest>=3.3",
-            "pytest-asyncio>=0.17",
-            "pytest-cov",
-            "requests-mock",
-            "playwright",
-            "virtualenv",
-        ],
-    },
-)
 
 
 def mtime(path):
@@ -373,22 +263,6 @@ class bdist_egg_disabled(bdist_egg):
         )
 
 
-setup_args['cmdclass'] = {
-    'js': NPM,
-    'css': CSS,
-    'jsx': JSX,
-    'build_py': js_css_first(build_py, strict=is_repo),
-    'sdist': js_css_first(sdist, strict=True),
-    'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
-}
-
-
-# setuptools requirements
-
-setup_args['zip_safe'] = False
-from setuptools.command.develop import develop
-
-
 class develop_js_css(develop):
     def run(self):
         if not self.uninstall:
@@ -397,23 +271,24 @@ class develop_js_css(develop):
         super().run()
 
 
-setup_args['cmdclass']['develop'] = develop_js_css
-setup_args['install_requires'] = install_requires = []
+cmdclass = {
+    'js': NPM,
+    'css': CSS,
+    'jsx': JSX,
+    'build_py': js_css_first(build_py, strict=is_repo),
+    'sdist': js_css_first(sdist, strict=True),
+    'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
+    'develop': develop_js_css,
+}
 
-with open('requirements.txt') as f:
-    for line in f.readlines():
-        req = line.strip()
-        if not req or req.startswith('#') or '://' in req:
-            continue
-        install_requires.append(req)
-
-# ---------------------------------------------------------------------------
-# setup
-# ---------------------------------------------------------------------------
+# run setup
 
 
 def main():
-    setup(**setup_args)
+    setup(
+        cmdclass=cmdclass,
+        data_files=get_data_files(),
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Mostly doesn't change how anything is built, but adds PEP 621 `[build-system]` config to make use of setuptools explicit.

Most of the changes are moving declarative config out of setup.py into pyproject.toml with no change in results.

Material, deliberate changes:

- add setuptools-scm build dependency, which enables sdists to include all tracked files by default. Has no effect on wheels, installs, versioning, etc. just means we don't have to maintain MANIFEST.in so much. Fixes a few files we were omitting from source distributions (e.g. pytest.ini). MANIFEST.in is now only needed for selecting files excluded by .gitignore (bundled components, built artifacts).
- a couple of trove classifiers are updated, e.g. adding `Framework :: Jupyter` and switching from `platform: Linux / mac` to `Operating System :: POSIX`. Trove classifiers are not especially consequential.

data_files still needs to be dynamic in setup.py because it gets reconstructed after setup.py starts. If we migrate to something like hatchling, we should be able to make it clearer when data files are to be evaluated (as seen in hatch-jupyter-builder).

Command to build distributions to compare:

```bash
python3 -m build --sdist --wheel .
cd dist
tar -xzf *.tar.gz
mkdir whl
cd whl
unzip ../*.whl
```

Comparison of package metadata shows the only material changes are some minor tweaks to a few metadata fields, and fixing the inclusion of the `jupyterhub.tests.browser` subpackage.

<details>
<summary>

```
diff -r before-dist/whl/jupyterhub-4.1.0.dev0.dist-info/ after-dist/whl/jupyterhub-4.1.0.dev0.dist-info/
```

</summary>


```
diff -r before-dist/whl/jupyterhub-4.1.0.dev0.dist-info/METADATA after-dist/whl/jupyterhub-4.1.0.dev0.dist-info/METADATA
5,8c5,7
< Home-page: https://jupyter.org
< Author: Jupyter Development Team
< Author-email: jupyter@googlegroups.com
< License: BSD
---
> Author-email: Jupyter Development Team <jupyter@googlegroups.com>
> License: BSD-3-Clause
> Project-URL: Homepage, https://hub.jupyter.org
11c10
< Project-URL: Source, https://github.com/jupyterhub/jupyterhub/
---
> Project-URL: Source, https://github.com/jupyterhub/jupyterhub
13,15c12,13
< Keywords: Interactive,Interpreter,Shell,Web
< Platform: Linux
< Platform: Mac OS X
---
> Keywords: Interactive,Interpreter,Shell,Web,Jupyter
> Classifier: Development Status :: 5 - Production/Stable
21a20,21
> Classifier: Operating System :: POSIX
> Classifier: Framework :: Jupyter
diff -r before-dist/whl/jupyterhub-4.1.0.dev0.dist-info/RECORD after-dist/whl/jupyterhub-4.1.0.dev0.dist-info/RECORD
99a100,102
> jupyterhub/tests/browser/__init__.py,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
> jupyterhub/tests/browser/conftest.py,sha256=8HKvMbCA_uD8HSTyzGP3VfKpb3EkG9LHy7KIPLl8U7o,448
> jupyterhub/tests/browser/test_browser.py,sha256=5op0zLdV3w-qAC_zhobAPfUh6lwYxlOqjqamMUcS7Kk,42813
956c959
< jupyterhub-4.1.0.dev0.dist-info/METADATA,sha256=Cfha52zvuqNpi4vypm-MHU7ln2NhCy2ZxHOy8swrCWk,13973
---
> jupyterhub-4.1.0.dev0.dist-info/METADATA,sha256=emHRqSGCGeKjqCos1hJZckUutPBE0v0cFFgLrzNZCPA,14091
```

</details>

Comparing all the files in sdists and wheels shows there are no files that were previously included that are lost. Almost all of the changes are files in the repo previously excluded from sdists due to their absence from MANIFEST.in, now included automatically by `setuptools-scm`.

<details>
<summary>

```
diff -rq before-dist after-dist
```

</summary>


```
Only in after-dist/jupyterhub-4.1.0.dev0: .coveragerc
Only in after-dist/jupyterhub-4.1.0.dev0: .dockerignore
Only in after-dist/jupyterhub-4.1.0.dev0: .flake8
Only in after-dist/jupyterhub-4.1.0.dev0: .github
Only in after-dist/jupyterhub-4.1.0.dev0: .gitignore
Only in after-dist/jupyterhub-4.1.0.dev0: .pre-commit-config.yaml
Only in after-dist/jupyterhub-4.1.0.dev0: .prettierignore
Only in after-dist/jupyterhub-4.1.0.dev0: .readthedocs.yaml
Only in after-dist/jupyterhub-4.1.0.dev0: CODE_OF_CONDUCT.md
Only in after-dist/jupyterhub-4.1.0.dev0: CONTRIBUTING.md
Files before-dist/jupyterhub-4.1.0.dev0/PKG-INFO and after-dist/jupyterhub-4.1.0.dev0/PKG-INFO differ
Only in after-dist/jupyterhub-4.1.0.dev0: RELEASE.md
Only in after-dist/jupyterhub-4.1.0.dev0: SECURITY.md
Only in after-dist/jupyterhub-4.1.0.dev0: demo-image
Only in after-dist/jupyterhub-4.1.0.dev0: dockerfiles
Only in after-dist/jupyterhub-4.1.0.dev0: examples
Files before-dist/jupyterhub-4.1.0.dev0/jupyterhub.egg-info/PKG-INFO and after-dist/jupyterhub-4.1.0.dev0/jupyterhub.egg-info/PKG-INFO differ
Files before-dist/jupyterhub-4.1.0.dev0/jupyterhub.egg-info/SOURCES.txt and after-dist/jupyterhub-4.1.0.dev0/jupyterhub.egg-info/SOURCES.txt differ
Files before-dist/jupyterhub-4.1.0.dev0/pyproject.toml and after-dist/jupyterhub-4.1.0.dev0/pyproject.toml differ
Only in after-dist/jupyterhub-4.1.0.dev0: pytest.ini
Files before-dist/jupyterhub-4.1.0.dev0/setup.py and after-dist/jupyterhub-4.1.0.dev0/setup.py differ
Files before-dist/jupyterhub-4.1.0.dev0/share/jupyterhub/static/css/style.min.css.map and after-dist/jupyterhub-4.1.0.dev0/share/jupyterhub/static/css/style.min.css.map differ
Only in after-dist/jupyterhub-4.1.0.dev0: testing
Files before-dist/jupyterhub-4.1.0.dev0-py3-none-any.whl and after-dist/jupyterhub-4.1.0.dev0-py3-none-any.whl differ
Files before-dist/jupyterhub-4.1.0.dev0.tar.gz and after-dist/jupyterhub-4.1.0.dev0.tar.gz differ
Only in after-dist/whl/jupyterhub/tests: browser
Files before-dist/whl/jupyterhub-4.1.0.dev0.data/data/share/jupyterhub/static/css/style.min.css.map and after-dist/whl/jupyterhub-4.1.0.dev0.data/data/share/jupyterhub/static/css/style.min.css.map differ
Files before-dist/whl/jupyterhub-4.1.0.dev0.dist-info/METADATA and after-dist/whl/jupyterhub-4.1.0.dev0.dist-info/METADATA differ
Files before-dist/whl/jupyterhub-4.1.0.dev0.dist-info/RECORD and after-dist/whl/jupyterhub-4.1.0.dev0.dist-info/RECORD differ
```

</details>