### PR TITLE
avoid counting failed requests to not-running servers as 'activity'

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1433,6 +1433,12 @@ class UserUrlHandler(BaseHandler):
     # accept token auth for API requests that are probably to non-running servers
     _accept_token_auth = True
 
+    # don't consider these redirects 'activity'
+    # if the redirect is followed and the subsequent action taken,
+    # _that_ is activity
+    def _record_activity(self, obj, timestamp=None):
+        return False
+
     def _fail_api_request(self, user_name='', server_name=''):
         """Fail an API request to a not-running server"""
         self.log.warning(


### PR DESCRIPTION
For example, when a user stops and a JupyterLab tab is left open, requests will be made to `/user/:name/api/...`. When these are handled by the Hub, they should not be considered 'activity', contributing to users' last activity metrics, etc.