### PR TITLE
Add missing param descriptions for `HubAuth`

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -596,6 +596,9 @@ class HubAuth(SingletonConfigurable):
         - in URL parameters: ?token=<token>
         - in header: Authorization: token <token>
         - in cookie (stored after oauth), if in_cookie is True
+
+        Args:
+            handler (tornado.web.RequestHandler): the current request handler
         """
 
         user_token = handler.get_argument('token', '')
@@ -623,6 +626,9 @@ class HubAuth(SingletonConfigurable):
         """Get the jupyterhub session id
 
         from the jupyterhub-session-id cookie.
+
+        Args:
+            handler (tornado.web.RequestHandler): the current request handler
         """
         return handler.get_cookie('jupyterhub-session-id', '')
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -950,7 +950,11 @@ class HubOAuth(HubAuth):
         handler.set_secure_cookie(self.cookie_name, access_token, **kwargs)
 
     def clear_cookie(self, handler):
-        """Clear the OAuth cookie"""
+        """Clear the OAuth cookie
+        
+        Args:
+            handler (tornado.web.RequestHandler): the current request handler
+        """
         handler.clear_cookie(self.cookie_name, path=self.base_url)
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -951,7 +951,7 @@ class HubOAuth(HubAuth):
 
     def clear_cookie(self, handler):
         """Clear the OAuth cookie
-        
+
         Args:
             handler (tornado.web.RequestHandler): the current request handler
         """


### PR DESCRIPTION
Hi,
The description for param `handler` was missing in 2 methods.
This PR just helps to understand what is expected to use them.