### PR TITLE
orm: trade backref for back_populates

### DIFF
--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -217,11 +217,7 @@ class Group(Base):
     properties = Column(JSONDict, default={})
 
     def __repr__(self):
-        return "<%s %s (%i users)>" % (
-            self.__class__.__name__,
-            self.name,
-            len(self.users),
-        )
+        return f"<{self.__class__.__name__} {self.name}>"
 
     @classmethod
     def find(cls, db, name):


### PR DESCRIPTION
relationship.backref is [considered legacy](https://docs.sqlalchemy.org/en/20/orm/backref.html), in favor of the more explicit "back_populates". This changes no behavior at all, only changing how bi-directional relationships are defined, trading:

```python
class A:
  b = relationship("B", backref="a")

class B:
  # has B.a dynamically defined from the above backref without anything declared on 'B' itself
```

for the more explicit and symmetrical

```python
class A:
  b = relationship("B", back_populates="a")

class B:
  a = relationship("A", back_populates="b")
```

Extracted from #4494 so that I can rebase that one to show only actual changes in behavior, rather than including a refactor that has no changes.

Also includes a tiny repr change on orm.Group, which was costly because it fetched all users in the group!