### PR TITLE
Documentation for RTC for JupyterLab >= 4.0

### DIFF
--- a/docs/source/tutorial/collaboration-users.md
+++ b/docs/source/tutorial/collaboration-users.md
@@ -6,6 +6,10 @@
 It is recommended to use at least JupyterLab 3.6 with JupyterHub >= 3.1.1 for this.
 :::
 
+:::{note}
+If you use the JupyterLab >=4.0 you need to install the [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration) package in your single-user notebook instance. 
+:::
+
 JupyterLab has support for real-time collaboration (RTC), where multiple users are working with the same Jupyter server and see each other's edits.
 Beyond other collaborative-editing environments, Jupyter includes _execution_.
 So granting someone access to your server also means granting them access to **run code as you**.

--- a/docs/source/tutorial/collaboration-users.md
+++ b/docs/source/tutorial/collaboration-users.md
@@ -7,7 +7,7 @@ It is recommended to use at least JupyterLab 3.6 with JupyterHub >= 3.1.1 for th
 :::
 
 :::{note}
-If you use the JupyterLab >=4.0 you need to install the [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration) package in your single-user notebook instance.
+Starting with JupyterLab >=4.0, installing the [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration) package in your single-user environment enables collaborative mode, instead of passing the `--collaborative` flag at runtime.
 :::
 
 JupyterLab has support for real-time collaboration (RTC), where multiple users are working with the same Jupyter server and see each other's edits.

--- a/docs/source/tutorial/collaboration-users.md
+++ b/docs/source/tutorial/collaboration-users.md
@@ -7,7 +7,7 @@ It is recommended to use at least JupyterLab 3.6 with JupyterHub >= 3.1.1 for th
 :::
 
 :::{note}
-If you use the JupyterLab >=4.0 you need to install the [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration) package in your single-user notebook instance. 
+If you use the JupyterLab >=4.0 you need to install the [jupyter-collaboration](https://github.com/jupyterlab/jupyter-collaboration) package in your single-user notebook instance.
 :::
 
 JupyterLab has support for real-time collaboration (RTC), where multiple users are working with the same Jupyter server and see each other's edits.


### PR DESCRIPTION
Hello,

since the `--collaborative` feature of JupyterLab was moved to the external https://github.com/jupyterlab/jupyter-collaboration package it is necessary to install it inside the single-user JupyterLab instance. Moreover, the jupyterlab instance will crash on startup if you will try to run it with the `--LabApp.collaborative=True` flag when no package is installed.