### PR TITLE
Fix external-oauth example jupyterhub_config.py

### DIFF
--- a/examples/external-oauth/jupyterhub_config.py
+++ b/examples/external-oauth/jupyterhub_config.py
@@ -1,16 +1,5 @@
 import os
 
-# Allow anyone to authenticate
-from jupyterhub.auth import DummyAuthenticator
-
-c.JupyterHub.authenticator_class = DummyAuthenticator
-
-# Optionally set a global password that all users must use
-# c.DummyAuthenticator.password = "your_password"
-
-# only listen on localhost for testing.
-c.JupyterHub.bind_url = 'http://127.0.0.1:8000'
-
 # get the oauth client's API token.
 # this could come from anywhere
 api_token = os.getenv("JUPYTERHUB_API_TOKEN")
@@ -38,3 +27,17 @@ c.JupyterHub.load_roles = [
     }
 
 ]
+
+# Boilerplate to make sure the example runs - this is not relevant
+# to external oauth services.
+
+# Allow authentication with any username and any password
+from jupyterhub.auth import DummyAuthenticator
+
+c.JupyterHub.authenticator_class = DummyAuthenticator
+
+# Optionally set a global password that all users must use
+# c.DummyAuthenticator.password = "your_password"
+
+# only listen on localhost for testing.
+c.JupyterHub.bind_url = 'http://127.0.0.1:8000'

--- a/examples/external-oauth/jupyterhub_config.py
+++ b/examples/external-oauth/jupyterhub_config.py
@@ -1,5 +1,16 @@
 import os
 
+# Allow anyone to authenticate
+from jupyterhub.auth import DummyAuthenticator
+
+c.JupyterHub.authenticator_class = DummyAuthenticator
+
+# Optionally set a global password that all users must use
+# c.DummyAuthenticator.password = "your_password"
+
+# only listen on localhost for testing.
+c.JupyterHub.bind_url = 'http://127.0.0.1:8000'
+
 # get the oauth client's API token.
 # this could come from anywhere
 api_token = os.getenv("JUPYTERHUB_API_TOKEN")
@@ -9,7 +20,6 @@ if not api_token:
     )
 
 # tell JupyterHub to register the service as an external oauth client
-
 c.JupyterHub.services = [
     {
         'name': 'external-oauth',
@@ -17,4 +27,14 @@ c.JupyterHub.services = [
         'api_token': api_token,
         'oauth_redirect_uri': 'http://127.0.0.1:5555/oauth_callback',
     }
+]
+
+# Grant all JupyterHub users ability to access services
+c.JupyterHub.load_roles = [
+    {
+        'name': 'user',
+        'description': 'Allow all users to access all services',
+        'scopes': ['access:services', 'self'],
+    }
+
 ]

--- a/examples/external-oauth/jupyterhub_config.py
+++ b/examples/external-oauth/jupyterhub_config.py
@@ -25,7 +25,6 @@ c.JupyterHub.load_roles = [
         'description': 'Allow all users to access all services',
         'scopes': ['access:services', 'self'],
     }
-
 ]
 
 # Boilerplate to make sure the example runs - this is not relevant


### PR DESCRIPTION
- Roles need to be explicitly granted, otherwise you get a
  403. This example predates roles.
- Explicitly set bind_url - without this, JupyterHub itself doesn't seem to bind anywhere, and so you just get a 404 when you visit whatever port configurable-http-proxy lands on. This is probably a separate bug to be investigated, but in the meantime copying this from testing/jupyterhub_config.py makes this example actually work
- Set DummyAuthenticator as the default, so users can get started with this example