### PR TITLE
singleuser extension: persist token from ?token=... url in cookie

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -686,6 +686,31 @@ class HubAuth(SingletonConfigurable):
         """Check whether the user has required scope(s)"""
         return check_scopes(required_scopes, set(user["scopes"]))
 
+    def _persist_url_token(self, handler):
+        """Persist ?token=... from URL in cookie
+
+        for use in future cookie-authenticated requests.
+
+        Allows initiating an authenticated session
+        via /user/name/?token=abc...,
+        otherwise only the initial request will be authenticated.
+        """
+        url_token = handler.get_argument('token', '')
+        if not url_token:
+            # no token to persist
+            return
+        # only do this if the token in the URL is the source of authentication
+        if not getattr(handler, '_token_authenticated', False):
+            return
+        if not hasattr(self, 'set_cookie'):
+            # only HubOAuth can persist cookies
+            return
+        self.log.info(
+            "Storing token from url in cookie for %s",
+            handler.request.remote_ip,
+        )
+        self.set_cookie(handler, url_token)
+
 
 class HubOAuth(HubAuth):
     """HubAuth using OAuth for login instead of cookies set by the Hub.
@@ -1175,18 +1200,8 @@ class HubAuthenticated:
             self._hub_auth_user_cache = None
             raise
 
-        # store ?token=... tokens passed via url in a cookie for future requests
-        url_token = self.get_argument('token', '')
-        if (
-            user_model
-            and url_token
-            and getattr(self, '_token_authenticated', False)
-            and hasattr(self.hub_auth, 'set_cookie')
-        ):
-            # authenticated via `?token=`
-            # set a cookie for future requests
-            # hub_auth.set_cookie is only available on HubOAuth
-            self.hub_auth.set_cookie(self, url_token)
+        if self.get_argument('token', ''):
+            self.hub_auth._persist_url_token(self)
         return self._hub_auth_user_cache
 
 

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -686,14 +686,16 @@ class HubAuth(SingletonConfigurable):
         """Check whether the user has required scope(s)"""
         return check_scopes(required_scopes, set(user["scopes"]))
 
-    def _persist_url_token(self, handler):
-        """Persist ?token=... from URL in cookie
+    def _persist_url_token_if_set(self, handler):
+        """Persist ?token=... from URL in cookie if set
 
         for use in future cookie-authenticated requests.
 
         Allows initiating an authenticated session
         via /user/name/?token=abc...,
         otherwise only the initial request will be authenticated.
+
+        No-op if no token URL parameter is given.
         """
         url_token = handler.get_argument('token', '')
         if not url_token:
@@ -1200,8 +1202,7 @@ class HubAuthenticated:
             self._hub_auth_user_cache = None
             raise
 
-        if self.get_argument('token', ''):
-            self.hub_auth._persist_url_token(self)
+        self.hub_auth._persist_url_token_if_set(self)
         return self._hub_auth_user_cache
 
 

--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -149,31 +149,6 @@ class JupyterHubIdentityProvider(IdentityProvider):
 
         handler.get_login_url = get_login_url
 
-    def _persist_url_token(self, handler):
-        """Persist ?token=... from URL in cookie
-
-        for use in future requests.
-
-        Allows initiating an authenticated session
-        via /user/name/?token=abc...,
-        otherwise only the initial request will be authenticated.
-        """
-        # store ?token=... tokens passed via url in a cookie for future requests
-        url_token = handler.get_argument('token', '')
-        if not url_token:
-            return
-        # only do this if the token in the URL is the source of authentication
-        if not getattr(handler, '_token_authenticated', False):
-            return
-        if not hasattr(self.hub_auth, 'set_cookie'):
-            # only HubOAuth can persist cookies
-            return
-        self.log.info(
-            "Storing token from url in cookie for %s",
-            handler.request.remote_ip,
-        )
-        self.hub_auth.set_cookie(handler, url_token)
-
     async def get_user(self, handler):
         if hasattr(handler, "_jupyterhub_user"):
             return handler._jupyterhub_user
@@ -212,8 +187,7 @@ class JupyterHubIdentityProvider(IdentityProvider):
 
             return None
         handler._jupyterhub_user = JupyterHubUser(user)
-        if handler.get_argument('token', ''):
-            self.hub_auth._persist_url_token(handler)
+        self.hub_auth._persist_url_token_if_set(handler)
         return handler._jupyterhub_user
 
     def get_handlers(self):

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -20,6 +20,12 @@ from .utils import AsyncSession, async_requests, get_page
 IS_JUPYVERSE = os.environ.get("JUPYTERHUB_SINGLEUSER_APP") == "jupyverse"
 
 
+@pytest.fixture(autouse=True)
+def _jupyverse(app):
+    if IS_JUPYVERSE:
+        app.config.Spawner.default_url = "/lab"
+
+
 @pytest.mark.parametrize(
     "access_scopes, server_name, expect_success",
     [
@@ -65,8 +71,6 @@ async def test_singleuser_auth(
         await user.spawn(server_name)
         await app.proxy.add_user(user, server_name)
     spawner = user.spawners[server_name]
-    if IS_JUPYVERSE:
-        spawner.default_url = "/lab"
     url = url_path_join(public_url(app, user), server_name)
 
     # no cookies, redirects to login page
@@ -373,3 +377,21 @@ async def test_nbclassic_control_panel(app, user, full_spawn):
     else:
         prefix = app.base_url
     assert link["href"] == url_path_join(prefix, "hub/home")
+
+
+async def test_token_url_cookie(app, user, full_spawn):
+    await user.spawn()
+    token = user.new_api_token(scopes=["access:servers!user"])
+    url = url_path_join(public_url(app, user), user.spawner.default_url or "/tree/")
+
+    # first request: auth with token in URL
+    r = await async_requests.get(url + f"?token={token}", allow_redirects=False)
+    print(r.url, r.status_code)
+    assert r.status_code == 200
+    assert r.cookies
+    # second request, use cookies set by first response,
+    # no token in URL
+    r = await async_requests.get(url, cookies=r.cookies, allow_redirects=False)
+    assert r.status_code == 200
+
+    await user.stop()

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -379,6 +379,9 @@ async def test_nbclassic_control_panel(app, user, full_spawn):
     assert link["href"] == url_path_join(prefix, "hub/home")
 
 
+@pytest.mark.skipif(
+    IS_JUPYVERSE, reason="jupyverse doesn't implement token authentication"
+)
 async def test_token_url_cookie(app, user, full_spawn):
     await user.spawn()
     token = user.new_api_token(scopes=["access:servers!user"])


### PR DESCRIPTION
matches pre-extension behavior

consolidated code to HubAuth, so it's easier to re-use, but logic is unchanged.

Reported [on the forum](https://discourse.jupyter.org/t/websocket-http-error-403/21141/8)