### PR TITLE
fix mutation of frozenset in scope intersection

### DIFF
--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -257,8 +257,12 @@ def _intersect_expanded_scopes(scopes_a, scopes_b, db=None):
             }
 
             # resolve hierarchies (group/user/server) in both directions
-            common_servers = common_filters[base].get("server", set())
-            common_users = common_filters[base].get("user", set())
+            common_servers = initial_common_servers = common_filters[base].get(
+                "server", frozenset()
+            )
+            common_users = initial_common_users = common_filters[base].get(
+                "user", frozenset()
+            )
 
             for a, b in [(filters_a, filters_b), (filters_b, filters_a)]:
                 if 'server' in a and b.get('server') != a['server']:
@@ -270,7 +274,7 @@ def _intersect_expanded_scopes(scopes_a, scopes_b, db=None):
                         for server in servers:
                             username, _, servername = server.partition("/")
                             if username in b['user']:
-                                common_servers.add(server)
+                                common_servers = common_servers | {server}
 
                     # resolve group/server hierarchy if db available
                     servers = servers.difference(common_servers)
@@ -279,7 +283,7 @@ def _intersect_expanded_scopes(scopes_a, scopes_b, db=None):
                         for server in servers:
                             server_groups = groups_for_server(server)
                             if server_groups & b['group']:
-                                common_servers.add(server)
+                                common_servers = common_servers | {server}
 
                 # resolve group/user hierarchy if db available and user sets aren't identical
                 if (
@@ -293,14 +297,16 @@ def _intersect_expanded_scopes(scopes_a, scopes_b, db=None):
                     for username in users:
                         groups = groups_for_user(username)
                         if groups & b["group"]:
-                            common_users.add(username)
+                            common_users = common_users | {username}
 
-            # add server filter if there wasn't one before
-            if common_servers and "server" not in common_filters[base]:
+            # add server filter if it's non-empty
+            # and it changed
+            if common_servers and common_servers != initial_common_servers:
                 common_filters[base]["server"] = common_servers
 
-            # add user filter if it's non-empty and there wasn't one before
-            if common_users and "user" not in common_filters[base]:
+            # add user filter if it's non-empty
+            # and it changed
+            if common_users and common_users != initial_common_users:
                 common_filters[base]["user"] = common_users
 
     intersection = unparse_scopes(common_filters)

--- a/jupyterhub/tests/test_scopes.py
+++ b/jupyterhub/tests/test_scopes.py
@@ -912,6 +912,22 @@ def test_intersect_expanded_scopes(left, right, expected, should_warn, recwarn):
             ["read:users!user=uy"],
             {"gx": ["ux"], "gy": ["uy"]},
         ),
+        (
+            # make sure the group > user > server hierarchy
+            # is managed
+            ["read:servers!server=ux/server", "read:servers!group=gy"],
+            ["read:servers!server=uy/server", "read:servers!user=ux"],
+            ["read:servers!server=ux/server", "read:servers!server=uy/server"],
+            {"gx": ["ux"], "gy": ["uy"]},
+        ),
+        (
+            # make sure the group > user hierarchy
+            # is managed
+            ["read:servers!user=ux", "read:servers!group=gy"],
+            ["read:servers!user=uy", "read:servers!group=gx"],
+            ["read:servers!user=ux", "read:servers!user=uy"],
+            {"gx": ["ux"], "gy": ["uy"]},
+        ),
     ],
 )
 def test_intersect_groups(request, db, left, right, expected, groups):


### PR DESCRIPTION
In the unusual situation of:

1. both sides having a filter on `servers`
2. those filters being different
3. _and_ some permissions are granted via higher-level group or user membership

the logic wasn't correct, and clearly untested because the `.add` was called on a frozenzet, which has no `.add`.

closes #4569 