### PR TITLE
Don't log user model on auth by default

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -1255,6 +1255,7 @@ class HubOAuthCallbackHandler(HubOAuthenticated, RequestHandler):
         )
         if user_model is None:
             raise HTTPError(500, "oauth callback failed to identify a user")
-        app_log.info("Logged-in user %s", user_model)
+        app_log.info("Logged-in user %s", user_model['name'])
+        app_log.debug("User model %s", user_model)
         self.hub_auth.set_cookie(self, token)
         self.redirect(next_url or self.hub_auth.base_url)


### PR DESCRIPTION
This is a suggestion to hide the user model from the logs (by default, with possibility to still get it in debug mode).

We might send these logs to external services for storing and this way we avoid sending unwanted info (in our case, we make the auth state available to jupyter, so logging the full user model exposes users' tokens).

Let me know if you prefer to have a bit more information or the username is enough (we can always correlate with jupyterhub logs).

(btw, do you want open tickets that gets solved by PRs or PRs can stand by themselves?)