### PR TITLE
temp ci fix: pin down traitlets in oldest_dependencies test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
           fi
           if [ "${{ matrix.legacy_notebook }}" != "" ]; then
               pip uninstall jupyter_server --yes
-              pip install 'notebook<7'
+              pip install 'notebook<7' 'traitlets<5'
           fi
           if [ "${{ matrix.jupyter_server }}" != "" ]; then
               pip install "jupyter_server==${{ matrix.jupyter_server }}"


### PR DESCRIPTION
because the bigger fix is proving more complicated (#4571), this should get CI passing in the meantime.