### PR TITLE
Improve requests for tokens with scopes

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -552,7 +552,11 @@ paths:
         - oauth2:
             - read:tokens
     post:
-      summary: Create a new token for the user
+      summary: |
+        Create a new token for the user.
+        Permissions can be limited by specifying a list of `scopes` in the JSON request body
+        (starting in JupyerHub 3.0; previously, permissions could be specified as `roles` could be specified,
+        which is deprecated in 3.0).
       parameters:
         - name: name
           in: path

--- a/docs/source/rbac/scopes.md
+++ b/docs/source/rbac/scopes.md
@@ -300,6 +300,11 @@ Custom scope _filters_ are NOT supported.
 
 ### Scopes and APIs
 
-The scopes are also listed in the [](jupyterhub-rest-API) documentation. Each API endpoint has a list of scopes which can be used to access the API; if no scopes are listed, the API is not authenticated and can be accessed without any permissions (i.e., no scopes).
+The scopes are also listed in the [](jupyterhub-rest-API) documentation.
+Each API endpoint has a list of scopes which can be used to access the API;
+if no scopes are listed, the API is not authenticated and can be accessed without any permissions (i.e., no scopes).
 
-Listed scopes by each API endpoint reflect the "lowest" permissions required to gain any access to the corresponding API. For example, posting user's activity (_POST /users/:name/activity_) needs `users:activity` scope. If scope `users` is passed during the request, the access will be granted as the required scope is a subscope of the `users` scope. If, on the other hand, `read:users:activity` scope is passed, the access will be denied.
+Listed scopes by each API endpoint reflect the "lowest" permissions required to gain any access to the corresponding API.
+For example, posting user's activity (_POST /users/:name/activity_) needs `users:activity` scope.
+If scope `users` is held by the request, the access will be granted as the required scope is a subscope of the `users` scope.
+If, on the other hand, `read:users:activity` scope is the only scope held, the request will be denied.

--- a/share/jupyterhub/static/js/token.js
+++ b/share/jupyterhub/static/js/token.js
@@ -22,19 +22,31 @@ require(["jquery", "jhapi", "moment"], function ($, JHAPI, moment) {
     }
     var expiration_seconds =
       parseInt($("#token-expiration-seconds").val()) || null;
-    api.request_token(
-      user,
-      {
-        note: note,
-        expires_in: expiration_seconds,
+
+    var scope_text = $("#token-scopes").val() || "";
+
+    // split on commas and/or space
+    var scope_list = scope_text.split(/[\s,]+/).filter(function (scope) {
+      // filter out empty scopes
+      return scope.length > 0;
+    });
+
+    var request_body = {
+      note: note,
+      expires_in: expiration_seconds,
+    };
+
+    if (scope_list.length > 0) {
+      // add scopes to body, if defined
+      request_body.scopes = scope_list;
+    }
+
+    api.request_token(user, request_body, {
+      success: function (reply) {
+        $("#token-result").text(reply.token);
+        $("#token-area").show();
       },
-      {
-        success: function (reply) {
-          $("#token-result").text(reply.token);
-          $("#token-area").show();
-        },
-      },
-    );
+    });
     return false;
   });
 

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -20,7 +20,7 @@
         <small id="note-note" class="form-text text-muted">
           This note will help you keep track of what your tokens are for.
         </small>
-        <br><br>
+        <br/>
         <label for="token-expiration-seconds">Token expires in</label>
         {% block expiration_options %}
         <select id="token-expiration-seconds"
@@ -34,6 +34,14 @@
         {% endblock expiration_options %}
         <small id="note-expires-at" class="form-text text-muted">
           You can configure when your token will expire.
+        </small>
+        <br/>
+        <label for="token-scopes">Permissions</label>
+        <input id="token-scopes" class="form-control" placeholder="list of scopes for the token to have, separated by space">
+        <small id="note-token-scopes" class="form-text text-muted">
+          You can limit the permissions of the token so it can only do what you want it to.
+          If none are specified, the token will have permission to do everything you can do.
+          See the <a href="https://jupyterhub.readthedocs.io/en/stable/rbac/scopes.html#available-scopes">JupyterHub documentation for a list of available scopes</a>.
         </small>
       </div>
     </form>
@@ -59,17 +67,18 @@
   </div>
 
   {% if api_tokens %}
-  <div class="row">
+  <div class="row" id="api-tokens-section">
     <h2>API Tokens</h2>
     <p>
       These are tokens with access to the JupyterHub API.
       Permissions for each token may be viewed via the JupyterHub tokens API.
       Revoking the API token for a running server will require restarting that server.
     </p>
-    <table class="table table-striped">
+    <table class="table table-striped" id="api-tokens-table">
       <thead>
         <tr>
           <th>Note</th>
+          <th>Permissions</th>
           <th>Last used</th>
           <th>Created</th>
           <th>Expires</th>
@@ -79,7 +88,15 @@
         {% for token in api_tokens %}
         <tr class="token-row" data-token-id="{{token.api_id}}">
           {% block token_row scoped %}
-          <td class="note-col col-sm-5">{{token.note}}</td>
+          <td class="note-col col-sm-4">{{token.note}}</td>
+          <td class="scope-col col-sm-1">
+            <details>
+              <summary>scopes</summary>
+                {% for scope in token.scopes %}
+                <pre class="token-scope">{{ scope }}</pre>
+                {% endfor %}
+            </details>
+          </td>
           <td class="time-col col-sm-3">
             {%- if token.last_activity -%}
             {{ token.last_activity.isoformat() + 'Z' }}
@@ -113,7 +130,7 @@
   {% endif %}
 
   {% if oauth_clients %}
-  <div class="row">
+  <div class="row" id="oauth-clients-section">
     <h2>Authorized Applications</h2>
     <p>
       These are applications that use OAuth with JupyterHub
@@ -122,10 +139,11 @@
       OAuth tokens can generally only be used to identify you,
       not take actions on your behalf.
     </p>
-    <table class="table table-striped">
+    <table class="table table-striped" id="oauth-tokens-table">
       <thead>
         <tr>
           <th>Application</th>
+          <th>Permissions</th>
           <th>Last used</th>
           <th>First authorized</th>
         </tr>
@@ -135,7 +153,18 @@
         <tr class="token-row"
           data-token-id="{{ client['token_id'] }}">
           {% block client_row scoped %}
-          <td class="note-col col-sm-5">{{ client['description'] }}</td>
+          <td class="note-col col-sm-4">{{ client['description'] }}</td>
+          <td class="scope-col col-sm-1">
+            <details>
+              <summary>scopes</summary>
+                {# create  set of scopes on all tokens -#}
+                {# sum concatenates all token.scopes into a single list -#}
+                {# then filter to unique set and sort -#}
+                {% for scope in client.tokens | sum(attribute="scopes", start=[]) | unique | sort %}
+                <pre class="token-scope">{{ scope }}</pre>
+                {% endfor %}
+            </details>
+          </td>
           <td class="time-col col-sm-3">
             {%- if client['last_activity'] -%}
             {{ client['last_activity'].isoformat() + 'Z' }}


### PR DESCRIPTION
- Docs update with specific example requesting token with scopes via API (closes #4576)
- Handler update for better error handling of invalid scopes (some invalid inputs would register as 500 instead of 400)
- Add input for permissions in token request form
- Add permissions column to token tables


I had been holding off on permissions inputs in the form since it really _should_ be a nice checkbox-list form of scopes with explanations (much like the permissions form on the oauth authorization page). This is tricky to get right, especially when exposing all the filter options, like !user, !user=someoneelse, !group=g, !server, !server=specific. But rather than waiting for that hard problem to be solved before we have _any_ way to request tokens with scopes, do the simple thing of a free text field so folks can type the scopes they want. Not the nicest, but at least it's fully capable, and the nice UI can be a later enhancement.


https://github.com/jupyterhub/jupyterhub/assets/151929/1c2c32dd-03cc-4e99-ab6a-f3323cc4477c


