### PR TITLE
update nodesource installation in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update -qq \
     ca-certificates \
     curl \
     git \
+    gnupg \
     locales \
     python3-dev \
     python3-pip \
@@ -53,7 +54,11 @@ RUN apt-get update -qq \
  && python3 -m pip install --no-cache-dir --upgrade setuptools pip build wheel
 # Ubuntu 22.04 comes with Nodejs 12 which is too old for building JupyterHub JS
 # It's fine at runtime though (used only by configurable-http-proxy)
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+ARG NODE_MAJOR=20
+RUN mkdir -p /etc/apt/keyrings \
+ && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+ && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+ && apt-get update \
  && apt-get install -yqq --no-install-recommends \
     nodejs \
  && npm install --global yarn


### PR DESCRIPTION
the setup script has been deprecated and adds a 60s wait

includes #4596 to avoid conflict on  `git` vs `gnupg` in the apt install list

updates node runtime to 20 in the build. This should be inconsequential since it doesn't affect the final image, which doesn't use nodesource.