### PR TITLE
Change `db_url` schema in docs from `postgres` to `postgresql`

### DIFF
--- a/docs/source/explanation/database.md
+++ b/docs/source/explanation/database.md
@@ -143,14 +143,14 @@ We recommend using PostgreSQL for production if you are unsure whether to use
 MySQL or PostgreSQL or if you do not have a strong preference.
 There is additional configuration required for MySQL that is not needed for PostgreSQL.
 
-For example, to connect to a postgres database with psycopg2:
+For example, to connect to a PostgreSQL database with psycopg2:
 
 1. install psycopg2: `pip install psycopg2` (or `psycopg2-binary` to avoid compilation, which is [not recommended for production][psycopg2-binary])
 2. set authentication via environment variables `PGUSER` and `PGPASSWORD`
 3. configure [](JupyterHub.db_url):
 
    ```python
-   c.JupyterHub.db_url = "postgres+psycopg2://my-postgres-server:5432/my-db-name"
+   c.JupyterHub.db_url = "postgresql+psycopg2://my-postgres-server:5432/my-db-name"
    ```
 
 [psycopg2-binary]: https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary


### PR DESCRIPTION
SQLAlchemy no longer supports `postgres` schema