### PR TITLE
test: ensure test server is added to proxy before talking to it

### DIFF
--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -363,6 +363,7 @@ def test_singleuser_app_class(JUPYTERHUB_SINGLEUSER_APP):
 async def test_nbclassic_control_panel(app, user, full_spawn):
     # login, start the server
     await user.spawn()
+    await app.proxy.add_user(user)
     cookies = await app.login_user(user.name)
     next_url = url_path_join(user.url, "tree/")
     url = '/?' + urlencode({'next': next_url})
@@ -384,6 +385,7 @@ async def test_nbclassic_control_panel(app, user, full_spawn):
 )
 async def test_token_url_cookie(app, user, full_spawn):
     await user.spawn()
+    await app.proxy.add_user(user)
     token = user.new_api_token(scopes=["access:servers!user"])
     url = url_path_join(public_url(app, user), user.spawner.default_url or "/tree/")
 


### PR DESCRIPTION
this should fix some flaky test failures in test_singleuser like [this one](https://github.com/jupyterhub/jupyterhub/actions/runs/6665391840/job/18114866017#step:11:1074):

```
FAILED jupyterhub/tests/test_singleuser.py::test_token_url_cookie - assert 302 == 200
   +  where 302 = <Response [302]>.status_code
```

I think the reason it doesn't always fail is that `proxy.check_routes()` is running in the background and will add the route when it sees it's missing.