### PR TITLE
try to improve reliability of test_external_proxy

### DIFF
--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -9,6 +9,7 @@ import pytest
 from traitlets import TraitError
 from traitlets.config import Config
 
+from ..utils import random_port
 from ..utils import url_path_join as ujoin
 from ..utils import wait_for_http_server
 from .mocking import MockHub
@@ -27,10 +28,11 @@ def disable_check_routes(app):
 
 
 @skip_if_ssl
+@pytest.mark.flaky(reruns=2)
 async def test_external_proxy(request):
     auth_token = 'secret!'
     proxy_ip = '127.0.0.1'
-    proxy_port = 54321
+    proxy_port = random_port()
     cfg = Config()
     cfg.ConfigurableHTTPProxy.auth_token = auth_token
     cfg.ConfigurableHTTPProxy.api_url = 'http://%s:%i' % (proxy_ip, proxy_port)
@@ -127,7 +129,7 @@ async def test_external_proxy(request):
     proxy.wait(timeout=10)
     new_auth_token = 'different!'
     env['CONFIGPROXY_AUTH_TOKEN'] = new_auth_token
-    proxy_port = 55432
+    proxy_port = random_port()
     cmd = [
         'configurable-http-proxy',
         '--ip',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ test = [
   "pytest>=3.3",
   "pytest-asyncio>=0.17",
   "pytest-cov",
+  "pytest-rerunfailures",
   "requests-mock",
   "playwright",
   "virtualenv",


### PR DESCRIPTION
- use random ports instead of pre-specified numbers, which may collide
- mark test as flaky to give it a second chance to succeed


This test has [failed intermittently](https://github.com/jupyterhub/jupyterhub/actions/runs/6574430927/job/18080283121) with port collisions, like this one:

```
12:05:28.756 [ConfigProxy] info: Proxy API at http://127.0.0.1:55432/api/routes
  12:05:28.758 [ConfigProxy] error: Uncaught Exception: listen EADDRINUSE: address already in use 127.0.0.1:55432
  12:05:28.758 [ConfigProxy] error: Error: listen EADDRINUSE: address already in use 127.0.0.1:55432
      at Server.setupListenHandle [as _listen2] (net.js:1331:16)
      at listenInCluster (net.js:1379:12)
      at doListen (net.js:1516:7)
      at processTicksAndRejections (internal/process/task_queues.js:83:21)
```

it's unclear exactly what it's colliding with, but using random ports may fix the issue, and marking the test as flaky should make it quite unlikely to fail (it's unlikely that _just_ marking it as flaky would fix it, since the collision is likely due to something outside the test allocating the requested port and it would just collide again if it tried the test on the same port a second time)