### PR TITLE
doc: Add the include_stopped_server field to the /users/name interface

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -209,6 +209,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: include_stopped_servers
+          in: query
+          description: Include stopped servers in user model(s).
+          schema:
+            type: boolean
+          allowEmptyValue: true
       responses:
         200:
           description: The User model


### PR DESCRIPTION
I would like to express my gratitude to the community and JupyterHub for providing a rich set of features that greatly facilitate my development work.

While querying for instances owned by each user, I noticed that by default, only running instances are queried. However, the include_stopped_servers field allows for querying instances that have stopped running. This is a useful feature, but it is not currently described in the documentation.

This pull request aims to add the necessary documentation for the include_stopped_servers query parameter to help other developers understand and utilize this feature.