### PR TITLE
Include LDAP groups in local spawner gids

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1481,7 +1481,7 @@ def set_user_setuid(username, chdir=True):
     uid = user.pw_uid
     gid = user.pw_gid
     home = user.pw_dir
-    gids = [g.gr_gid for g in grp.getgrall() if username in g.gr_mem]
+    gids = os.getgrouplist(username, gid)
 
     def preexec():
         """Set uid/gid of current process

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1474,7 +1474,6 @@ def set_user_setuid(username, chdir=True):
     Returned preexec_fn will set uid/gid, and attempt to chdir to the target user's
     home directory.
     """
-    import grp
     import pwd
 
     user = pwd.getpwnam(username)


### PR DESCRIPTION
The original code only returns local groups, at least with a Kerberos and LDAP setup with CentOS 7. The new code matches what `id` returns on that system.

Quick test script:

```python
import os
import grp
import pwd

username = "weber"
user =  pwd.getpwnam(username)
gid = user.pw_gid
old_gids = [g.gr_gid for g in grp.getgrall() if username in g.gr_mem]
new_gids = os.getgrouplist(username, gid)

print("old", old_gids)
print("new", new_gids)
```

```
(jupyterhub311) [weber@iff588 ~]$ id
uid=20335(weber) gid=68100(erc-1) groups=68100(erc-1),680(iff_ms),975(docker),1020(iff),68000(pgi-5)
(jupyterhub311) [weber@iff588 ~]$ python3 grouplist.py
old [975]
new [68100, 975, 68000, 1020, 680]
```