### PR TITLE
simplify, avoid errors in parsing accept headers

### DIFF
--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -165,3 +165,53 @@ def test_subdomain_hook_legacy(name, expected):
     expected_domain = expected + ".domain"
     resolved = utils.subdomain_hook_legacy(name, "domain", "user")
     assert resolved == expected_domain
+
+
+@pytest.mark.parametrize(
+    "accept_header, choices, expected",
+    [
+        (
+            "",
+            ["application/json"],
+            None,
+        ),
+        (
+            "text/html",
+            ["application/json"],
+            None,
+        ),
+        (
+            "nonsense",
+            ["application/json"],
+            None,
+        ),
+        (
+            "text/html, application/json",
+            ["application/json"],
+            "application/json",
+        ),
+        (
+            "text/html, application/json",
+            ["application/json", "text/html"],
+            "text/html",
+        ),
+        (
+            "text/html; q=0.8, application/json; q=0.9",
+            ["application/json", "text/html"],
+            "application/json",
+        ),
+        (
+            "text/html, application/json; q=0.9",
+            ["application/json", "text/html"],
+            "text/html",
+        ),
+        (
+            "text/html; q=notunderstood, application/json; q=0.9",
+            ["application/json", "text/html"],
+            "text/html",
+        ),
+    ],
+)
+def test_get_accepted_mimetype(accept_header, choices, expected):
+    accepted = utils.get_accepted_mimetype(accept_header, choices=choices)
+    assert accepted == expected

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -661,58 +661,34 @@ def utcnow():
 
 def _parse_accept_header(accept):
     """
-    Parse the Accept header *accept*
+    Parse the Accept header
 
-    Return a list with 3-tuples of
-    [(str(media_type), dict(params), float(q_value)),] ordered by q values.
-    If the accept header includes vendor-specific types like::
-        application/vnd.yourcompany.yourproduct-v1.1+json
-    It will actually convert the vendor and version into parameters and
-    convert the content type into `application/json` so appropriate content
-    negotiation decisions can be made.
+    Return a list with 2-tuples of
+    [(str(media_type), float(q_value)),] ordered by q values (descending).
+
     Default `q` for values that are not specified is 1.0
-
-    From: https://gist.github.com/samuraisam/2714195
     """
     result = []
+    if not accept:
+        return result
     for media_range in accept.split(","):
-        parts = media_range.split(";")
-        media_type = parts.pop(0).strip()
-        media_params = []
-        # convert vendor-specific content type to application/json
-        typ, subtyp = media_type.split('/')
-        # check for a + in the sub-type
-        if '+' in subtyp:
-            # if it exists, determine if the subtype is a vendor-specific type
-            vnd, sep, extra = subtyp.partition('+')
-            if vnd.startswith('vnd'):
-                # and then... if it ends in something like "-v1.1" parse the
-                # version out
-                if '-v' in vnd:
-                    vnd, sep, rest = vnd.rpartition('-v')
-                    if len(rest):
-                        # add the version as a media param
-                        try:
-                            version = media_params.append(('version', float(rest)))
-                        except ValueError:
-                            version = 1.0  # could not be parsed
-                # add the vendor code as a media param
-                media_params.append(('vendor', vnd))
-                # and re-write media_type to something like application/json so
-                # it can be used usefully when looking up emitters
-                media_type = f'{typ}/{extra}'
+        media_type, *parts = media_range.split(";")
+        media_type = media_type.strip()
+        if not media_type:
+            continue
 
         q = 1.0
         for part in parts:
-            (key, value) = part.lstrip().split("=", 1)
+            (key, _, value) = part.partition("=")
             key = key.strip()
-            value = value.strip()
             if key == "q":
-                q = float(value)
-            else:
-                media_params.append((key, value))
-        result.append((media_type, dict(media_params), q))
-    result.sort(key=itemgetter(2))
+                try:
+                    q = float(value)
+                except ValueError:
+                    pass
+                break
+        result.append((media_type, q))
+    result.sort(key=itemgetter(1), reverse=True)
     return result
 
 
@@ -725,7 +701,7 @@ def get_accepted_mimetype(accept_header, choices=None):
     Return `None` if choices is given and no match is found,
     or nothing is specified.
     """
-    for mime, params, q in _parse_accept_header(accept_header):
+    for mime, q in _parse_accept_header(accept_header):
         if choices:
             if mime in choices:
                 return mime


### PR DESCRIPTION
Certain Accept header values weren't handled (most critically, supplying no Accept header at all) could result in an error attempting to parse the header. q-value priority was also inverted.

The main change here is to remove a bunch of parsing of unused values and avoid server-side errors for empty or invalid values.