### PR TITLE
ETHZ added to references in documentation

### DIFF
--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -91,6 +91,12 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
     - log troubleshooting
     - Profiles in IPython Clusters tab
 
+### ETH Zurich
+
+[ETH Zurich](https://ethz.ch/en.html), also known as *Federal Institute of Technology Zurich*, is
+
+- [ETH Computational Competencies: JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
+
 ### George Washington University
 
 - [JupyterHub](https://go.gwu.edu/jupyter) with university single-sign-on. Deployed early 2017.

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -97,7 +97,7 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
 
 The [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) unit provides JupyterHub exclusively for teaching and learning, integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Each course gets its individually configured JupyterHub environment deployed on a on-premise Kubernetes cluster. 
 
-- [ETH Computational Competencies: LET JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
+- [ETH JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html) for teaching and learning
 
 ### George Washington University
 

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -93,15 +93,11 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
 
 ### ETH Zurich
 
-[ETH Zurich](https://ethz.ch/en.html), also known as *Federal Institute of Technology Zurich*, is
-
-- [ETH Computational Competencies: JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
-
-[ETH Zurich](https://ethz.ch/en.html) is a public research university in Zürich, Switzerland, with focus on science, technology, engineering, and mathematics, although its 16 departments span a variety of disciplines and subjects.
+[ETH Zurich](https://ethz.ch/en.html), also known as *Federal Institute of Technology Zurich*, is a public research university in Zürich, Switzerland, with focus on science, technology, engineering, and mathematics, although its 16 departments span a variety of disciplines and subjects.
 
 The administrative unit for [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) provides a JupyterHub exclusively for teaching and learning which is integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Every course gets its individually configured JupyterHub environment. 
 
-[LET Jupyter Hub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
+- [ETH Computational COmpetencies: LET JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
 
 
 

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -97,7 +97,7 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
 
 The administrative unit for [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) provides a JupyterHub exclusively for teaching and learning which is integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Every course gets its individually configured JupyterHub environment. 
 
-- [ETH Computational COmpetencies: LET JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
+- [ETH Computational Competencies: LET JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
 
 
 

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -93,14 +93,11 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
 
 ### ETH Zurich
 
-[ETH Zurich](https://ethz.ch/en.html), also known as *Federal Institute of Technology Zurich*, is a public research university in Zürich, Switzerland, with focus on science, technology, engineering, and mathematics, although its 16 departments span a variety of disciplines and subjects.
+[ETH Zurich](https://ethz.ch/en.html), (Federal Institute of Technology Zurich), is a public research university in Zürich, Switzerland, with focus on science, technology, engineering, and mathematics, although its 16 departments span a variety of disciplines and subjects.
 
-The administrative unit for [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) provides JupyterHubs exclusively for teaching and learning, integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Each course gets its individually configured JupyterHub environment deployed on a on premise Kubernetes cluster. 
+The [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) unit provides JupyterHub exclusively for teaching and learning, integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Each course gets its individually configured JupyterHub environment deployed on a on-premise Kubernetes cluster. 
 
 - [ETH Computational Competencies: LET JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
-
-
-
 
 ### George Washington University
 

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -95,7 +95,7 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
 
 [ETH Zurich](https://ethz.ch/en.html), also known as *Federal Institute of Technology Zurich*, is a public research university in Zürich, Switzerland, with focus on science, technology, engineering, and mathematics, although its 16 departments span a variety of disciplines and subjects.
 
-The administrative unit for [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) provides a JupyterHub exclusively for teaching and learning which is integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Every course gets its individually configured JupyterHub environment. 
+The administrative unit for [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/organisation/departments/educational-development-and-technology.html) provides JupyterHubs exclusively for teaching and learning, integrated in the learning management system [Moodle](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/moodle-service.html). Each course gets its individually configured JupyterHub environment deployed on a on premise Kubernetes cluster. 
 
 - [ETH Computational Competencies: LET JupyterHub](https://ethz.ch/staffnet/en/teaching/academic-support/it-services-teaching/teaching-applications/jupyterhub.html)
 


### PR DESCRIPTION
ETH Zurich provides JupyterHub for teaching and learning. This PR adds a description and links to the reference page.