### PR TITLE
add warning when an oauth client is used after its secret is deleted

### DIFF
--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -424,6 +424,7 @@ class JupyterHubRequestValidator(RequestValidator):
         if orm_client is None:
             return False
         if not orm_client.secret:
+            app_log.warning("OAuth client %s present without secret", client_id)
             return False
         request.client = orm_client
         return True


### PR DESCRIPTION
the client cannot be used for much anymore, so this situation is likely caused by an error, so we should notice it.