### PR TITLE
explicitly require groups in auth model when Authenticator.manage_groups is enabled

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -630,6 +630,7 @@ class Authenticator(LoggingConfigurable):
                 - `admin`, the admin setting value for the user
                 - `groups`, the list of group names the user should be a member of,
                   if Authenticator.manage_groups is True.
+                  `groups` MUST always be present if manage_groups is enabled.
         """
 
     def pre_spawn_start(self, user, spawner):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -820,7 +820,16 @@ class BaseHandler(RequestHandler):
 
         # apply authenticator-managed groups
         if self.authenticator.manage_groups:
-            group_names = authenticated.get("groups")
+            if "groups" not in authenticated:
+                # to use manage_groups, group membership must always be specified
+                # Authenticators that don't support this feature will omit it,
+                # which should fail here rather than silently not implement the requested behavior
+                auth_cls = self.authenticator.__class__.__name__
+                raise ValueError(
+                    f"Authenticator.manage_groups is enabled, but auth_model for {username} specifies no groups."
+                    f" Does {auth_cls} support manage_groups=True?"
+                )
+            group_names = authenticated["groups"]
             if group_names is not None:
                 user.sync_groups(group_names)
 


### PR DESCRIPTION
avoids the experience of silently ignored config for Authenticators that don't support `manage_groups`, which leads to confusion like https://github.com/jupyterhub/oauthenticator/issues/706.

technically breaking, because the previously unspecified behavior allowed Authenticators to omit the groups field which is interpreted as "no change to group membership." That will no longer be allowed.