### PR TITLE
avoid attempting to patch removed IPythonHandler with notebook v7

### DIFF
--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -856,13 +856,21 @@ def _patch_app_base_handlers(app):
     if BaseHandler is not None:
         base_handlers.append(BaseHandler)
 
-    # patch juptyer_server and notebook handlers if they have been imported
+    # patch jupyter_server and notebook handlers if they have been imported
     for base_handler_name in [
         "jupyter_server.base.handlers.JupyterHandler",
         "notebook.base.handlers.IPythonHandler",
     ]:
         modname, _ = base_handler_name.rsplit(".", 1)
         if modname in sys.modules:
+            root_mod = modname.partition(".")[0]
+            if root_mod == "notebook":
+                import notebook
+
+                if int(notebook.__version__.partition(".")[0]) >= 7:
+                    # notebook 7 is a server extension,
+                    # it doesn't have IPythonHandler anymore
+                    continue
             base_handlers.append(import_item(base_handler_name))
 
     if not base_handlers:


### PR DESCRIPTION
it's been removed, so there's nothing to patch

This only affects the unconditional patch, when Extensions could inherit from both base handler classes. When JUPYTERHUB_SINGLEUSER_APP=notebook, it's still right to patch this class, because that option only makes sense for notebook<7 (it will raise informatively if attempted with notebook 7).

JupyterHub 4's default behavior of using the extension implementation of jupyterhub-singleuser is not affected.

closes #4649