### PR TITLE
Compare major hub and singleuser versions only

### DIFF
--- a/jupyterhub/_version.py
+++ b/jupyterhub/_version.py
@@ -40,22 +40,20 @@ def _check_version(hub_version, singleuser_version, log):
         )
         return
 
-    # compare minor X.Y versions
+    # semver: compare major versions only
     if hub_version != singleuser_version:
         from packaging.version import parse
 
         hub = parse(hub_version)
-        hub_major_minor = (hub.major, hub.minor)
         singleuser = parse(singleuser_version)
-        singleuser_major_minor = (singleuser.major, singleuser.minor)
         extra = ""
         do_log = True
-        if singleuser_major_minor == hub_major_minor:
-            # patch-level mismatch or lower, log difference at debug-level
+        if singleuser.major == hub.major:
+            # minor-level mismatch or lower, log difference at debug-level
             # because this should be fine
             log_method = log.debug
         else:
-            # log warning-level for more significant mismatch, such as 0.8 vs 0.9, etc.
+            # log warning-level for more significant mismatch, such as 1.0.0 vs 2.0.0
             key = f'{hub_version}-{singleuser_version}'
             global _version_mismatch_warning_logged
             if _version_mismatch_warning_logged.get(key):

--- a/jupyterhub/tests/test_version.py
+++ b/jupyterhub/tests/test_version.py
@@ -16,7 +16,8 @@ def setup_function(function):
         ('0.8.0', '0.8.0', logging.DEBUG, 'both on version'),
         ('0.8.0', '0.8.1', logging.DEBUG, ''),
         ('0.8.0', '0.8.0.dev', logging.DEBUG, ''),
-        ('0.8.0', '0.9.0', logging.WARNING, 'This could cause failure to authenticate'),
+        ('2.0.0', '2.1.0', logging.DEBUG, ''),
+        ('1.0.0', '2.0.0', logging.WARNING, 'This could cause failure to authenticate'),
         ('', '0.8.0', logging.WARNING, 'Hub has no version header'),
         ('0.8.0', '', logging.WARNING, 'Single-user server has no version header'),
     ],
@@ -37,8 +38,8 @@ def test_check_version_singleton(caplog):
     # once.
     for x in range(2):
         test_check_version(
-            '1.2.0',
-            '1.1.0',
+            '2.0.0',
+            '1.0.0',
             logging.WARNING,
             'This could cause failure to authenticate',
             caplog,
@@ -47,8 +48,8 @@ def test_check_version_singleton(caplog):
     # a warning.
     caplog.clear()
     test_check_version(
-        '1.2.0',
-        '1.1.1',
+        '2.0.0',
+        '1.1.0',
         logging.WARNING,
         'This could cause failure to authenticate',
         caplog,


### PR DESCRIPTION
JupyterHub uses semantic versioning and has been >1.0.0 for a long time. It should be fine for the hub and singleuser versions to differ in their minor component.