### PR TITLE
docs: Remove non-actionable step from developer setup

### DIFF
--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -98,20 +98,13 @@ a more detailed discussion.
    python3 -m pip install --editable ".[test]"
    ```
 
-5. Set up a database.
-
-   The default database engine is `sqlite` so if you are just trying
-   to get up and running quickly for local development that should be
-   available via [Python](https://docs.python.org/3.5/library/sqlite3.html).
-   See [The Hub's Database](hub-database) for details on other supported databases.
-
-6. You are now ready to start JupyterHub!
+5. You are now ready to start JupyterHub!
 
    ```bash
    jupyterhub
    ```
 
-7. You can access JupyterHub from your browser at
+6. You can access JupyterHub from your browser at
    `http://localhost:8000` now.
 
 Happy developing!


### PR DESCRIPTION
I just went through these with @jmunroe, and found the db step a little confusing - there is no action to really be taken here, as pretty much everyone just uses sqlite for development (and even production). So I've just removed that step, as python almost always ships with sqlite built into it.