### PR TITLE
use $http_host in nginx proxy header

### DIFF
--- a/docs/source/howto/configuration/config-proxy.md
+++ b/docs/source/howto/configuration/config-proxy.md
@@ -79,7 +79,7 @@ server {
     location / {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         # websocket headers


### PR DESCRIPTION
$host is the hostname, $http_host is `hostname[:port]`, which is what's needed here if a port is specified.

$host works fine in the example because it uses the default port 80/443 in which case the two variables have the same value. But if it's on a different port, the two will differ, resulting in cross-origin check errors in the singleuser websocket requests because `hostname != hostname:port`.