### PR TITLE
Add appropriate scope in examples/service-whoami-flask

### DIFF
--- a/examples/service-whoami-flask/README.md
+++ b/examples/service-whoami-flask/README.md
@@ -15,14 +15,19 @@ After logging in with your local-system credentials, you should see a JSON dump 
 ```json
 {
   "admin": false,
-  "last_activity": "2016-05-27T14:05:18.016372",
+  "groups": [],
+  "kind": "user",
   "name": "queequeg",
-  "pending": null,
-  "server": "/user/queequeg"
+  "scopes": [
+    "access:services!service=whoami",
+    "read:users:groups!user=queequeg",
+    "read:users:name!user=queequeg"
+  ],
+  "session_id": "a32e59cdd7b445759c58c48e47394a38"
 }
 ```
 
-This relies on the Hub starting the whoami service, via config (see [jupyterhub_config.py](./jupyterhub_config.py)).
+This relies on the Hub starting the whoami service, via config (see [jupyterhub_config.py](./jupyterhub_config.py)).  For ordinary users to access this service, they need to be given the appropriate scope (again, see [jupyterhub_config.py](./jupyterhub_config.py)).
 
 A similar service could be run externally, by setting the JupyterHub service environment variables:
 

--- a/examples/service-whoami-flask/README.md
+++ b/examples/service-whoami-flask/README.md
@@ -27,7 +27,7 @@ After logging in with your local-system credentials, you should see a JSON dump 
 }
 ```
 
-This relies on the Hub starting the whoami service, via config (see [jupyterhub_config.py](./jupyterhub_config.py)).  For ordinary users to access this service, they need to be given the appropriate scope (again, see [jupyterhub_config.py](./jupyterhub_config.py)).
+This relies on the Hub starting the whoami service, via config (see [jupyterhub_config.py](./jupyterhub_config.py)). For ordinary users to access this service, they need to be given the appropriate scope (again, see [jupyterhub_config.py](./jupyterhub_config.py)).
 
 A similar service could be run externally, by setting the JupyterHub service environment variables:
 

--- a/examples/service-whoami-flask/jupyterhub_config.py
+++ b/examples/service-whoami-flask/jupyterhub_config.py
@@ -6,6 +6,15 @@ c.JupyterHub.services = [
         'environment': {'FLASK_APP': 'whoami-flask.py'},
     },
 ]
+c.JupyterHub.load_roles = [
+    {
+        'name': 'user',
+        'scopes': [
+            'access:services!service=whoami',
+            'self'
+        ]
+    }
+]
 
 # dummy auth and simple spawner for testing
 # any username and password will work

--- a/examples/service-whoami-flask/jupyterhub_config.py
+++ b/examples/service-whoami-flask/jupyterhub_config.py
@@ -7,7 +7,13 @@ c.JupyterHub.services = [
     },
 ]
 c.JupyterHub.load_roles = [
-    {'name': 'user', 'scopes': ['access:services!service=whoami', 'self']}
+    {
+        'name': 'user',
+        'scopes': [
+            'access:services!service=whoami',  # access this service
+            'self',  # and all of the standard things for a user
+        ],
+    }
 ]
 
 # dummy auth and simple spawner for testing

--- a/examples/service-whoami-flask/jupyterhub_config.py
+++ b/examples/service-whoami-flask/jupyterhub_config.py
@@ -7,13 +7,7 @@ c.JupyterHub.services = [
     },
 ]
 c.JupyterHub.load_roles = [
-    {
-        'name': 'user',
-        'scopes': [
-            'access:services!service=whoami',
-            'self'
-        ]
-    }
+    {'name': 'user', 'scopes': ['access:services!service=whoami', 'self']}
 ]
 
 # dummy auth and simple spawner for testing

--- a/examples/service-whoami-flask/whoami-flask.py
+++ b/examples/service-whoami-flask/whoami-flask.py
@@ -56,14 +56,14 @@ def whoami(user):
 def oauth_callback():
     code = request.args.get('code', None)
     if code is None:
-        return 403
+        return "Forbidden", 403
 
     # validate state field
     arg_state = request.args.get('state', None)
     cookie_state = request.cookies.get(auth.state_cookie_name)
     if arg_state is None or arg_state != cookie_state:
         # state doesn't match
-        return 403
+        return "Forbidden", 403
 
     token = auth.token_for_code(code)
     # store token in session cookie


### PR DESCRIPTION
I ran into some trouble trying to get services to work with an updated version of JupyterHub.  I went to this example for help, but it also failed.  I think this is the appropriate solution -- the `user` role needs a scope to access the service.  There seems to be an analogous fix already in examples/service-whoami.

In the process of testing this, I got a Flask error from the `return 403` lines in the example.  I don't know if that was ever valid Flask code, but it doesn't work now.  I've changed those so something that should be backwards-compatible.