### PR TITLE
Improve validation, docs for token.expires_in

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -572,9 +572,11 @@ paths:
               properties:
                 expires_in:
                   type: number
+                  example: 3600
                   description:
                     lifetime (in seconds) after which the requested token
                     will expire.
+                    Omit or specify null for no expiration.
                 note:
                   type: string
                   description: A note attached to the token for future bookkeeping

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -576,7 +576,7 @@ paths:
                   description:
                     lifetime (in seconds) after which the requested token
                     will expire.
-                    Omit or specify null for no expiration.
+                    Omit, or specify null or 0 for no expiration.
                 note:
                   type: string
                   description: A note attached to the token for future bookkeeping

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -575,8 +575,7 @@ paths:
                   example: 3600
                   description:
                     lifetime (in seconds) after which the requested token
-                    will expire.
-                    Omit, or specify null or 0 for no expiration.
+                    will expire. Omit, or specify null or 0 for no expiration.
                 note:
                   type: string
                   description: A note attached to the token for future bookkeeping

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -472,7 +472,14 @@ class UserTokenListAPIHandler(APIHandler):
             user_kind = 'user' if isinstance(user, User) else 'service'
             self.log.info("%s %s requested new API token", user_kind.title(), user.name)
         # retrieve the model
-        token_model = self.token_model(orm.APIToken.find(self.db, api_token))
+        orm_token = orm.APIToken.find(self.db, api_token)
+        if orm_token is None:
+            self.log.error(
+                "Failed to find token after creating it: %r. Maybe it expired already?",
+                body,
+            )
+            raise web.HTTPError(500, "Failed to create token")
+        token_model = self.token_model(orm_token)
         token_model['token'] = api_token
         self.write(json.dumps(token_model))
         self.set_status(201)

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of the Modified BSD License.
 import enum
 import json
+import numbers
 from base64 import decodebytes, encodebytes
 from datetime import timedelta
 from functools import partial
@@ -813,7 +814,18 @@ class APIToken(Hashed, Base):
         else:
             assert service.id is not None
             orm_token.service = service
-        if expires_in is not None:
+        if expires_in:
+            if not isinstance(expires_in, numbers.Real):
+                raise TypeError(
+                    f"expires_in must be a positive integer or null, not {expires_in!r}"
+                )
+            expires_in = int(expires_in)
+            # tokens must always expire in the future
+            if expires_in < 1:
+                raise ValueError(
+                    f"expires_in must be a positive integer or null, not {expires_in!r}"
+                )
+
             orm_token.expires_at = cls.now() + timedelta(seconds=expires_in)
 
         db.commit()


### PR DESCRIPTION
#4660 describes a problem where the generated rest api docs use 0 as a default number in examples, but expires_in=0  is interpreted as create a token that is immediately expired, rather than one that never expires.

Collection of small changes to improve this situation:

- accept 0 meaning no expiration, since folks have tried to use it that way
- clear error message for invalid (e.g. negative) values
- specify nonzero example in rest api doc so it doesn't default to invalid `0` (which is now valid)
- better error logging if orm token fails to be retrieved

closes #4660