### PR TITLE
pre_spawn_hook doc: make example generic to all spawners

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -885,10 +885,9 @@ class Spawner(LoggingConfigurable):
 
         Example::
 
-            from subprocess import check_call
             def my_hook(spawner):
                 username = spawner.user.name
-                check_call(['./examples/bootstrap-script/bootstrap.sh', username])
+                spawner.environment["GREETING"] = f"Hello {username}"
 
             c.Spawner.pre_spawn_hook = my_hook
 


### PR DESCRIPTION
This docstring appears in the documentation for spawners such as KubeSpawner where the example isn't relevant
https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.pre_spawn_hook