### PR TITLE
don't run check_allowed until after check_blocked_users resolves

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -535,13 +535,12 @@ class Authenticator(LoggingConfigurable):
         blocked_pass = await maybe_future(
             self.check_blocked_users(username, authenticated)
         )
-        allowed_pass = await maybe_future(self.check_allowed(username, authenticated))
 
-        if blocked_pass:
-            pass
-        else:
+        if not blocked_pass:
             self.log.warning("User %r blocked. Stop authentication", username)
             return
+
+        allowed_pass = await maybe_future(self.check_allowed(username, authenticated))
 
         if allowed_pass:
             if authenticated['admin'] is None:


### PR DESCRIPTION
avoids computing an unused value if blocked_pass is going to halt authorization anyway

no change in behavior