### PR TITLE
Backport PR #4617: try to improve reliability of test_external_proxy

### DIFF
--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -10,6 +10,7 @@ import pytest
 from traitlets import TraitError
 from traitlets.config import Config
 
+from ..utils import random_port
 from ..utils import url_path_join as ujoin
 from ..utils import wait_for_http_server
 from .mocking import MockHub
@@ -28,10 +29,11 @@ def disable_check_routes(app):
 
 
 @skip_if_ssl
+@pytest.mark.flaky(reruns=2)
 async def test_external_proxy(request):
     auth_token = 'secret!'
     proxy_ip = '127.0.0.1'
-    proxy_port = 54321
+    proxy_port = random_port()
     cfg = Config()
     cfg.ConfigurableHTTPProxy.auth_token = auth_token
     cfg.ConfigurableHTTPProxy.api_url = 'http://%s:%i' % (proxy_ip, proxy_port)
@@ -128,7 +130,7 @@ async def test_external_proxy(request):
     proxy.wait(timeout=10)
     new_auth_token = 'different!'
     env['CONFIGPROXY_AUTH_TOKEN'] = new_auth_token
-    proxy_port = 55432
+    proxy_port = random_port()
     cmd = [
         'configurable-http-proxy',
         '--ip',

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup_args = dict(
             "pytest-cov",
             "requests-mock",
             "playwright",
+            "pytest-rerunfailures",
             "virtualenv",
         ],
     },


### PR DESCRIPTION
backport of #4617

trying to backport some of the flaky test fixes, since the intermittent failures are making other backports harder