### PR TITLE
clarify some points where users can disable security for their own servers

### DIFF
--- a/docs/source/explanation/websecurity.md
+++ b/docs/source/explanation/websecurity.md
@@ -52,6 +52,7 @@ ensure that:
     their single-user server;
   - the modification of the configuration of the notebook server
     (the `~/.jupyter` or `JUPYTER_CONFIG_DIR` directory).
+  - unrestricted selection of the base environment (e.g. the image used in container-based Spawners)
 
 If any additional services are run on the same domain as the Hub, the services
 **must never** display user-authored HTML that is neither _sanitized_ nor _sandboxed_
@@ -93,6 +94,8 @@ the Spawner should _not_ evaluate shell configuration files prior to launching t
 Package isolation is most easily handled by running the single-user server in
 a virtualenv with disabled system-site-packages. The user should not have
 permission to install packages into this environment.
+The same principle extends to the images used by container-based deployments.
+If users can select the images in which their servers run, they can disable all security.
 
 It is important to note that the control over the environment only affects the
 single-user server, and not the environment(s) in which the user's kernel(s)

--- a/docs/source/rbac/scopes.md
+++ b/docs/source/rbac/scopes.md
@@ -298,6 +298,17 @@ class MyHandler(HubOAuthenticated, BaseHandler):
 Existing scope filters (`!user=`, etc.) may be applied to custom scopes.
 Custom scope _filters_ are NOT supported.
 
+:::{warning}
+JupyterHub allows you to define custom scopes,
+but it does not enforce that your services apply them.
+
+For example, if you enable read-only access to servers via custom JupyterHub
+(as seen in the `read-only` example),
+it is the administrator's responsibility to enforce that they are applied.
+If you allow users to launch servers without that custom Authorizer,
+read-only permissions will not be enforced, and the default behavior of unrestricted access via the `access:servers` scope will be applied.
+:::
+
 ### Scopes and APIs
 
 The scopes are also listed in the [](jupyterhub-rest-API) documentation.

--- a/examples/read-only/README.md
+++ b/examples/read-only/README.md
@@ -23,3 +23,8 @@ To test this, you'll want two browser sessions:
 
 Percy can use their server as normal, but vex will only be able to read files.
 Vex won't be able to run any code, connect to kernels, or save edits to files.
+
+Note that defining custom scopes does not enforce that they are used.
+Defining scopes for read-only access and then running user servers without the custom Authorizer
+will result in users who are supposed to have read-only access actually having unrestricted access,
+because only the default `access:servers` scope is checked.


### PR DESCRIPTION
makes explicit that selecting images is equivalent to the installing packages issue.

@consideRatio this is my attempt at addressing https://github.com/jupyterhub/jupyterhub/pull/4594#issuecomment-1929293237