### PR TITLE
Use redoc for REST API

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -36,14 +36,18 @@ env:
 
 jobs:
   validate-rest-api-definition:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate REST API definition
-        uses: char0n/swagger-editor-validate@v1.3.2
+      - uses: actions/setup-node@v4
         with:
-          definition-file: docs/source/_static/rest-api.yml
+          node-version: "20"
+          cache: npm
+
+      - name: Validate REST API definition
+        run: |
+          npx @redocly/cli lint
 
   test-docs:
     runs-on: ubuntu-20.04

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 share/jupyterhub/templates/
 share/jupyterhub/static/js/admin-react.js
 jupyterhub/singleuser/templates/
+docs/source/_templates/

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -2,8 +2,10 @@ openapi: 3.0.3
 # note: 3.1.0 required for requestBody on DELETE
 # which we should maybe move away from
 info:
-  title: JupyterHub
-  description: The REST API for JupyterHub
+  title: JupyterHub REST API
+  description: |
+    The REST API for JupyterHub.
+    <a href="./">Return to JupyterHub documentation</a>.
   license:
     name: BSD-3-Clause
   version: 5.0.0.dev

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -6,6 +6,7 @@ info:
     <a href="./">Return to JupyterHub documentation</a>.
   license:
     name: BSD-3-Clause
+    identifier: BSD-3-Clause
   version: 5.0.0.dev
 servers:
   - url: /hub/api
@@ -16,6 +17,7 @@ security:
 paths:
   /:
     get:
+      operationId: get-api
       summary: Get JupyterHub version
       description: |
         This endpoint is not authenticated for the purpose of clients and user
@@ -33,6 +35,7 @@ paths:
                     description: The version of JupyterHub itself
   /info:
     get:
+      operationId: get-info
       summary: Get detailed info about JupyterHub
       description: |
         Detailed JupyterHub information, including Python version,
@@ -82,6 +85,7 @@ paths:
             - read:hub
   /user:
     get:
+      operationId: get-current-user
       summary: Return authenticated user's model
       responses:
         200:
@@ -104,6 +108,7 @@ paths:
             - admin:server_state
   /users:
     get:
+      operationId: get-users
       summary: List users
       parameters:
         - name: state
@@ -155,6 +160,7 @@ paths:
             - admin:auth_state
             - admin:server_state
     post:
+      operationId: post-users
       summary: Create multiple users
       requestBody:
         content:
@@ -187,6 +193,7 @@ paths:
       x-codegen-request-body-name: body
   /users/{name}:
     get:
+      operationId: get-user
       summary: Get a user by name
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -214,6 +221,7 @@ paths:
             - admin:auth_state
             - admin:server_state
     post:
+      operationId: post-user
       summary: Create a single user
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -228,6 +236,7 @@ paths:
         - oauth2:
             - admin:users
     delete:
+      operationId: delete-user
       summary: Delete a user
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -239,6 +248,7 @@ paths:
         - oauth2:
             - admin:users
     patch:
+      operationId: patch-user
       summary: Modify a user
       description: Change a user's name or admin status
       parameters:
@@ -276,6 +286,7 @@ paths:
       x-codegen-request-body-name: body
   /users/{name}/activity:
     post:
+      operationId: post-user-activity
       summary: Notify Hub of activity for a given user
       description:
         Notify the Hub of activity by the user, e.g. accessing a service
@@ -335,6 +346,7 @@ paths:
       x-codegen-request-body-name: body
   /users/{name}/server:
     post:
+      operationId: post-user-server
       summary: Start a user's single-user notebook server
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -365,6 +377,7 @@ paths:
             - servers
       x-codegen-request-body-name: options
     delete:
+      operationId: delete-user-server
       summary: Stop a user's server
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -382,6 +395,7 @@ paths:
             - servers
   /users/{name}/servers/{server_name}:
     post:
+      operationId: post-user-server-name
       summary: Start a user's named server
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -411,6 +425,7 @@ paths:
             - servers
       x-codegen-request-body-name: options
     delete:
+      operationId: delete-user-server-name
       summary: Stop a user's named server
       description: |
         To remove the named server in addition to deleting it,
@@ -453,6 +468,7 @@ paths:
 
   /users/{name}/shared:
     get:
+      operationId: get-user-shared
       summary: List servers shared with user
       description:
         Returns list of Shares granting the user access to servers owned
@@ -480,6 +496,7 @@ paths:
 
   /users/{name}/shared/{owner}/{server_name}:
     get:
+      operationId: get-user-shared-server
       summary: |
         Get user's shared access to server
       description: |
@@ -501,6 +518,7 @@ paths:
         - oauth2:
             - read:users:shares
     delete:
+      operationId: delete-user-shared-server
       summary: |
         Leave a shared server
       description: |
@@ -523,6 +541,7 @@ paths:
 
   /users/{name}/tokens:
     get:
+      operationId: get-user-tokens
       summary: List tokens for the user
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -545,6 +564,7 @@ paths:
         - oauth2:
             - read:tokens
     post:
+      operationId: post-user-tokens
       summary: Create a new token for the user
       description: |
         Creates a new token owned by the user.
@@ -605,6 +625,7 @@ paths:
       x-codegen-request-body-name: token_params
   /users/{name}/tokens/{token_id}:
     get:
+      operationId: get-user-token
       summary: Get one token
       description: Get the details for one token by id
       parameters:
@@ -625,6 +646,7 @@ paths:
         - oauth2:
             - read:tokens
     delete:
+      operationId: delete-user-token
       summary: Delete (revoke) a token by id
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -642,6 +664,7 @@ paths:
             - tokens
   /groups:
     get:
+      operationId: get-groups
       summary: List groups
       parameters:
         - $ref: "#/components/parameters/paginationOffset"
@@ -662,6 +685,7 @@ paths:
             - read:roles:groups
   /groups/{name}:
     get:
+      operationId: get-group
       summary: Get a group by name
       parameters:
         - $ref: "#/components/parameters/groupName"
@@ -678,6 +702,7 @@ paths:
             - read:groups:name
             - read:roles:groups
     post:
+      operationId: post-group
       summary: Create a group
       parameters:
         - $ref: "#/components/parameters/groupName"
@@ -692,6 +717,7 @@ paths:
         - oauth2:
             - admin:groups
     delete:
+      operationId: delete-group
       summary: Delete a group
       parameters:
         - $ref: "#/components/parameters/groupName"
@@ -705,6 +731,7 @@ paths:
 
   /groups/{name}/shared:
     get:
+      operationId: get-group-shared
       summary: List servers shared with group
       description: |
         Lists shares granting `group` access to shared servers
@@ -731,6 +758,7 @@ paths:
 
   /groups/{name}/shared/{owner}/{server_name}:
     get:
+      operationId: get-group-shared-server
       summary: Get group's shared access
       description: |
         Get the Share representing a single group's access to a single server
@@ -750,6 +778,7 @@ paths:
         - oauth2:
             - read:groups:shares
     delete:
+      operationId: delete-group-shared-server
       summary: Leave a share (group)
       description: |
         Leave a share by revoking a group's permissions on a single server
@@ -770,6 +799,7 @@ paths:
 
   /groups/{name}/users:
     post:
+      operationId: get-group-users
       summary: Add users to a group
       parameters:
         - $ref: "#/components/parameters/groupName"
@@ -798,6 +828,7 @@ paths:
             - groups
       x-codegen-request-body-name: body
     delete:
+      operationId: delete-group-users
       summary: |
         Remove users from a group
       description: |
@@ -836,6 +867,7 @@ paths:
 
   /groups/{name}/properties:
     put:
+      operationId: put-group-properties
       summary: Set group properties
       description: |
         Set properties on a group
@@ -865,6 +897,7 @@ paths:
 
   /shares/{owner}:
     get:
+      operationId: get-shares-owner
       summary: List shares by owner
       description: |
         List shares granting access to any of owner's servers
@@ -893,6 +926,7 @@ paths:
 
   /shares/{owner}/{server_name}:
     get:
+      operationId: get-shares-server
       summary: List server shares
       description: |
         List shares granting access to a single server
@@ -920,6 +954,7 @@ paths:
         - oauth2:
             - read:shares
     post:
+      operationId: post-shares-server
       summary: Grant shared access
       description: |
         Grant shared access to a single server
@@ -970,6 +1005,7 @@ paths:
             - read:users:name
             - read:groups:name
     patch:
+      operationId: patch-shares-server
       summary: Revoke shared access
       description: |
         Revoke shared access to a single server for a single user or group.
@@ -1022,6 +1058,7 @@ paths:
             - read:users:name
             - read:groups:name
     delete:
+      operationId: delete-shares-server
       summary: Revoke all shared access
       description: |
         Revoke all shared access to a given server
@@ -1039,6 +1076,7 @@ paths:
 
   /share-codes/{owner}:
     get:
+      operationId: get-share-codes-owner
       summary: List share codes by owner
       description: |
         List share codes granting access to a user's servers
@@ -1067,6 +1105,7 @@ paths:
 
   /share-codes/{owner}/{server_name}:
     get:
+      operationId: get-share-codes-server
       summary: List share codes
       description: |
         List share codes which can be exchanged for access to a single server
@@ -1094,6 +1133,7 @@ paths:
         - oauth2:
             - read:shares
     post:
+      operationId: post-share-code
       summary: Issue share code
       description: |
         Issue a share code, which can be exchanged for shared access to a single server
@@ -1147,6 +1187,7 @@ paths:
         - oauth2:
             - shares
     delete:
+      operationId: delete-share-code
       summary: Revoke share code
       description: |
         Revoke a share code by id or code.
@@ -1176,6 +1217,7 @@ paths:
 
   /services:
     get:
+      operationId: get-services
       summary: List services
       parameters:
         - $ref: "#/components/parameters/paginationOffset"
@@ -1196,6 +1238,7 @@ paths:
             - read:roles:services
   /services/{name}:
     get:
+      operationId: get-service
       summary: Get a service by name
       parameters:
         - name: name
@@ -1218,6 +1261,7 @@ paths:
             - read:roles:services
   /proxy:
     get:
+      operationId: get-proxy
       summary: Get the proxy's routing table
       description:
         A convenience alias for getting the routing table directly from
@@ -1239,6 +1283,7 @@ paths:
         - oauth2:
             - proxy
     post:
+      operationId: post-proxy
       summary: Force the Hub to sync with the proxy
       responses:
         200:
@@ -1248,6 +1293,7 @@ paths:
         - oauth2:
             - proxy
     patch:
+      operationId: patch-proxy
       summary: Notify the Hub about a new proxy
       description: Notifies the Hub of a new proxy to use.
       requestBody:
@@ -1282,6 +1328,7 @@ paths:
       x-codegen-request-body-name: body
   /authorizations/token:
     post:
+      operationId: post-auth-token
       summary: Request a new API token
       description: |
         Request a new API token to use with the JupyterHub REST API.
@@ -1320,6 +1367,7 @@ paths:
       x-codegen-request-body-name: credentials
   /authorizations/token/{token}:
     get:
+      operationId: get-auth-token
       summary: Identify a user or service from an API token
       parameters:
         - name: token
@@ -1339,6 +1387,7 @@ paths:
             - (no_scope)
   /authorizations/cookie/{cookie_name}/{cookie_value}:
     get:
+      operationId: get-auth-cookie
       summary: Identify a user from a cookie
       description:
         Used by single-user notebook servers to hand off cookie authentication
@@ -1367,6 +1416,7 @@ paths:
       deprecated: true
   /oauth2/authorize:
     get:
+      operationId: get-oauth-authorize
       summary: OAuth 2.0 authorize endpoint
       description: |
         Redirect users to this URL to begin the OAuth process.
@@ -1404,6 +1454,7 @@ paths:
           content: {}
   /oauth2/token:
     post:
+      operationId: post-oauth-token
       summary: Request an OAuth2 token
       description: |
         Request an OAuth2 token from an authorization code.
@@ -1451,6 +1502,7 @@ paths:
                     description: Will always be 'Bearer'
   /shutdown:
     post:
+      operationId: post-shutdown
       summary: Shutdown the Hub
       requestBody:
         content:

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1,6 +1,4 @@
-openapi: 3.0.3
-# note: 3.1.0 required for requestBody on DELETE
-# which we should maybe move away from
+openapi: 3.1.0
 info:
   title: JupyterHub REST API
   description: |
@@ -425,21 +423,20 @@ paths:
         - $ref: "#/components/parameters/userName"
         - $ref: "#/components/parameters/serverName"
 
-      # FIXME: openapi 3.1 is required for requestBody on DELETE
-      # we probably shouldn't have request bodies on DELETE
-      # requestBody:
-      #   content:
-      #     application/json:
-      #       schema:
-      #         type: object
-      #         properties:
-      #           remove:
-      #             type: boolean
-      #             description: |
-      #               Whether to fully remove the server, rather than just stop it.
-      #               Removing a server deletes things like the state of the stopped server.
-      #               Default: false.
-      #   required: false
+      # FIXME: we probably shouldn't have request bodies on DELETE
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                remove:
+                  type: boolean
+                  description: |
+                    Whether to fully remove the server, rather than just stop it.
+                    Removing a server deletes things like the state of the stopped server.
+                    Default: false.
+        required: false
       responses:
         202:
           description:
@@ -815,19 +812,19 @@ paths:
 
       parameters:
         - $ref: "#/components/parameters/groupName"
-      # requestBody:
-      #   description: The users to remove from the group
-      #   content:
-      #     application/json:
-      #       schema:
-      #         type: object
-      #         properties:
-      #           users:
-      #             type: array
-      #             description: List of usernames to remove from the group
-      #             items:
-      #               type: string
-      #   required: true
+      requestBody:
+        description: The users to remove from the group
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                users:
+                  type: array
+                  description: List of usernames to remove from the group
+                  items:
+                    type: string
+        required: true
       responses:
         200:
           description: The users have been removed from the group

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -1,0 +1,2 @@
+{%- set _meta = meta | default({}) %}
+{%- extends _meta.page_template | default('!page.html') %}

--- a/docs/source/_templates/redoc.html
+++ b/docs/source/_templates/redoc.html
@@ -1,0 +1,34 @@
+{%- extends "!layout.html" %}
+
+{# not sure why, but theme CSS prevents scrolling within redoc content
+ # If this were fixed, we could keep the navbar and footer
+ #}
+{%- block css %}{%- endblock %}
+{%- block docs_navbar %}{%- endblock %}
+{%- block footer %}{% endblock %}
+{%- block body_tag %}
+<body>
+{%- endblock %}
+
+{%- block extrahead %}
+{{ super() }}
+<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+<script src="{{ pathto('_static/redoc.js', 1) }}"></script>
+{%- endblock %}
+
+{%- block content %}
+<redoc id="redoc-spec"></redoc>
+<script>
+  if (location.protocol === "file:") {
+    document.body.innerText = "Rendered API specification doesn't work with file: protocol. Use sphinx-autobuild to do local builds of the docs, served over HTTP."
+  } else {
+    Redoc.init(
+      "{{ pathto('_static/rest-api.yml', 1) }}",
+      {{ meta.redoc_options | default({}) }},
+      document.getElementById("redoc-spec"),
+    );
+  }
+</script>
+{%- endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,13 +7,17 @@ import datetime
 import io
 import os
 import subprocess
+from pathlib import Path
+from urllib.request import urlretrieve
 
 from docutils import nodes
 from sphinx.directives.other import SphinxDirective
+from sphinx.util import logging
 
 import jupyterhub
 from jupyterhub.app import JupyterHub
 
+logger = logging.getLogger(__name__)
 # -- Project information -----------------------------------------------------
 # ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 #
@@ -119,7 +123,24 @@ class HelpAllDirective(SphinxDirective):
         return [par]
 
 
+templates_path = ["_templates"]
+
+
+def stage_redoc_js(app, exception):
+    """Download redoc.js to our static files"""
+    redoc_version = "2.1.3"
+    redoc_url = (
+        f"https://cdn.redoc.ly/redoc/v{redoc_version}/bundles/redoc.standalone.js"
+    )
+
+    dest = Path(app.builder.outdir) / "_static/redoc.js"
+    if not dest.exists():
+        logger.info(f"Downloading {redoc_url} -> {dest}")
+        urlretrieve(redoc_url, dest)
+
+
 def setup(app):
+    app.connect("build-finished", stage_redoc_js)
     app.add_css_file("custom.css")
     app.add_directive("jupyterhub-generate-config", ConfigDirective)
     app.add_directive("jupyterhub-help-all", HelpAllDirective)

--- a/docs/source/reference/rest-api.md
+++ b/docs/source/reference/rest-api.md
@@ -1,33 +1,14 @@
-<!---
-This doc is part of the API references section of the References documentation.
---->
+---
+page_template: redoc.html
+# see: https://redocly.com/docs/redoc/config/ for options
+redoc_options:
+  hideHostname: true
+  hideLoading: true
+---
 
 (jupyterhub-rest-API)=
 
 # JupyterHub REST API
 
-Below is an interactive view of JupyterHub's OpenAPI specification.
-
-<!-- client-rendered openapi UI copied from FastAPI -->
-
-<link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css">
-<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.1/swagger-ui-bundle.js"></script>
-<!-- `SwaggerUIBundle` is now available on the page -->
-
-<!-- render the ui here -->
-<div id="openapi-ui"></div>
-
-<script>
-const ui = SwaggerUIBundle({
-  url: '../_static/rest-api.yml',
-  dom_id: '#openapi-ui',
-  presets: [
-    SwaggerUIBundle.presets.apis,
-    SwaggerUIBundle.SwaggerUIStandalonePreset
-  ],
-  layout: "BaseLayout",
-  deepLinking: true,
-  showExtensions: true,
-  showCommonExtensions: true,
-});
-</script>
+NOTE: The contents of this markdown file are not used,
+this page is entirely generated from `_templates/redoc.html` and `_static/rest-api.yml`

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,10 @@
+extends:
+  - recommended
+
+apis:
+  rest:
+    root: ./docs/source/_static/rest-api.yml
+    rules:
+      info-license-url: off
+      operation-4xx-response: off
+      no-unused-components: warn


### PR DESCRIPTION
Switches OpenAPI spec rendering to using [redoc](https://redocly.com/redoc/)

rest-api page is rendered with redoc via custom template in sphinx. linter is also switched to redoc, which is easier to run localy.

Changes to the API spec document:

- add operationId to every operation, to satisfy the linter. These are used in anchor links, so should stay stable once set, but don't need to be meaningful.
- add link back to outer docs, since there is no nav header on the page anymore
- update spec to 3.1.0, which lets us uncomment valid but previously rejected specs on some requests

Embedding the API in-line on a regular page doesn't seem to work due to some conflicts with scrolling. I don't know why.

The rendered page can't be viewed on a `file://` page. If we rendered a fully static document with `redocly build-docs`, then it would, but we would need to shell out to npm during docs build. Is this better? I don't know!

(will update with URL when rtd build starts)

closes #4669 