### PR TITLE
Add Authenticator config `allow_all` and `allow_existing_users`

### DIFF
--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -211,7 +211,7 @@ authorization
 It is perfectly fine in the simplest cases for `Authenticator.authenticate` to be responsible for authentication _and_ authorization,
 in which case `authenticate` may return `None` if the user is not authorized.
 
-However, Authenticators also have have two methods {meth}`~.Authenticator.check_allowed` and {meth}`~.Authenticator.check_blocked_users`, which are called after successful authentication to further check if the user is allowed.
+However, Authenticators also have two methods, {meth}`~.Authenticator.check_allowed` and {meth}`~.Authenticator.check_blocked_users`, which are called after successful authentication to further check if the user is allowed.
 
 If `check_blocked_users()` returns False, authorization stops and the user is not allowed.
 
@@ -227,7 +227,7 @@ which is a change from pre-5.0, where `allow_all` was implicitly True if `allowe
 ### Overriding `check_allowed`
 
 :::{versionchanged} 5.0
-`check_allowed()` is **not called** is `allow_all` is True.
+`check_allowed()` is **not called** if `allow_all` is True.
 :::
 
 :::{versionchanged} 5.0
@@ -242,14 +242,10 @@ The base implementation of {meth}`~.Authenticator.check_allowed` checks:
 - else return False
 
 :::{versionchanged} 5.0
-Prior to 5.0, the check was
+Prior to 5.0, this would also return True if `allowed_users` was empty.
 
-```python
-if (not allowed_users) or username in allowed_users:
-```
-
-but the implicit `not allowed_users` has been replaced by explicit `allow_all`, which is checked _before_ calling `check_allowed`.
-`check_allowed` **is not called** if `allow_all` is True.
+For clarity, this is no longer the case. A new `allow_all` property (default False) has been added which is checked _before_ calling `check_allowed`.
+If `allow_all` is True, this takes priority over `check_allowed`, which will be ignored.
 
 If your Authenticator subclass similarly returns True when no allow config is defined,
 this is fully backward compatible for your users, but means `allow_all = False` has no real effect.
@@ -349,7 +345,7 @@ So the logical expression for a user being authorized should look like:
 
 #### Custom error messages
 
-Any of these authentication and authorization methods may
+Any of these authentication and authorization methods may raise a `web.HTTPError` Exception
 
 ```python
 from tornado import web

--- a/docs/source/tutorial/getting-started/authenticators-users-basics.md
+++ b/docs/source/tutorial/getting-started/authenticators-users-basics.md
@@ -130,7 +130,8 @@ By default, only the deprecated `admin` role has global `access` permissions.
 ## Add or remove users from the Hub
 
 :::{versionadded} 5.0
-`c.Authenticator.allow_existing_users` is added in 5.0 and enabled by default.
+`c.Authenticator.allow_existing_users` is added in 5.0 and True by default _if_ any `allowed_users` are specified.
+
 Prior to 5.0, this behavior was not optional.
 :::
 

--- a/docs/source/tutorial/getting-started/authenticators-users-basics.md
+++ b/docs/source/tutorial/getting-started/authenticators-users-basics.md
@@ -6,30 +6,57 @@ The default Authenticator uses [PAM][] (Pluggable Authentication Module) to auth
 their usernames and passwords. With the default Authenticator, any user
 with an account and password on the system will be allowed to login.
 
-## Create a set of allowed users (`allowed_users`)
+## Deciding who is allowed
+
+In the base Authenticator, there are 3 configuration options for granting users access to your Hub:
+
+1. `allow_all` grants any user who can successfully authenticate access to the Hub
+2. `allowed_users` defines a set of users who can access the Hub
+3. `allow_existing_users` enables managing users via the JupyterHub API or admin page
+
+These options should apply to all Authenticators.
+Your chosen Authenticator may add additional configuration options to admit users, such as team membership, course enrollment, etc.
+
+:::{important}
+You should always specify at least one allow configuration if you want people to be able to access your Hub!
+In most cases, this looks like:
+
+```python
+c.Authenticator.allow_all = True
+# or
+c.Authenticator.allowed_users = {"name", ...}
+```
+
+:::
+
+:::{versionchanged} 5.0
+If no allow config is specified, then by default **nobody will have access to your Hub**.
+Prior to 5.0, the opposite was true; effectively `allow_all = True` if no other allow config was specified.
+:::
 
 You can restrict which users are allowed to login with a set,
 `Authenticator.allowed_users`:
 
 ```python
 c.Authenticator.allowed_users = {'mal', 'zoe', 'inara', 'kaylee'}
-c.Authenticator.allow_all = False
+# c.Authenticator.allow_all = False
 c.Authenticator.allow_existing_users = False
 ```
 
 Users in the `allowed_users` set are added to the Hub database when the Hub is started.
 
-```{warning}
-If `allowed_users` is not specified, then by default **all authenticated users will be allowed into your hub**,
-i.e. `allow_all` defaults to True if neither `allowed_users` nor `allow_all` are set.
-```
+:::{versionchanged} 5.0
+{attr}`.Authenticator.allow_all` and {attr}`.Authenticator.allow_existing_users` are new in JupyterHub 5.0
+to enable explicit configuration of previously implicit behavior.
 
-:::{versionadded} 5.0
-{attr}`Authenticator.allow_all` and {attr}`Authenticator.allow_existing_users` are new in JupyterHub 5.0.
+Prior to 5.0, `allow_all` was implicitly True if `allowed_users` was empty.
+Starting with 5.0, to allow all authenticated users by default,
+`allow_all` must be explicitly set to True.
 
-By default, `allow_all` is True when `allowed_users` is empty,
-and `allow_existing_users` is True when `allowed_users` is not empty.
-This is to ensure backward-compatibility.
+By default, `allow_existing_users` is True when `allowed_users` is not empty,
+to ensure backward-compatibility.
+To make the `allowed_users` set _restrictive_,
+set `allow_existing_users = False`.
 :::
 
 ## One Time Passwords ( request_otp )
@@ -101,6 +128,11 @@ By default, only the deprecated `admin` role has global `access` permissions.
 **As a courtesy, you should make sure your users know if admin access is enabled.**
 
 ## Add or remove users from the Hub
+
+:::{versionadded} 5.0
+`c.Authenticator.allow_existing_users` is added in 5.0 and enabled by default.
+Prior to 5.0, this behavior was not optional.
+:::
 
 Users can be added to and removed from the Hub via the admin
 panel or the REST API.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2077,6 +2077,9 @@ class JupyterHub(Application):
                     "auth_state is enabled, but encryption is not available: %s" % e
                 )
 
+        # give the authenticator a chance to check its own config
+        self.authenticator.check_allow_config()
+
         if self.admin_users and not self.authenticator.admin_users:
             self.log.warning(
                 "\nJupyterHub.admin_users is deprecated since version 0.7.2."
@@ -2104,9 +2107,9 @@ class JupyterHub(Application):
                 new_users.append(user)
             else:
                 user.admin = True
+
         # the admin_users config variable will never be used after this point.
         # only the database values will be referenced.
-
         allowed_users = [
             self.authenticator.normalize_username(name)
             for name in self.authenticator.allowed_users
@@ -2116,10 +2119,10 @@ class JupyterHub(Application):
             if not self.authenticator.validate_username(username):
                 raise ValueError("username %r is not valid" % username)
 
-        if not allowed_users:
-            self.log.info(
-                "Not using allowed_users. Any authenticated user will be allowed."
-            )
+        if self.authenticator.allowed_users and self.authenticator.admin_users:
+            # make sure admin users are in the allowed_users set, if defined,
+            # otherwise they won't be able to login
+            self.authenticator.allowed_users |= self.authenticator.admin_users
 
         # add allowed users to the db
         for name in allowed_users:

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -125,7 +125,7 @@ class Authenticator(LoggingConfigurable):
         False,
         help="""Is there any allow config?
         
-        Used to show a warning if it looks like nobody can access the HUb,
+        Used to show a warning if it looks like nobody can access the Hub,
         which can happen when upgrading to JupyterHub 5,
         now that `allow_all` defaults to False.
         
@@ -199,7 +199,7 @@ class Authenticator(LoggingConfigurable):
         Allow every user who can successfully authenticate to access JupyterHub.
         
         False by default, which means for most Authenticators,
-        _some_ allow-related configuration is required to allow any users to log in.
+        _some_ allow-related configuration is required to allow users to log in.
 
         Authenticator subclasses may override the default with e.g.::
 

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -808,6 +808,7 @@ class Authenticator(LoggingConfigurable):
         This is called:
          - When a user first authenticates, _after_ all allow and block checks have passed
          - When the hub restarts, for all users in the database (i.e. users previously allowed)
+         - When a user is added to the database, either via configuration or REST API
 
         This method may be a coroutine.
 

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -166,7 +166,8 @@ class Authenticator(LoggingConfigurable):
             self.log.warning(
                 "No allow config found, it's possible that nobody can login to your Hub!\n"
                 "You can set `c.Authenticator.allow_all = True` to allow any user who can login to access the Hub,\n"
-                "or e.g. `allowed_users` to a set of users who should have access."
+                "or e.g. `allowed_users` to a set of users who should have access.\n"
+                "You may suppress this warning by setting c.Authenticator.any_allow_config = True."
             )
 
     whitelist = Set(

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -249,7 +249,7 @@ class Authenticator(LoggingConfigurable):
            When this is enabled and you wish to remove access for one or more
            users previously allowed, you must make sure that they
            are removed from the jupyterhub database. This can be tricky to do
-           if you stop allowing a group of externally managed users for example.
+           if you stop allowing an externally managed group of users for example.
 
         With this enabled, JupyterHub admin users can visit `/hub/admin` or use
         JupyterHub's REST API to add and remove users to manage who can login.

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -243,6 +243,7 @@ class MockHub(JupyterHub):
             cert_location = kwargs['internal_certs_location']
             kwargs['external_certs'] = ssl_setup(cert_location, 'hub-ca')
         super().__init__(*args, **kwargs)
+        self.config.Authenticator.allow_all = True
 
     @default('subdomain_host')
     def _subdomain_host_default(self):

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -244,7 +244,7 @@ class MockHub(JupyterHub):
             kwargs['external_certs'] = ssl_setup(cert_location, 'hub-ca')
         super().__init__(*args, **kwargs)
         if 'allow_all' not in self.config.Authenticator:
-            self.config.Authenticatorallow_all = True
+            self.config.Authenticator.allow_all = True
 
     @default('subdomain_host')
     def _subdomain_host_default(self):

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -243,7 +243,8 @@ class MockHub(JupyterHub):
             cert_location = kwargs['internal_certs_location']
             kwargs['external_certs'] = ssl_setup(cert_location, 'hub-ca')
         super().__init__(*args, **kwargs)
-        self.config.Authenticator.allow_all = True
+        if 'allow_all' not in self.config.Authenticator:
+            self.config.Authenticatorallow_all = True
 
     @default('subdomain_host')
     def _subdomain_host_default(self):

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -475,6 +475,7 @@ async def test_user_creation(tmpdir, request):
     ]
 
     cfg = Config()
+    cfg.Authenticator.allow_all = False
     cfg.Authenticator.allowed_users = allowed_users
     cfg.JupyterHub.load_groups = groups
     cfg.JupyterHub.load_roles = roles

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -609,22 +609,20 @@ async def test_auth_managed_groups(
 
 
 @pytest.mark.parametrize(
-    "allowed_users, allow_all, allow_existing_users",
+    "allowed_users,  allow_existing_users",
     [
-        ('specified', False, True),
-        ('', False, False),
+        ('specified', True),
+        ('', False),
     ],
 )
-async def test_allow_defaults(
-    app, user, allowed_users, allow_all, allow_existing_users
-):
+async def test_allow_defaults(app, user, allowed_users, allow_existing_users):
     if allowed_users:
         allowed_users = set(allowed_users.split(','))
     else:
         allowed_users = set()
     authenticator = auth.Authenticator(allowed_users=allowed_users)
     authenticator.authenticate = lambda handler, data: data["username"]
-    assert authenticator.allow_all == allow_all
+    assert authenticator.allow_all is False
     assert authenticator.allow_existing_users == allow_existing_users
 
     # user was already in the database


### PR DESCRIPTION
<details><summary>Initial outdated PR text</summary>

Configuring `Authenticator.allowed_users` truthy makes other existing users in JupyterHub's database be allowed access, this could come as a surprise. This new config is meant to help avoid such surprise. With this new config, a JupyterHub admin is able to directly declare if the existing users in JupyterHub's database is to be granted access or not.

If `allow_existing_users` isn't explicity set, the default value will be computed to True or False depending on if `allowed_users` is Truthy, which makes the introduction of this config a non-breaking change.

This configuration was initially introduced in jupyterhub/oauthenticator via https://github.com/jupyterhub/oauthenticator/pull/631, and is with this PR being upstreamed to the base Authenticator class.

## Review notes

- __Should be non-breaking for oauthenticator__
  I've concluded that defining a dedicated `@default` function for `allow_existing_users`, which we don't in jupyterhub/oauthenticator, doesn't result in that having precedence in oauthenticator or similar - so introducing this in Authenticator for JupyterHub 5 won't be breaking for oauthenticator that re-defines it (and the default value - even if we have a dedicated `@default` dectorated function.

</details>

## Todo

- [x] Add allow_all config in this PR also
- [x] Add tests
- [x] Check for documentation to update

---

- closes #4484 
- closes #4487