### PR TITLE
Add system monitor for API endpoint

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -127,7 +127,7 @@ paths:
                     description: |
                       The percent of CPU usage, rounded to nearest integer
                       The output of psutil.cpu_percent()
-                  cpu_count :
+                  cpu_count:
                     type: number
                     description: The number of CPUs, as output by psutil.cpu_count()
       security:

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -80,6 +80,59 @@ paths:
       security:
         - oauth2:
             - read:hub
+  /sysmon:
+    get:
+      summary: Get system monitor information
+      description: |
+        CPU and memory usage of the server as a whole
+      responses:
+        200:
+          description: CPU and Memory usage, availability, and totals in GB or percent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  last_updated:
+                    type: string
+                    description: The local date and time, as returned by time.ctime
+                  seconds_interval:
+                    type: number
+                    description: The interval in which the metrics are updated in seconds
+                  ram_free_gb:
+                    type: number
+                    description: |
+                      Free GBs of virtual memory
+                      The output of psutil.virtual_memory().free / 1e9
+                  ram_used_gb:
+                    type: number
+                    description: |
+                      Used GBs of virtual memory
+                      The output of psutil.virtual_memory().used / 1e9
+                  ram_total_gb:
+                    type: number
+                    description: |
+                      Total GBs of virtual memory
+                      The output of psutil.virtual_memory().total / 1e9
+                  ram_free_percent:
+                    type: number
+                    description: |
+                      The percentage of free virtual memory, rounded to nearest integer
+                  ram_used_percent:
+                    type: number
+                    description: |
+                      The percentage of used virtual memory, rounded to nearest integer
+                  cpu_usage_percent:
+                    type: number
+                    description: |
+                      The percent of CPU usage, rounded to nearest integer
+                      The output of psutil.cpu_percent()
+                  cpu_count :
+                    type: number
+                    description: The number of CPUs, as output by psutil.cpu_count()
+      security:
+        - oauth2:
+            - read:hub
   /user:
     get:
       summary: Return authenticated user's model

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -4,9 +4,9 @@
 # Distributed under the terms of the Modified BSD License.
 import json
 import sys
-from time import time, ctime
+from time import ctime, time
 
-from psutil import virtual_memory, cpu_count, cpu_percent
+from psutil import cpu_count, cpu_percent, virtual_memory
 from tornado import web
 
 from .._version import __version__

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -4,15 +4,15 @@
 # Distributed under the terms of the Modified BSD License.
 import json
 import sys
+from time import time, ctime
 
+from psutil import virtual_memory, cpu_count, cpu_percent
 from tornado import web
 
 from .._version import __version__
 from ..scopes import needs_scope
 from .base import APIHandler
 
-from psutil import virtual_memory, cpu_count, cpu_percent
-from time import time, ctime
 
 class ShutdownAPIHandler(APIHandler):
     @needs_scope('shutdown')
@@ -76,8 +76,8 @@ class SysMonAPIHandler(APIHandler):
     def get(self):
         """GET /api/sysmon returns resource information about the server
 
-          It currently returns cpu and memory usage information as output by psutil.
-          The update interval can be set via 'JupyterHub.sysmon_interval' in the config.
+        It currently returns cpu and memory usage information as output by psutil.
+        The update interval can be set via 'JupyterHub.sysmon_interval' in the config.
         """
         this = SysMonAPIHandler
         conf = self.settings["config"]["JupyterHub"]
@@ -93,12 +93,12 @@ class SysMonAPIHandler(APIHandler):
                 "seconds_interval": this.seconds_interval,
                 ##"virtual_memory" : dict(vmem._asdict()),
                 "ram_free_gb": vmem.free / 1e9,
-                "ram_used_gb" : vmem.used / 1e9,
-                "ram_total_gb" : vmem.total / 1e9,
+                "ram_used_gb": vmem.used / 1e9,
+                "ram_total_gb": vmem.total / 1e9,
                 "ram_free_percent": round(100 * vmem.free / vmem.total),
                 "ram_used_percent": vmem.percent,
                 "cpu_usage_percent": round(cpu_percent()),
-                "cpu_count" : cpu_count()
+                "cpu_count": cpu_count(),
             }
             this.last_updated = current_time
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -2412,7 +2412,7 @@ async def test_sysmon(app):
         'ram_total_gb',
         'ram_used_gb',
         'ram_used_percent',
-        'seconds_interval'
+        'seconds_interval',
     ]
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -2398,6 +2398,24 @@ async def test_info(app):
     }
 
 
+async def test_sysmon(app):
+    r = await api_request(app, 'sysmon')
+    r.raise_for_status()
+    data = r.json()
+    assert data['seconds_interval'] == 10
+    assert sorted(data) == [
+        'cpu_count',
+        'cpu_usage_percent',
+        'last_updated',
+        'ram_free_gb',
+        'ram_free_percent',
+        'ram_total_gb',
+        'ram_used_gb',
+        'ram_used_percent',
+        'seconds_interval'
+    ]
+
+
 # ------------------
 # Activity API tests
 # ------------------


### PR DESCRIPTION
Continuation of: #4718 

### Motivation

I want to quickly peek at my JupyterHub machine to see what resources I have free before I spawn a new user server.

I also want to show this information to my users at the spawn page, to make them more aware of the finite resources we actually have.

### Usage

```bash
curl -H "Authorization: token <read:hub token> https://<server>/hub/api/sysmon
```

```json
{
   "last_updated": "Sat Mar  2 12:57:57 2024", 
   "seconds_interval": 20,
   "ram_free_gb": 192.120967168, 
   "ram_used_gb": 0.851726336,
   "ram_total_gb": 202.312220672,
   "ram_free_percent": 95,
   "ram_used_percent": 1.3,
   "cpu_usage_percent": 0,
   "cpu_count": 36
}
```

These results are cached and only updated every `seconds_interval` which is by default 10, but can be easily configured via `c.JupyterHub.sysmon_interval` setting.
