### PR TITLE
admin: persist page view parameters in url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ docs/source/reference/metrics.rst
 oldest-requirements.txt
 jupyterhub-proxy.pid
 examples/server-api/service-token
+
+*.hot-update*

--- a/jsx/package-lock.json
+++ b/jsx/package-lock.json
@@ -20,6 +20,7 @@
         "react-multi-select-component": "^4.3.4",
         "react-redux": "^7.2.8",
         "react-router-dom": "^5.3.4",
+        "react-router-dom-v5-compat": "^6.22.2",
         "recompose": "npm:react-recompose@^0.33.0",
         "redux": "^4.2.1",
         "regenerator-runtime": "^0.13.11"
@@ -2406,6 +2407,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
+      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@restart/hooks": {
@@ -8408,6 +8417,37 @@
       },
       "peerDependencies": {
         "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.22.2.tgz",
+      "integrity": "sha512-d7Bo6q3lRwUqtrmuULkpu3NECk+nOT3eNz6PnR5lGIWi0NN7gu6i281cqe3Cfu8v0MmNE41D0g/JdKJhfE7Brw==",
+      "dependencies": {
+        "history": "^5.3.0",
+        "react-router": "6.22.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
+        "react-router-dom": "4 || 5"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
+      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
+      "dependencies": {
+        "@remix-run/router": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom/node_modules/history": {

--- a/jsx/package-lock.json
+++ b/jsx/package-lock.json
@@ -45,7 +45,6 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "prettier": "^2.8.7",
-        "sinon": "^15.0.3",
         "style-loader": "^3.3.2",
         "webpack": "^5.79.0",
         "webpack-cli": "^5.0.1",
@@ -2467,29 +2466,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.4.14",
       "license": "MIT",
@@ -4384,14 +4360,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/diff-sequences": {
       "version": "29.4.3",
@@ -7211,11 +7179,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "dev": true,
@@ -7307,11 +7270,6 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
       "dev": true,
       "license": "MIT"
     },
@@ -7522,26 +7480,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nise": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -9038,23 +8976,6 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/sinon": {
-      "version": "15.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^10.1.0",
-        "@sinonjs/samsam": "^8.0.0",
-        "diff": "^5.1.0",
-        "nise": "^5.1.4",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/jsx/package-lock.json
+++ b/jsx/package-lock.json
@@ -19,8 +19,7 @@
         "react-icons": "^4.8.0",
         "react-multi-select-component": "^4.3.4",
         "react-redux": "^7.2.8",
-        "react-router-dom": "^5.3.4",
-        "react-router-dom-v5-compat": "^6.22.2",
+        "react-router-dom": "^6.22.2",
         "recompose": "npm:react-recompose@^0.33.0",
         "redux": "^4.2.1",
         "regenerator-runtime": "^0.13.11"
@@ -7845,17 +7844,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "dev": true,
@@ -8324,57 +8312,6 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom-v5-compat": {
-      "version": "6.22.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.22.2.tgz",
-      "integrity": "sha512-d7Bo6q3lRwUqtrmuULkpu3NECk+nOT3eNz6PnR5lGIWi0NN7gu6i281cqe3Cfu8v0MmNE41D0g/JdKJhfE7Brw==",
-      "dependencies": {
-        "history": "^5.3.0",
-        "react-router": "6.22.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "react-router-dom": "4 || 5"
-      }
-    },
-    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
       "version": "6.22.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
       "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
@@ -8388,28 +8325,20 @@
         "react": ">=16.8"
       }
     },
-    "node_modules/react-router-dom/node_modules/history": {
-      "version": "4.10.1",
-      "license": "MIT",
+    "node_modules/react-router-dom": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
+      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/history": {
-      "version": "4.10.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@remix-run/router": "1.15.2",
+        "react-router": "6.22.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {
@@ -8632,10 +8561,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "license": "MIT"
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
@@ -9449,14 +9374,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "dev": true,
@@ -9725,10 +9642,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -39,8 +39,7 @@
     "react-icons": "^4.8.0",
     "react-multi-select-component": "^4.3.4",
     "react-redux": "^7.2.8",
-    "react-router-dom": "^5.3.4",
-    "react-router-dom-v5-compat": "^6.22.2",
+    "react-router-dom": "^6.22.2",
     "recompose": "npm:react-recompose@^0.33.0",
     "redux": "^4.2.1",
     "regenerator-runtime": "^0.13.11"

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -40,6 +40,7 @@
     "react-multi-select-component": "^4.3.4",
     "react-redux": "^7.2.8",
     "react-router-dom": "^5.3.4",
+    "react-router-dom-v5-compat": "^6.22.2",
     "recompose": "npm:react-recompose@^0.33.0",
     "redux": "^4.2.1",
     "regenerator-runtime": "^0.13.11"

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -7,8 +7,8 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "build": "webpack",
+    "build:watch": "webpack watch",
     "hot": "webpack && webpack-dev-server",
-    "place": "cp build/admin-react.js* ../share/jupyterhub/static/js/",
     "test": "jest --verbose",
     "snap": "jest --updateSnapshot",
     "lint": "eslint --ext .jsx --ext .js src/",

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -65,7 +65,6 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "prettier": "^2.8.7",
-    "sinon": "^15.0.3",
     "style-loader": "^3.3.2",
     "webpack": "^5.79.0",
     "webpack-cli": "^5.0.1",

--- a/jsx/src/App.jsx
+++ b/jsx/src/App.jsx
@@ -5,7 +5,7 @@ import { createStore } from "redux";
 import { compose } from "recompose";
 import { initialState, reducers } from "./Store";
 import withAPI from "./util/withAPI";
-import { HashRouter, Switch, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 
 import ServerDashboard from "./components/ServerDashboard/ServerDashboard";
 import Groups from "./components/Groups/Groups";
@@ -13,7 +13,6 @@ import GroupEdit from "./components/GroupEdit/GroupEdit";
 import CreateGroup from "./components/CreateGroup/CreateGroup";
 import AddUser from "./components/AddUser/AddUser";
 import EditUser from "./components/EditUser/EditUser";
-import { CompatRouter } from "react-router-dom-v5-compat";
 
 import "./style/root.css";
 
@@ -24,40 +23,17 @@ const App = () => {
     <div className="resets">
       <Provider store={store}>
         <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <Route
-                exact
-                path="/"
-                component={compose(withAPI)(ServerDashboard)}
-              />
-              <Route
-                exact
-                path="/groups"
-                component={compose(withAPI)(Groups)}
-              />
-              <Route
-                exact
-                path="/group-edit"
-                component={compose(withAPI)(GroupEdit)}
-              />
-              <Route
-                exact
-                path="/create-group"
-                component={compose(withAPI)(CreateGroup)}
-              />
-              <Route
-                exact
-                path="/add-users"
-                component={compose(withAPI)(AddUser)}
-              />
-              <Route
-                exact
-                path="/edit-user"
-                component={compose(withAPI)(EditUser)}
-              />
-            </Switch>
-          </CompatRouter>
+          <Routes>
+            <Route path="/" element={compose(withAPI)(ServerDashboard)()} />
+            <Route path="/groups" element={compose(withAPI)(Groups)()} />
+            <Route path="/group-edit" element={compose(withAPI)(GroupEdit)()} />
+            <Route
+              path="/create-group"
+              element={compose(withAPI)(CreateGroup)()}
+            />
+            <Route path="/add-users" element={compose(withAPI)(AddUser)()} />
+            <Route path="/edit-user" element={compose(withAPI)(EditUser)()} />
+          </Routes>
         </HashRouter>
       </Provider>
     </div>

--- a/jsx/src/App.jsx
+++ b/jsx/src/App.jsx
@@ -13,6 +13,7 @@ import GroupEdit from "./components/GroupEdit/GroupEdit";
 import CreateGroup from "./components/CreateGroup/CreateGroup";
 import AddUser from "./components/AddUser/AddUser";
 import EditUser from "./components/EditUser/EditUser";
+import { CompatRouter } from "react-router-dom-v5-compat";
 
 import "./style/root.css";
 
@@ -23,34 +24,40 @@ const App = () => {
     <div className="resets">
       <Provider store={store}>
         <HashRouter>
-          <Switch>
-            <Route
-              exact
-              path="/"
-              component={compose(withAPI)(ServerDashboard)}
-            />
-            <Route exact path="/groups" component={compose(withAPI)(Groups)} />
-            <Route
-              exact
-              path="/group-edit"
-              component={compose(withAPI)(GroupEdit)}
-            />
-            <Route
-              exact
-              path="/create-group"
-              component={compose(withAPI)(CreateGroup)}
-            />
-            <Route
-              exact
-              path="/add-users"
-              component={compose(withAPI)(AddUser)}
-            />
-            <Route
-              exact
-              path="/edit-user"
-              component={compose(withAPI)(EditUser)}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <Route
+                exact
+                path="/"
+                component={compose(withAPI)(ServerDashboard)}
+              />
+              <Route
+                exact
+                path="/groups"
+                component={compose(withAPI)(Groups)}
+              />
+              <Route
+                exact
+                path="/group-edit"
+                component={compose(withAPI)(GroupEdit)}
+              />
+              <Route
+                exact
+                path="/create-group"
+                component={compose(withAPI)(CreateGroup)}
+              />
+              <Route
+                exact
+                path="/add-users"
+                component={compose(withAPI)(AddUser)}
+              />
+              <Route
+                exact
+                path="/edit-user"
+                component={compose(withAPI)(EditUser)}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>
     </div>

--- a/jsx/src/Store.js
+++ b/jsx/src/Store.js
@@ -17,6 +17,13 @@ export const reducers = (state = initialState, action) => {
         }),
       });
 
+    case "USER_LIMIT":
+      return Object.assign({}, state, {
+        user_page: Object.assign({}, state.user_page, {
+          limit: action.value.limit,
+        }),
+      });
+
     case "USER_NAME_FILTER":
       // set offset to 0 if name filter changed,
       // otherwise leave it alone

--- a/jsx/src/Store.js
+++ b/jsx/src/Store.js
@@ -1,53 +1,18 @@
 export const initialState = {
   user_data: undefined,
-  user_page: { offset: 0, limit: window.api_page_limit || 100 },
-  name_filter: "",
+  user_page: undefined,
   groups_data: undefined,
-  groups_page: { offset: 0, limit: window.api_page_limit || 100 },
+  groups_page: undefined,
   limit: window.api_page_limit || 100,
 };
 
 export const reducers = (state = initialState, action) => {
   switch (action.type) {
     // Updates the client user model data and stores the page
-    case "USER_OFFSET":
-      return Object.assign({}, state, {
-        user_page: Object.assign({}, state.user_page, {
-          offset: action.value.offset,
-        }),
-      });
-
-    case "USER_LIMIT":
-      return Object.assign({}, state, {
-        user_page: Object.assign({}, state.user_page, {
-          limit: action.value.limit,
-        }),
-      });
-
-    case "USER_NAME_FILTER":
-      // set offset to 0 if name filter changed,
-      // otherwise leave it alone
-      const newOffset =
-        action.value.name_filter !== state.name_filter ? 0 : state.name_filter;
-      return Object.assign({}, state, {
-        user_page: Object.assign({}, state.user_page, {
-          offset: newOffset,
-        }),
-        name_filter: action.value.name_filter,
-      });
-
     case "USER_PAGE":
       return Object.assign({}, state, {
         user_page: action.value.page,
         user_data: action.value.data,
-      });
-
-    // Updates the client group user model data and stores the page
-    case "GROUPS_OFFSET":
-      return Object.assign({}, state, {
-        groups_page: Object.assign({}, state.groups_page, {
-          offset: action.value.offset,
-        }),
       });
 
     case "GROUPS_PAGE":

--- a/jsx/src/components/DynamicTable/DynamicTable.jsx
+++ b/jsx/src/components/DynamicTable/DynamicTable.jsx
@@ -199,8 +199,8 @@ const DynamicTable = (props) => {
 DynamicTable.propTypes = {
   current_keys: PropTypes.array,
   current_values: PropTypes.array,
-  setPropKeys: PropTypes.array,
-  setPropValues: PropTypes.array,
+  setPropKeys: PropTypes.func,
+  setPropValues: PropTypes.func,
   setProp: PropTypes.func,
 };
 export default DynamicTable;

--- a/jsx/src/components/DynamicTable/DynamicTable.jsx
+++ b/jsx/src/components/DynamicTable/DynamicTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import "./table-select.css";
 import PropTypes from "prop-types";
 

--- a/jsx/src/components/GroupEdit/GroupEdit.test.jsx
+++ b/jsx/src/components/GroupEdit/GroupEdit.test.jsx
@@ -6,7 +6,6 @@ import userEvent from "@testing-library/user-event";
 import { Provider, useSelector } from "react-redux";
 import { createStore } from "redux";
 import { HashRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 // eslint-disable-next-line
 import regeneratorRuntime from "regenerator-runtime";
 
@@ -28,22 +27,20 @@ var okPacket = new Promise((resolve) => resolve(true));
 var groupEditJsx = (callbackSpy) => (
   <Provider store={createStore(() => {}, {})}>
     <HashRouter>
-      <CompatRouter>
-        <GroupEdit
-          location={{
-            state: {
-              group_data: { users: ["foo"], name: "group" },
-              callback: () => {},
-            },
-          }}
-          addToGroup={callbackSpy}
-          removeFromGroup={callbackSpy}
-          deleteGroup={callbackSpy}
-          history={{ push: () => callbackSpy }}
-          updateGroups={callbackSpy}
-          validateUser={jest.fn().mockImplementation(() => okPacket)}
-        />
-      </CompatRouter>
+      <GroupEdit
+        location={{
+          state: {
+            group_data: { users: ["foo"], name: "group" },
+            callback: () => {},
+          },
+        }}
+        addToGroup={callbackSpy}
+        removeFromGroup={callbackSpy}
+        deleteGroup={callbackSpy}
+        history={{ push: () => callbackSpy }}
+        updateGroups={callbackSpy}
+        validateUser={jest.fn().mockImplementation(() => okPacket)}
+      />
     </HashRouter>
   </Provider>
 );

--- a/jsx/src/components/GroupEdit/GroupEdit.test.jsx
+++ b/jsx/src/components/GroupEdit/GroupEdit.test.jsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 import { Provider, useSelector } from "react-redux";
 import { createStore } from "redux";
 import { HashRouter } from "react-router-dom";
+import { CompatRouter } from "react-router-dom-v5-compat";
 // eslint-disable-next-line
 import regeneratorRuntime from "regenerator-runtime";
 
@@ -27,20 +28,22 @@ var okPacket = new Promise((resolve) => resolve(true));
 var groupEditJsx = (callbackSpy) => (
   <Provider store={createStore(() => {}, {})}>
     <HashRouter>
-      <GroupEdit
-        location={{
-          state: {
-            group_data: { users: ["foo"], name: "group" },
-            callback: () => {},
-          },
-        }}
-        addToGroup={callbackSpy}
-        removeFromGroup={callbackSpy}
-        deleteGroup={callbackSpy}
-        history={{ push: () => callbackSpy }}
-        updateGroups={callbackSpy}
-        validateUser={jest.fn().mockImplementation(() => okPacket)}
-      />
+      <CompatRouter>
+        <GroupEdit
+          location={{
+            state: {
+              group_data: { users: ["foo"], name: "group" },
+              callback: () => {},
+            },
+          }}
+          addToGroup={callbackSpy}
+          removeFromGroup={callbackSpy}
+          deleteGroup={callbackSpy}
+          history={{ push: () => callbackSpy }}
+          updateGroups={callbackSpy}
+          validateUser={jest.fn().mockImplementation(() => okPacket)}
+        />
+      </CompatRouter>
     </HashRouter>
   </Provider>
 );

--- a/jsx/src/components/Groups/Groups.jsx
+++ b/jsx/src/components/Groups/Groups.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
-import { debounce } from "lodash";
 
 import { Link } from "react-router-dom";
 import { useSearchParams } from "react-router-dom-v5-compat";
@@ -12,49 +11,15 @@ const Groups = (props) => {
     groups_page = useSelector((state) => state.groups_page),
     dispatch = useDispatch();
 
-  let [searchParams, setSearchParams] = useSearchParams();
-
-  var offset = parseInt(searchParams.get("offset", "0")) || 0;
-  var limit = parseInt(searchParams.get("limit", "0")) || window.api_page_limit;
-
-  const setOffset = (offset) => {
-    console.log("setting offset", offset);
-    if (offset < 0) {
-      offset = 0;
-    }
-    setSearchParams((params) => {
-      params.set("offset", offset);
-      return params;
-    });
-    dispatch({
-      type: "GROUPS_OFFSET",
-      value: {
-        offset: offset,
-      },
-    });
-  };
-
-  const setLimit = (newLimit) => {
-    if (newLimit < 1) {
-      newLimit = 10;
-    }
-    setSearchParams((params) => {
-      params.set("limit", newLimit);
-      return params;
-    });
-    dispatch({
-      type: "GROUP_LIMIT",
-      value: {
-        limit: newLimit,
-      },
-    });
-  };
+  const { setOffset, offset, setLimit, handleLimit, limit, setPagination } =
+    usePaginationParams();
 
   var total = groups_page ? groups_page.total : undefined;
 
   var { updateGroups, history } = props;
 
   const dispatchPageUpdate = (data, page) => {
+    setPagination(page);
     dispatch({
       type: "GROUPS_PAGE",
       value: {
@@ -73,10 +38,6 @@ const Groups = (props) => {
   if (!groups_data || !groups_page) {
     return <div data-testid="no-show"></div>;
   }
-
-  const handleLimit = debounce(async (event) => {
-    setLimit(event.target.value);
-  }, 300);
 
   return (
     <div className="container" data-testid="container">

--- a/jsx/src/components/Groups/Groups.jsx
+++ b/jsx/src/components/Groups/Groups.jsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 
 import { Link } from "react-router-dom";
-import { useSearchParams } from "react-router-dom-v5-compat";
+import { usePaginationParams } from "../../util/paginationParams";
 import PaginationFooter from "../PaginationFooter/PaginationFooter";
 
 const Groups = (props) => {

--- a/jsx/src/components/Groups/Groups.test.js
+++ b/jsx/src/components/Groups/Groups.test.js
@@ -5,6 +5,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import { createStore } from "redux";
 import { HashRouter } from "react-router-dom";
+import { CompatRouter, useSearchParams } from "react-router-dom-v5-compat";
 // eslint-disable-next-line
 import regeneratorRuntime from "regenerator-runtime";
 
@@ -16,13 +17,20 @@ jest.mock("react-redux", () => ({
   useSelector: jest.fn(),
 }));
 
+jest.mock("react-router-dom-v5-compat", () => ({
+  ...jest.requireActual("react-router-dom-v5-compat"),
+  useSearchParams: jest.fn(),
+}));
+
 var mockAsync = () =>
   jest.fn().mockImplementation(() => Promise.resolve({ key: "value" }));
 
 var groupsJsx = (callbackSpy) => (
   <Provider store={createStore(mockReducers, mockAppState())}>
     <HashRouter>
-      <Groups location={{ search: "0" }} updateGroups={callbackSpy} />
+      <CompatRouter>
+        <Groups location={{ search: "0" }} updateGroups={callbackSpy} />
+      </CompatRouter>
     </HashRouter>
   </Provider>
 );
@@ -50,11 +58,6 @@ var mockAppState = () =>
       offset: 0,
       limit: 2,
       total: 4,
-      next: {
-        offset: 2,
-        limit: 2,
-        url: "http://localhost:8000/hub/api/groups?offset=2&limit=2",
-      },
     },
   });
 
@@ -62,11 +65,15 @@ beforeEach(() => {
   useSelector.mockImplementation((callback) => {
     return callback(mockAppState());
   });
+  useSearchParams.mockImplementation(() => {
+    return [new URLSearchParams(), jest.fn()];
+  });
 });
 
 afterEach(() => {
   useSelector.mockClear();
   mockReducers.mockClear();
+  useSearchParams.mockClear();
 });
 
 test("Renders", async () => {
@@ -109,13 +116,23 @@ test("Renders nothing if required data is not available", async () => {
 });
 
 test("Interacting with PaginationFooter causes state update and refresh via useEffect call", async () => {
-  let callbackSpy = mockAsync();
-
+  let upgradeGroupsSpy = mockAsync();
+  let setSearchParamsSpy = mockAsync();
+  let searchParams = new URLSearchParams({ limit: "2" });
+  useSearchParams.mockImplementation(() => [
+    searchParams,
+    (callback) => {
+      searchParams = callback(searchParams);
+      setSearchParamsSpy(searchParams.toString());
+    },
+  ]);
+  let _, setSearchParams;
   await act(async () => {
-    render(groupsJsx(callbackSpy));
+    render(groupsJsx(upgradeGroupsSpy));
+    [_, setSearchParams] = useSearchParams();
   });
 
-  expect(callbackSpy).toBeCalledWith(0, 2);
+  expect(upgradeGroupsSpy).toBeCalledWith(0, 2);
 
   var lastState =
     mockReducers.mock.results[mockReducers.mock.results.length - 1].value;
@@ -123,12 +140,10 @@ test("Interacting with PaginationFooter causes state update and refresh via useE
   expect(lastState.groups_page.limit).toEqual(2);
 
   let next = screen.getByTestId("paginate-next");
-  fireEvent.click(next);
-
-  lastState =
-    mockReducers.mock.results[mockReducers.mock.results.length - 1].value;
-  expect(lastState.groups_page.offset).toEqual(2);
-  expect(lastState.groups_page.limit).toEqual(2);
+  await act(async () => {
+    fireEvent.click(next);
+  });
+  expect(setSearchParamsSpy).toBeCalledWith("limit=2&offset=2");
 
   // FIXME: mocked useSelector, state seem to prevent updateGroups from being called
   // making the test environment not representative

--- a/jsx/src/components/Groups/Groups.test.js
+++ b/jsx/src/components/Groups/Groups.test.js
@@ -4,8 +4,7 @@ import { act } from "react-dom/test-utils";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import { createStore } from "redux";
-import { HashRouter } from "react-router-dom";
-import { CompatRouter, useSearchParams } from "react-router-dom-v5-compat";
+import { HashRouter, useSearchParams } from "react-router-dom";
 // eslint-disable-next-line
 import regeneratorRuntime from "regenerator-runtime";
 
@@ -17,8 +16,8 @@ jest.mock("react-redux", () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock("react-router-dom-v5-compat", () => ({
-  ...jest.requireActual("react-router-dom-v5-compat"),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
   useSearchParams: jest.fn(),
 }));
 
@@ -28,9 +27,7 @@ var mockAsync = () =>
 var groupsJsx = (callbackSpy) => (
   <Provider store={createStore(mockReducers, mockAppState())}>
     <HashRouter>
-      <CompatRouter>
-        <Groups location={{ search: "0" }} updateGroups={callbackSpy} />
-      </CompatRouter>
+      <Groups location={{ search: "0" }} updateGroups={callbackSpy} />
     </HashRouter>
   </Provider>
 );

--- a/jsx/src/components/Groups/Groups.test.js
+++ b/jsx/src/components/Groups/Groups.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import "@testing-library/jest-dom";
 import { act } from "react-dom/test-utils";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { Provider, useDispatch, useSelector } from "react-redux";
+import { Provider, useSelector } from "react-redux";
 import { createStore } from "redux";
 import { HashRouter, useSearchParams } from "react-router-dom";
 // eslint-disable-next-line

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -9,7 +9,7 @@ const PaginationFooter = (props) => {
   return (
     <div className="pagination-footer">
       <p>
-        Displaying {offset}-{offset + visible}
+        Displaying {offset}-{offset + visible} {total ? `of ${total}` : ""}
         <br />
         {offset >= 1 ? (
           <button className="btn btn-sm btn-light spaced">
@@ -61,10 +61,13 @@ const PaginationFooter = (props) => {
 
 PaginationFooter.propTypes = {
   endpoint: PropTypes.string,
-  page: PropTypes.number,
+  offset: PropTypes.number,
   limit: PropTypes.number,
-  numOffset: PropTypes.number,
-  numElements: PropTypes.number,
+  visible: PropTypes.number,
+  total: PropTypes.number,
+  handleLimit: PropTypes.func,
+  next: PropTypes.func,
+  prev: PropTypes.func,
 };
 
 export default PaginationFooter;

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -1,16 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { FormControl } from "react-bootstrap";
 
 import "./pagination-footer.css";
 
 const PaginationFooter = (props) => {
-  let { offset, limit, visible, total, next, prev } = props;
+  let { offset, limit, visible, total, next, prev, handleLimit } = props;
   return (
     <div className="pagination-footer">
       <p>
         Displaying {offset}-{offset + visible}
-        <br></br>
-        <br></br>
+        <br />
         {offset >= 1 ? (
           <button className="btn btn-sm btn-light spaced">
             <span
@@ -41,6 +41,19 @@ const PaginationFooter = (props) => {
             <span className="inactive-pagination">Next</span>
           </button>
         )}
+        <label>
+          Items per page:
+          <FormControl
+            type="number"
+            min="25"
+            step="25"
+            name="pagination-limit"
+            placeholder={limit}
+            aria-label="pagination-limit"
+            defaultValue={limit}
+            onChange={handleLimit}
+          />
+        </label>
       </p>
     </div>
   );

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -9,7 +9,7 @@ const PaginationFooter = (props) => {
   return (
     <div className="pagination-footer">
       <p>
-        Displaying {offset}-{offset + visible} {total ? `of ${total}` : ""}
+        Displaying {offset + 1}-{offset + visible} {total ? `of ${total}` : ""}
         <br />
         {offset >= 1 ? (
           <button className="btn btn-sm btn-light spaced">

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -86,10 +86,14 @@ const ServerDashboard = (props) => {
     });
   };
 
-  const setNameFilter = (name_filter) => {
+  const setNameFilter = (new_name_filter) => {
     setSearchParams((params) => {
-      if (name_filter) {
-        params.set("name_filter", name_filter);
+      // clear offset when name filter changes
+      if (new_name_filter !== name_filter) {
+        params.delete("offset");
+      }
+      if (new_name_filter) {
+        params.set("name_filter", new_name_filter);
       } else {
         params.delete("name_filter");
       }

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -14,10 +14,7 @@ import {
 } from "react-bootstrap";
 import ReactObjectTableViewer from "../ReactObjectTableViewer/ReactObjectTableViewer";
 
-import { Link } from "react-router-dom";
-// react-router-dom v6 API
-// should be able to upgrade to v6 someday
-import { useSearchParams } from "react-router-dom-v5-compat";
+import { Link, useSearchParams } from "react-router-dom";
 import { FaSort, FaSortUp, FaSortDown } from "react-icons/fa";
 
 import "./server-dashboard.css";

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -55,13 +55,13 @@ const ServerDashboard = (props) => {
   const [sortMethod, setSortMethod] = useState(null);
   const [collapseStates, setCollapseStates] = useState({});
 
-  const user_data = useSelector((state) => state.user_data);
+  let user_data = useSelector((state) => state.user_data);
   const user_page = useSelector((state) => state.user_page);
 
   const { setOffset, offset, setLimit, handleLimit, limit, setPagination } =
     usePaginationParams();
 
-  const name_filter = searchParams.get("name_filter");
+  const name_filter = searchParams.get("name_filter") || "";
 
   const total = user_page ? user_page.total : undefined;
 

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -10,6 +10,7 @@ import {
   getAllByRole,
 } from "@testing-library/react";
 import { HashRouter, Switch } from "react-router-dom";
+import { CompatRouter, useSearchParams } from "react-router-dom-v5-compat";
 import { Provider, useSelector } from "react-redux";
 import { createStore } from "redux";
 // eslint-disable-next-line
@@ -25,20 +26,26 @@ jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
   useSelector: jest.fn(),
 }));
+jest.mock("react-router-dom-v5-compat", () => ({
+  ...jest.requireActual("react-router-dom-v5-compat"),
+  useSearchParams: jest.fn(),
+}));
 
 var serverDashboardJsx = (spy) => (
   <Provider store={createStore(mockReducers, mockAppState())}>
     <HashRouter>
-      <Switch>
-        <ServerDashboard
-          updateUsers={spy}
-          shutdownHub={spy}
-          startServer={spy}
-          stopServer={spy}
-          startAll={spy}
-          stopAll={spy}
-        />
-      </Switch>
+      <CompatRouter>
+        <Switch>
+          <ServerDashboard
+            updateUsers={spy}
+            shutdownHub={spy}
+            startServer={spy}
+            stopServer={spy}
+            startAll={spy}
+            stopAll={spy}
+          />
+        </Switch>
+      </CompatRouter>
     </HashRouter>
   </Provider>
 );
@@ -137,14 +144,25 @@ var mockReducers = jest.fn((state, action) => {
   return state;
 });
 
+let searchParams = new URLSearchParams();
+
 beforeEach(() => {
   clock = sinon.useFakeTimers();
   useSelector.mockImplementation((callback) => {
     return callback(mockAppState());
   });
+  searchParams = new URLSearchParams();
+
+  useSearchParams.mockImplementation(() => [
+    searchParams,
+    (callback) => {
+      searchParams = callback(searchParams);
+    },
+  ]);
 });
 
 afterEach(() => {
+  useSearchParams.mockClear();
   useSelector.mockClear();
   mockReducers.mockClear();
   clock.restore();
@@ -350,16 +368,16 @@ test("Shows server details with button click", async () => {
 
   await act(async () => {
     fireEvent.click(button);
+    await clock.tick(400);
   });
-  clock.tick(400);
 
   expect(collapse).toHaveClass("collapse show");
   expect(collapseBar).not.toHaveClass("show");
 
   await act(async () => {
     fireEvent.click(button);
+    await clock.tick(400);
   });
-  clock.tick(400);
 
   expect(collapse).toHaveClass("collapse");
   expect(collapse).not.toHaveClass("show");
@@ -367,8 +385,8 @@ test("Shows server details with button click", async () => {
 
   await act(async () => {
     fireEvent.click(button);
+    await clock.tick(400);
   });
-  clock.tick(400);
 
   expect(collapse).toHaveClass("collapse show");
   expect(collapseBar).not.toHaveClass("show");
@@ -398,16 +416,18 @@ test("Shows a UI error dialogue when start all servers fails", async () => {
     render(
       <Provider store={createStore(() => {}, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={spy}
-              shutdownHub={spy}
-              startServer={spy}
-              stopServer={spy}
-              startAll={rejectSpy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={spy}
+                shutdownHub={spy}
+                startServer={spy}
+                stopServer={spy}
+                startAll={rejectSpy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -432,16 +452,18 @@ test("Shows a UI error dialogue when stop all servers fails", async () => {
     render(
       <Provider store={createStore(() => {}, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={spy}
-              shutdownHub={spy}
-              startServer={spy}
-              stopServer={spy}
-              startAll={spy}
-              stopAll={rejectSpy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={spy}
+                shutdownHub={spy}
+                startServer={spy}
+                stopServer={spy}
+                startAll={spy}
+                stopAll={rejectSpy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -466,16 +488,18 @@ test("Shows a UI error dialogue when start user server fails", async () => {
     render(
       <Provider store={createStore(() => {}, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={spy}
-              shutdownHub={spy}
-              startServer={rejectSpy}
-              stopServer={spy}
-              startAll={spy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={spy}
+                shutdownHub={spy}
+                startServer={rejectSpy}
+                stopServer={spy}
+                startAll={spy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -501,16 +525,18 @@ test("Shows a UI error dialogue when start user server returns an improper statu
     render(
       <Provider store={createStore(() => {}, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={spy}
-              shutdownHub={spy}
-              startServer={rejectSpy}
-              stopServer={spy}
-              startAll={spy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={spy}
+                shutdownHub={spy}
+                startServer={rejectSpy}
+                stopServer={spy}
+                startAll={spy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -536,16 +562,18 @@ test("Shows a UI error dialogue when stop user servers fails", async () => {
     render(
       <Provider store={createStore(() => {}, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={spy}
-              shutdownHub={spy}
-              startServer={spy}
-              stopServer={rejectSpy}
-              startAll={spy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={spy}
+                shutdownHub={spy}
+                startServer={spy}
+                stopServer={rejectSpy}
+                startAll={spy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -570,16 +598,18 @@ test("Shows a UI error dialogue when stop user server returns an improper status
     render(
       <Provider store={createStore(() => {}, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={spy}
-              shutdownHub={spy}
-              startServer={spy}
-              stopServer={rejectSpy}
-              startAll={spy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={spy}
+                shutdownHub={spy}
+                startServer={spy}
+                stopServer={rejectSpy}
+                startAll={spy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -616,16 +646,18 @@ test("Search for user calls updateUsers with name filter", async () => {
     render(
       <Provider store={createStore(mockReducers, mockAppState())}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={mockUpdateUsers}
-              shutdownHub={spy}
-              startServer={spy}
-              stopServer={spy}
-              startAll={spy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={mockUpdateUsers}
+                shutdownHub={spy}
+                startServer={spy}
+                stopServer={spy}
+                startAll={spy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );
@@ -637,21 +669,20 @@ test("Search for user calls updateUsers with name filter", async () => {
 
   userEvent.type(search, "a");
   expect(search.value).toEqual("a");
-  clock.tick(400);
-  expect(mockReducers.mock.calls).toHaveLength(3);
-  var lastState =
-    mockReducers.mock.results[mockReducers.mock.results.length - 1].value;
-  expect(lastState.name_filter).toEqual("a");
-  // TODO: this should
-  expect(mockUpdateUsers.mock.calls).toHaveLength(1);
+  await act(async () => {
+    await clock.tick(400);
+  });
+  expect(searchParams.get("name_filter")).toEqual("a");
+  // FIXME: useSelector mocks prevent updateUsers from being called
+  // expect(mockUpdateUsers.mock.calls).toHaveLength(2);
+  // expect(mockUpdateUsers).toBeCalledWith(0, 100, "a");
   userEvent.type(search, "b");
   expect(search.value).toEqual("ab");
-  clock.tick(400);
-  expect(mockReducers.mock.calls).toHaveLength(4);
-  lastState =
-    mockReducers.mock.results[mockReducers.mock.results.length - 1].value;
-  expect(lastState.name_filter).toEqual("ab");
-  expect(lastState.user_page.offset).toEqual(0);
+  await act(async () => {
+    jest.runAllTimers();
+  });
+  expect(searchParams.get("name_filter")).toEqual("ab");
+  // expect(mockUpdateUsers).toBeCalledWith(0, 100, "ab");
 });
 
 test("Interacting with PaginationFooter causes state update and refresh via useEffect call", async () => {
@@ -661,24 +692,20 @@ test("Interacting with PaginationFooter causes state update and refresh via useE
     render(serverDashboardJsx(callbackSpy));
   });
 
-  expect(callbackSpy).toBeCalledWith(0, 2, "");
+  expect(callbackSpy).toBeCalledWith(0, 100, "");
 
-  expect(mockReducers.mock.results).toHaveLength(2);
-  lastState =
-    mockReducers.mock.results[mockReducers.mock.results.length - 1].value;
-  console.log(lastState);
-  expect(lastState.user_page.offset).toEqual(0);
-  expect(lastState.user_page.limit).toEqual(2);
+  var n = 3;
+  expect(searchParams.get("offset")).toEqual(null);
+  expect(searchParams.get("limit")).toEqual(null);
 
   let next = screen.getByTestId("paginate-next");
-  fireEvent.click(next);
-  clock.tick(400);
+  await act(async () => {
+    fireEvent.click(next);
+    await clock.tick(400);
+  });
 
-  expect(mockReducers.mock.results).toHaveLength(3);
-  var lastState =
-    mockReducers.mock.results[mockReducers.mock.results.length - 1].value;
-  expect(lastState.user_page.offset).toEqual(2);
-  expect(lastState.user_page.limit).toEqual(2);
+  expect(searchParams.get("offset")).toEqual("100");
+  expect(searchParams.get("limit")).toEqual(null);
 
   // FIXME: should call updateUsers, does in reality.
   // tests don't reflect reality due to mocked state/useSelector
@@ -721,16 +748,18 @@ test("Start server and confirm pending state", async () => {
     render(
       <Provider store={createStore(mockReducers, {})}>
         <HashRouter>
-          <Switch>
-            <ServerDashboard
-              updateUsers={mockUpdateUsers}
-              shutdownHub={spy}
-              startServer={mockStartServer}
-              stopServer={spy}
-              startAll={spy}
-              stopAll={spy}
-            />
-          </Switch>
+          <CompatRouter>
+            <Switch>
+              <ServerDashboard
+                updateUsers={mockUpdateUsers}
+                shutdownHub={spy}
+                startServer={mockStartServer}
+                stopServer={spy}
+                startAll={spy}
+                stopAll={spy}
+              />
+            </Switch>
+          </CompatRouter>
         </HashRouter>
       </Provider>,
     );

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -9,8 +9,8 @@ import {
   getByText,
   getAllByRole,
 } from "@testing-library/react";
-import { HashRouter, Switch } from "react-router-dom";
-import { CompatRouter, useSearchParams } from "react-router-dom-v5-compat";
+import { HashRouter, Routes, Route, useSearchParams } from "react-router-dom";
+// import { CompatRouter,  } from "react-router-dom-v5-compat";
 import { Provider, useSelector } from "react-redux";
 import { createStore } from "redux";
 // eslint-disable-next-line
@@ -23,8 +23,8 @@ jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
   useSelector: jest.fn(),
 }));
-jest.mock("react-router-dom-v5-compat", () => ({
-  ...jest.requireActual("react-router-dom-v5-compat"),
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
   useSearchParams: jest.fn(),
 }));
 

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -509,6 +509,7 @@ test("Search for user calls updateUsers with name filter", async () => {
     });
   });
   await act(async () => {
+    searchParams.set("offset", "2");
     render(serverDashboardJsx({ updateUsers: mockUpdateUsers }));
   });
 
@@ -516,12 +517,14 @@ test("Search for user calls updateUsers with name filter", async () => {
 
   expect(mockUpdateUsers.mock.calls).toHaveLength(1);
 
+  expect(searchParams.get("offset")).toEqual("2");
   userEvent.type(search, "a");
   expect(search.value).toEqual("a");
   await act(async () => {
     jest.runAllTimers();
   });
   expect(searchParams.get("name_filter")).toEqual("a");
+  expect(searchParams.get("offset")).toEqual(null);
   // FIXME: useSelector mocks prevent updateUsers from being called
   // expect(mockUpdateUsers.mock.calls).toHaveLength(2);
   // expect(mockUpdateUsers).toBeCalledWith(0, 100, "a");

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -18,9 +18,6 @@ import regeneratorRuntime from "regenerator-runtime";
 
 import ServerDashboard from "./ServerDashboard";
 import { initialState, reducers } from "../../Store";
-import * as sinon from "sinon";
-
-let clock;
 
 jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
@@ -147,7 +144,7 @@ var mockReducers = jest.fn((state, action) => {
 let searchParams = new URLSearchParams();
 
 beforeEach(() => {
-  clock = sinon.useFakeTimers();
+  jest.useFakeTimers();
   useSelector.mockImplementation((callback) => {
     return callback(mockAppState());
   });
@@ -165,7 +162,7 @@ afterEach(() => {
   useSearchParams.mockClear();
   useSelector.mockClear();
   mockReducers.mockClear();
-  clock.restore();
+  jest.runAllTimers();
 });
 
 test("Renders", async () => {
@@ -368,7 +365,7 @@ test("Shows server details with button click", async () => {
 
   await act(async () => {
     fireEvent.click(button);
-    await clock.tick(400);
+    jest.runAllTimers();
   });
 
   expect(collapse).toHaveClass("collapse show");
@@ -376,7 +373,7 @@ test("Shows server details with button click", async () => {
 
   await act(async () => {
     fireEvent.click(button);
-    await clock.tick(400);
+    jest.runAllTimers();
   });
 
   expect(collapse).toHaveClass("collapse");
@@ -385,7 +382,7 @@ test("Shows server details with button click", async () => {
 
   await act(async () => {
     fireEvent.click(button);
-    await clock.tick(400);
+    jest.runAllTimers();
   });
 
   expect(collapse).toHaveClass("collapse show");
@@ -670,7 +667,7 @@ test("Search for user calls updateUsers with name filter", async () => {
   userEvent.type(search, "a");
   expect(search.value).toEqual("a");
   await act(async () => {
-    await clock.tick(400);
+    jest.runAllTimers();
   });
   expect(searchParams.get("name_filter")).toEqual("a");
   // FIXME: useSelector mocks prevent updateUsers from being called
@@ -701,7 +698,7 @@ test("Interacting with PaginationFooter causes state update and refresh via useE
   let next = screen.getByTestId("paginate-next");
   await act(async () => {
     fireEvent.click(next);
-    await clock.tick(400);
+    jest.runAllTimers();
   });
 
   expect(searchParams.get("offset")).toEqual("100");
@@ -736,7 +733,7 @@ test("Start server and confirm pending state", async () => {
 
   let mockStartServer = jest.fn(() => {
     return new Promise(async (resolve) =>
-      clock.setTimeout(() => {
+      setTimeout(() => {
         resolve({ status: 200 });
       }, 100),
     );
@@ -784,7 +781,7 @@ test("Start server and confirm pending state", async () => {
   expect(buttons[1]).toBeEnabled();
 
   await act(async () => {
-    await clock.tick(100);
+    jest.runAllTimers();
   });
   expect(mockUpdateUsers.mock.calls).toHaveLength(2);
 });

--- a/jsx/src/components/ServerDashboard/ServerDashboard.test.js
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.test.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { withProps } from "recompose";
 import "@testing-library/jest-dom";
 import { act } from "react-dom/test-utils";
 import userEvent from "@testing-library/user-event";
@@ -28,24 +29,25 @@ jest.mock("react-router-dom", () => ({
   useSearchParams: jest.fn(),
 }));
 
-var serverDashboardJsx = (spy) => (
-  <Provider store={createStore(mockReducers, mockAppState())}>
-    <HashRouter>
-      <CompatRouter>
-        <Switch>
-          <ServerDashboard
-            updateUsers={spy}
-            shutdownHub={spy}
-            startServer={spy}
-            stopServer={spy}
-            startAll={spy}
-            stopAll={spy}
-          />
-        </Switch>
-      </CompatRouter>
-    </HashRouter>
-  </Provider>
-);
+const serverDashboardJsx = (props) => {
+  // create mock ServerDashboard
+  // spies is a dict of properties to mock in
+  // any API calls that will fire during the test should be mocked
+  props = props || {};
+  const defaultSpy = mockAsync();
+  if (!props.updateUsers) {
+    props.updateUsers = defaultSpy;
+  }
+  return (
+    <Provider store={createStore(mockReducers, mockAppState())}>
+      <HashRouter>
+        <Routes>
+          <Route path="/" element={withProps(props)(ServerDashboard)()} />
+        </Routes>
+      </HashRouter>
+    </Provider>
+  );
+};
 
 var mockAsync = (data) =>
   jest.fn().mockImplementation(() => Promise.resolve(data ? data : { k: "v" }));
@@ -166,20 +168,16 @@ afterEach(() => {
 });
 
 test("Renders", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   expect(screen.getByTestId("container")).toBeVisible();
 });
 
 test("Renders users from props.user_data into table", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let foo = screen.getByTestId("user-name-div-foo");
@@ -192,10 +190,8 @@ test("Renders users from props.user_data into table", async () => {
 });
 
 test("Renders correctly the status of a single-user server", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let start_elems = screen.getAllByText("Start Server");
@@ -209,10 +205,8 @@ test("Renders correctly the status of a single-user server", async () => {
 });
 
 test("Renders spawn page link", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   for (let server in bar_servers) {
@@ -227,7 +221,7 @@ test("Invokes the startServer event on button click", async () => {
   let callbackSpy = mockAsync();
 
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx({ startServer: callbackSpy }));
   });
 
   let start_elems = screen.getAllByText("Start Server");
@@ -244,7 +238,7 @@ test("Invokes the stopServer event on button click", async () => {
   let callbackSpy = mockAsync();
 
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx({ stopServer: callbackSpy }));
   });
 
   let stop = screen.getByText("Stop Server");
@@ -260,7 +254,7 @@ test("Invokes the shutdownHub event on button click", async () => {
   let callbackSpy = mockAsync();
 
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx({ shutdownHub: callbackSpy }));
   });
 
   let shutdown = screen.getByText("Shutdown Hub");
@@ -273,10 +267,8 @@ test("Invokes the shutdownHub event on button click", async () => {
 });
 
 test("Sorts according to username", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let handler = screen.getByTestId("user-sort");
@@ -292,10 +284,8 @@ test("Sorts according to username", async () => {
 });
 
 test("Sorts according to admin", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let handler = screen.getByTestId("admin-sort");
@@ -311,10 +301,8 @@ test("Sorts according to admin", async () => {
 });
 
 test("Sorts according to last activity", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let handler = screen.getByTestId("last-activity-sort");
@@ -330,10 +318,8 @@ test("Sorts according to last activity", async () => {
 });
 
 test("Sorts according to server status (running/not running)", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let handler = screen.getByTestId("running-status-sort");
@@ -349,10 +335,8 @@ test("Sorts according to server status (running/not running)", async () => {
 });
 
 test("Shows server details with button click", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
   let button = screen.getByTestId("foo-collapse-button");
   let collapse = screen.getByTestId("foo-collapse");
@@ -394,10 +378,8 @@ test("Renders nothing if required data is not available", async () => {
     return callback({});
   });
 
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   let noShow = screen.getByTestId("no-show");
@@ -406,28 +388,8 @@ test("Renders nothing if required data is not available", async () => {
 });
 
 test("Shows a UI error dialogue when start all servers fails", async () => {
-  let spy = mockAsync();
-  let rejectSpy = mockAsyncRejection;
-
   await act(async () => {
-    render(
-      <Provider store={createStore(() => {}, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={spy}
-                shutdownHub={spy}
-                startServer={spy}
-                stopServer={spy}
-                startAll={rejectSpy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ startAll: mockAsyncRejection }));
   });
 
   let startAll = screen.getByTestId("start-all");
@@ -442,28 +404,8 @@ test("Shows a UI error dialogue when start all servers fails", async () => {
 });
 
 test("Shows a UI error dialogue when stop all servers fails", async () => {
-  let spy = mockAsync();
-  let rejectSpy = mockAsyncRejection;
-
   await act(async () => {
-    render(
-      <Provider store={createStore(() => {}, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={spy}
-                shutdownHub={spy}
-                startServer={spy}
-                stopServer={spy}
-                startAll={spy}
-                stopAll={rejectSpy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ stopAll: mockAsyncRejection }));
   });
 
   let stopAll = screen.getByTestId("stop-all");
@@ -478,28 +420,8 @@ test("Shows a UI error dialogue when stop all servers fails", async () => {
 });
 
 test("Shows a UI error dialogue when start user server fails", async () => {
-  let spy = mockAsync();
-  let rejectSpy = mockAsyncRejection();
-
   await act(async () => {
-    render(
-      <Provider store={createStore(() => {}, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={spy}
-                shutdownHub={spy}
-                startServer={rejectSpy}
-                stopServer={spy}
-                startAll={spy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ startServer: mockAsyncRejection() }));
   });
 
   let start_elems = screen.getAllByText("Start Server");
@@ -515,28 +437,9 @@ test("Shows a UI error dialogue when start user server fails", async () => {
 });
 
 test("Shows a UI error dialogue when start user server returns an improper status code", async () => {
-  let spy = mockAsync();
   let rejectSpy = mockAsync({ status: 403 });
-
   await act(async () => {
-    render(
-      <Provider store={createStore(() => {}, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={spy}
-                shutdownHub={spy}
-                startServer={rejectSpy}
-                stopServer={spy}
-                startAll={spy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ startServer: rejectSpy }));
   });
 
   let start_elems = screen.getAllByText("Start Server");
@@ -556,24 +459,7 @@ test("Shows a UI error dialogue when stop user servers fails", async () => {
   let rejectSpy = mockAsyncRejection();
 
   await act(async () => {
-    render(
-      <Provider store={createStore(() => {}, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={spy}
-                shutdownHub={spy}
-                startServer={spy}
-                stopServer={rejectSpy}
-                startAll={spy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ stopServer: rejectSpy }));
   });
 
   let stop = screen.getByText("Stop Server");
@@ -592,24 +478,7 @@ test("Shows a UI error dialogue when stop user server returns an improper status
   let rejectSpy = mockAsync({ status: 403 });
 
   await act(async () => {
-    render(
-      <Provider store={createStore(() => {}, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={spy}
-                shutdownHub={spy}
-                startServer={spy}
-                stopServer={rejectSpy}
-                startAll={spy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ stopServer: rejectSpy }));
   });
 
   let stop = screen.getByText("Stop Server");
@@ -640,24 +509,7 @@ test("Search for user calls updateUsers with name filter", async () => {
     });
   });
   await act(async () => {
-    render(
-      <Provider store={createStore(mockReducers, mockAppState())}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={mockUpdateUsers}
-                shutdownHub={spy}
-                startServer={spy}
-                stopServer={spy}
-                startAll={spy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
-    );
+    render(serverDashboardJsx({ updateUsers: mockUpdateUsers }));
   });
 
   let search = screen.getByLabelText("user-search");
@@ -683,13 +535,13 @@ test("Search for user calls updateUsers with name filter", async () => {
 });
 
 test("Interacting with PaginationFooter causes state update and refresh via useEffect call", async () => {
-  let callbackSpy = mockAsync();
+  let updateUsers = mockAsync();
 
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx({ updateUsers: updateUsers }));
   });
 
-  expect(callbackSpy).toBeCalledWith(0, 100, "");
+  expect(updateUsers).toBeCalledWith(0, 100, "");
 
   var n = 3;
   expect(searchParams.get("offset")).toEqual(null);
@@ -712,10 +564,8 @@ test("Interacting with PaginationFooter causes state update and refresh via useE
 });
 
 test("Server delete button exists for named servers", async () => {
-  let callbackSpy = mockAsync();
-
   await act(async () => {
-    render(serverDashboardJsx(callbackSpy));
+    render(serverDashboardJsx());
   });
 
   for (let server in bar_servers) {
@@ -729,8 +579,6 @@ test("Server delete button exists for named servers", async () => {
 });
 
 test("Start server and confirm pending state", async () => {
-  let spy = mockAsync();
-
   let mockStartServer = jest.fn(() => {
     return new Promise(async (resolve) =>
       setTimeout(() => {
@@ -743,22 +591,10 @@ test("Start server and confirm pending state", async () => {
 
   await act(async () => {
     render(
-      <Provider store={createStore(mockReducers, {})}>
-        <HashRouter>
-          <CompatRouter>
-            <Switch>
-              <ServerDashboard
-                updateUsers={mockUpdateUsers}
-                shutdownHub={spy}
-                startServer={mockStartServer}
-                stopServer={spy}
-                startAll={spy}
-                stopAll={spy}
-              />
-            </Switch>
-          </CompatRouter>
-        </HashRouter>
-      </Provider>,
+      serverDashboardJsx({
+        updateUsers: mockUpdateUsers,
+        startServer: mockStartServer,
+      }),
     );
   });
 

--- a/jsx/src/util/paginationParams.js
+++ b/jsx/src/util/paginationParams.js
@@ -1,0 +1,63 @@
+import { debounce } from "lodash";
+import { useSearchParams } from "react-router-dom-v5-compat";
+
+export const usePaginationParams = () => {
+  // get offset, limit, name filter from URL
+  const [searchParams, setSearchParams] = useSearchParams();
+  const offset = parseInt(searchParams.get("offset", "0")) || 0;
+  const limit =
+    parseInt(searchParams.get("limit", "0")) || window.api_page_limit;
+
+  const _setOffset = (params, offset) => {
+    if (offset < 0) offset = 0;
+    if (offset === 0) {
+      params.delete("offset");
+    } else {
+      params.set("offset", offset);
+    }
+  };
+  const _setLimit = (params, limit) => {
+    if (limit < 10) limit = 10;
+    if (limit === window.api_page_limit) {
+      params.delete("limit");
+    } else {
+      params.set("limit", limit);
+    }
+  };
+  const setPagination = (pagination) => {
+    // update pagination in one
+    setSearchParams((params) => {
+      _setOffset(params, pagination.offset);
+      _setLimit(params, pagination.limit);
+      return params;
+    });
+  };
+
+  const setOffset = (offset) => {
+    if (offset < 0) offset = 0;
+    setSearchParams((params) => {
+      _setOffset(params, offset);
+      return params;
+    });
+  };
+
+  const setLimit = (limit) => {
+    setSearchParams((params) => {
+      _setLimit(params, limit);
+      return params;
+    });
+  };
+
+  const handleLimit = debounce(async (event) => {
+    setLimit(event.target.value);
+  }, 300);
+
+  return {
+    offset,
+    setOffset,
+    limit,
+    setLimit,
+    handleLimit,
+    setPagination,
+  };
+};

--- a/jsx/src/util/paginationParams.js
+++ b/jsx/src/util/paginationParams.js
@@ -1,5 +1,5 @@
 import { debounce } from "lodash";
-import { useSearchParams } from "react-router-dom-v5-compat";
+import { useSearchParams } from "react-router-dom";
 
 export const usePaginationParams = () => {
   // get offset, limit, name filter from URL

--- a/jsx/src/util/paginationParams.js
+++ b/jsx/src/util/paginationParams.js
@@ -6,7 +6,7 @@ export const usePaginationParams = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const offset = parseInt(searchParams.get("offset", "0")) || 0;
   const limit =
-    parseInt(searchParams.get("limit", "0")) || window.api_page_limit;
+    parseInt(searchParams.get("limit", "0")) || window.api_page_limit || 100;
 
   const _setOffset = (params, offset) => {
     if (offset < 0) offset = 0;
@@ -26,6 +26,9 @@ export const usePaginationParams = () => {
   };
   const setPagination = (pagination) => {
     // update pagination in one
+    if (!pagination) {
+      return;
+    }
     setSearchParams((params) => {
       _setOffset(params, pagination.offset);
       _setLimit(params, pagination.limit);

--- a/jsx/webpack.config.js
+++ b/jsx/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
   output: {
     publicPath: "/",
     filename: "admin-react.js",
-    path: path.resolve(__dirname, "build"),
+    path: path.resolve(__dirname, "../share/jupyterhub/static/js/"),
   },
   resolve: {
     extensions: [".css", ".js", ".jsx"],

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -1041,7 +1041,7 @@ async def test_start_stop_all_servers_on_admin_page(app, browser, admin_user):
     )
 
 
-@pytest.mark.parametrize("added_count_users", [10, 47, 48, 49, 110])
+@pytest.mark.parametrize("added_count_users", [10, 49, 50, 51, 99, 100, 101])
 async def test_paging_on_admin_page(
     app, browser, admin_user, added_count_users, create_user_with_scopes
 ):
@@ -1057,7 +1057,7 @@ async def test_paging_on_admin_page(
     btn_next = browser.get_by_role("button", name="Next")
     # verify "Previous"/"Next" button clickability depending on users number on the page
     await expect(displaying).to_have_text(
-        re.compile(".*" + f"0-{min(users_count_db,50)}" + ".*")
+        re.compile(".*" + f"1-{min(users_count_db, 50)}" + ".*")
     )
     if users_count_db > 50:
         await expect(btn_next.locator("//span")).to_have_class("active-pagination")
@@ -1065,10 +1065,10 @@ async def test_paging_on_admin_page(
         await btn_next.click()
         if users_count_db <= 100:
             await expect(displaying).to_have_text(
-                re.compile(".*" + f"50-{users_count_db}" + ".*")
+                re.compile(".*" + f"51-{users_count_db}" + ".*")
             )
         else:
-            await expect(displaying).to_have_text(re.compile(".*" + "50-100" + ".*"))
+            await expect(displaying).to_have_text(re.compile(".*" + "51-100" + ".*"))
             await expect(btn_next.locator("//span")).to_have_class("active-pagination")
         await expect(btn_previous.locator("//span")).to_have_class("active-pagination")
         # click on Previous button
@@ -1117,7 +1117,7 @@ async def test_search_on_admin_page(
     if users_count_db_filtered <= 50:
         await expect(filtered_list_on_page).to_have_count(users_count_db_filtered)
         await expect(displaying).to_contain_text(
-            re.compile(f"0-{users_count_db_filtered}")
+            re.compile(f"1-{users_count_db_filtered}")
         )
         # check that users names contain the search value in the filtered list
         for element in await filtered_list_on_page.get_by_test_id(
@@ -1126,7 +1126,7 @@ async def test_search_on_admin_page(
             await expect(element).to_contain_text(re.compile(f".*{search_value}.*"))
     else:
         await expect(filtered_list_on_page).to_have_count(50)
-        await expect(displaying).to_contain_text(re.compile("0-50"))
+        await expect(displaying).to_contain_text(re.compile("1-50"))
         # click on Next button to verify that the rest part of filtered list is displayed on the next page
         await browser.get_by_role("button", name="Next").click()
         filtered_list_on_next_page = browser.locator('//tr[@class="user-row"]')

--- a/setup.py
+++ b/setup.py
@@ -215,13 +215,6 @@ class JSX(BaseCommand):
             shell=shell,
         )
 
-        print("Copying JSX admin app to static/js")
-        check_call(
-            ["npm", "run", "place"],
-            cwd=self.jsx_dir,
-            shell=shell,
-        )
-
         # update data-files in case this created new files
         self.distribution.data_files = get_data_files()
         assert not self.should_run(), 'JSX.run failed'


### PR DESCRIPTION
- persist offset, limit, name_filter in URL parameters, so they are stable across page reload
- add UI element to specify items per page (closes #4709)

This allows specifying a URL (e.g. `/hub/admin#/?limit=50&name_filter=student`), which will show a specific view of a page of users. it also means the view persists across a reload.

It specifically does _not_ address #3816, which I want to do in one or two separate PRs. That one's trickier because it needs to rewrite how sorting is implemented, since client-side sorting should be entirely removed.