### PR TITLE
Implement sort order in GET /users

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -135,6 +135,27 @@ paths:
           schema:
             type: boolean
           allowEmptyValue: true
+        - name: sort
+          in: query
+          description: |
+            Sort users by this key (new in JupyterHub 5.0).
+            Default: id (opaque but stable internal order).
+          schema:
+            type: string
+            enum:
+              - id
+              - name
+              - last_activity
+        - name: direction
+          in: query
+          description: |
+            Direction of sorted results (new in JupyterHub 5.0).
+            Default: 'asc' (ascending).
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
       responses:
         200:
           description: The Hub's user list

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -139,23 +139,26 @@ paths:
           in: query
           description: |
             Sort users by this key (new in JupyterHub 5.0).
-            Default: id (opaque but stable internal order).
+            Default: `id` (opaque but stable internal order).
+            Supported fields: `id`, `name`, `last_activity`.
+            Results will be in ascending order.
+            Descending order can be requested with a `-` prefix,
+            e.g. `sort=-last_activity` for most recently active users first.
           schema:
             type: string
-            enum:
-              - id
-              - name
-              - last_activity
-        - name: direction
-          in: query
-          description: |
-            Direction of sorted results (new in JupyterHub 5.0).
-            Default: 'asc' (ascending).
-          schema:
-            type: string
-            enum:
-              - asc
-              - desc
+          examples:
+            default:
+              value: id
+              summary: |
+                default: sort by internal id
+            by_name:
+              value: name
+              summary: |
+                sort by user.name
+            recent_activity:
+              value: "-last_activity"
+              summary: |
+                sort by last activity, most recent first
       responses:
         200:
           description: The Hub's user list

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -9,7 +9,7 @@ from datetime import timedelta, timezone
 
 from async_generator import aclosing
 from dateutil.parser import parse as parse_date
-from sqlalchemy import func, or_
+from sqlalchemy import func, nulls_first, nulls_last, or_
 from sqlalchemy.orm import joinedload, selectinload
 from tornado import web
 from tornado.iostream import StreamClosedError
@@ -102,6 +102,9 @@ class UserListAPIHandler(APIHandler):
         if sort_direction in {"asc", "desc"}:
             # default: sort_order = orm.User.id.asc()
             sort_order = getattr(sort_column, sort_direction)()
+            # explicit NULL sorting
+            null_order = nulls_first if sort_direction == "asc" else nulls_last
+            sort_order = null_order(sort_order)
         else:
             raise web.HTTPError(
                 400, f"direction must be 'asc' or 'desc', not '{sort_direction}'"

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -494,8 +494,10 @@ async def test_get_users_sort(app, sort, direction):
         "last_activity": ["never", "early", "middle", "late"],
     }
     expected_order = orders[sort]
+    sort_param = sort
     if direction == "desc":
         expected_order.reverse()
+        sort_param = "-" + sort
 
     # create the users, encode the expected sort order in the names
     u = add_user(db, app=app, name='xyz-c-1-middle')
@@ -523,8 +525,7 @@ async def test_get_users_sort(app, sort, direction):
     # to ensure offset is handled correctly
     params = {
         "name_filter": "xyz",
-        "sort": sort,
-        "direction": direction,
+        "sort": sort_param,
         "limit": 2,
     }
 
@@ -557,7 +558,7 @@ async def test_get_users_sort(app, sort, direction):
 async def test_get_users_sort_invalid(app):
     r = await api_request(app, "users", params={"sort": "servers"})
     assert r.status_code == 400
-    r = await api_request(app, "users", params={"direction": "ascending"})
+    r = await api_request(app, "users", params={"sort": "--id"})
     assert r.status_code == 400
 
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -6,6 +6,7 @@ import re
 import sys
 import uuid
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from unittest import mock
 from urllib.parse import parse_qs, quote, urlparse
@@ -267,7 +268,6 @@ def max_page_limit(app):
 
 
 @mark.user
-@mark.role
 @mark.parametrize(
     "n, offset, limit, accepts_pagination, expected_count, include_stopped_servers",
     [
@@ -479,6 +479,86 @@ async def test_get_users_name_filter(app):
     assert r.status_code == 200
     response_users = [u.get("name") for u in r.json()]
     assert response_users == ['qrst']
+
+
+@mark.user
+@pytest.mark.parametrize("direction", ["asc", "desc"])
+@pytest.mark.parametrize("sort", ["id", "name", "last_activity"])
+async def test_get_users_sort(app, sort, direction):
+    db = app.db
+
+    # 4 users, different order depending on sort field
+    orders = {
+        "id": ["1", "2", "3", "4"],
+        "name": ["a", "b", "c", "d"],
+        "last_activity": ["never", "early", "middle", "late"],
+    }
+    expected_order = orders[sort]
+    if direction == "desc":
+        expected_order.reverse()
+
+    # create the users, encode the expected sort order in the names
+    u = add_user(db, app=app, name='xyz-c-1-middle')
+    u.last_activity = utcnow() - timedelta(hours=1)
+    u = add_user(db, app=app, name='xyz-a-2-late')
+    u.last_activity = utcnow()
+    u = add_user(db, app=app, name='xyz-d-3-never')
+    u.last_activity = None
+    u = add_user(db, app=app, name='xyz-b-4-early')
+    u.last_activity = utcnow() - timedelta(days=1)
+    app.db.commit()
+
+    @dataclass
+    class UserName:
+        """Parse username so we can get the current sort field"""
+
+        id: str
+        name: str
+        last_activity: str
+
+        def __init__(self, username):
+            prefix, self.name, self.id, self.last_activity = username.split("-")
+
+    # fetch 4 users in 2 pages of 2 items each
+    # to ensure offset is handled correctly
+    params = {
+        "name_filter": "xyz",
+        "sort": sort,
+        "direction": direction,
+        "limit": 2,
+    }
+
+    r = await api_request(
+        app, 'users', params=params, headers={"Accept": PAGINATION_MEDIA_TYPE}
+    )
+    assert r.status_code == 200
+    page_1 = r.json()
+
+    assert page_1["_pagination"]["total"] == 4
+    users = page_1["items"]
+    assert len(users) == 2
+
+    # next page
+    params["offset"] = page_1["_pagination"]["next"]["offset"]
+    r = await api_request(
+        app, 'users', params=params, headers={"Accept": PAGINATION_MEDIA_TYPE}
+    )
+    assert r.status_code == 200
+    page_2 = r.json()
+
+    # turn user dicts into list of only the relevant component,
+    # e.g. { "name": "xyz-a-2-late" } -> "late"
+    users.extend(page_2["items"])
+    usernames = [UserName(u["name"]) for u in users]
+    sorted_fields = [getattr(u, sort) for u in usernames]
+    assert sorted_fields == expected_order
+
+
+async def test_get_users_sort_invalid(app):
+    r = await api_request(app, "users", params={"sort": "servers"})
+    assert r.status_code == 400
+    r = await api_request(app, "users", params={"direction": "ascending"})
+    assert r.status_code == 400
 
 
 @mark.user


### PR DESCRIPTION
support sorting by id (current, default), name, last_activity

Names and definitions of `sort`, `direction` match GitHub REST API.

This is the server-side part of #3816. With and #4720, we can include the sort info in the URL