### PR TITLE
server-side sorting of admin page

### DIFF
--- a/jsx/package-lock.json
+++ b/jsx/package-lock.json
@@ -14,7 +14,7 @@
         "lodash": "^4.17.21",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
-        "react-bootstrap": "^2.7.4",
+        "react-bootstrap": "^2.10.1",
         "react-dom": "^17.0.2",
         "react-icons": "^4.8.0",
         "react-multi-select-component": "^4.3.4",
@@ -8209,13 +8209,14 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.7.4",
-      "license": "MIT",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.1.tgz",
+      "integrity": "sha512-J3OpRZIvCTQK+Tg/jOkRUvpYLHMdGeU9KqFUBQrV0d/Qr/3nsINpiOJyZMWnM5SJ3ctZdhPA6eCIKpEJR3Ellg==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.5",
         "@restart/hooks": "^0.4.9",
-        "@restart/ui": "^1.6.3",
-        "@types/react-transition-group": "^4.4.5",
+        "@restart/ui": "^1.6.6",
+        "@types/react-transition-group": "^4.4.6",
         "classnames": "^2.3.2",
         "dom-helpers": "^5.2.1",
         "invariant": "^2.2.4",

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
-    "react-bootstrap": "^2.7.4",
+    "react-bootstrap": "^2.10.1",
     "react-dom": "^17.0.2",
     "react-icons": "^4.8.0",
     "react-multi-select-component": "^4.3.4",

--- a/jsx/src/components/PaginationFooter/PaginationFooter.jsx
+++ b/jsx/src/components/PaginationFooter/PaginationFooter.jsx
@@ -5,11 +5,12 @@ import { FormControl } from "react-bootstrap";
 import "./pagination-footer.css";
 
 const PaginationFooter = (props) => {
-  let { offset, limit, visible, total, next, prev, handleLimit } = props;
+  const { offset, limit, visible, total, next, prev, handleLimit } = props;
   return (
     <div className="pagination-footer">
       <p>
-        Displaying {offset + 1}-{offset + visible} {total ? `of ${total}` : ""}
+        Displaying {visible ? offset + 1 : offset}-{offset + visible}{" "}
+        {total ? `of ${total}` : ""}
         <br />
         {offset >= 1 ? (
           <button className="btn btn-sm btn-light spaced">

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -7,6 +7,7 @@ import {
   Button,
   Col,
   Row,
+  Form,
   FormControl,
   Card,
   CardGroup,
@@ -32,21 +33,6 @@ RowListItem.propTypes = {
 const ServerDashboard = (props) => {
   const base_url = window.base_url || "/";
   const [searchParams, setSearchParams] = useSearchParams();
-  // sort methods
-  const usernameDesc = (e) => e.sort((a, b) => (a.name > b.name ? 1 : -1)),
-    usernameAsc = (e) => e.sort((a, b) => (a.name < b.name ? 1 : -1)),
-    adminDesc = (e) => e.sort((a) => (a.admin ? -1 : 1)),
-    adminAsc = (e) => e.sort((a) => (a.admin ? 1 : -1)),
-    dateDesc = (e) =>
-      e.sort((a, b) =>
-        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? -1 : 1,
-      ),
-    dateAsc = (e) =>
-      e.sort((a, b) =>
-        new Date(a.last_activity) - new Date(b.last_activity) > 0 ? 1 : -1,
-      ),
-    runningAsc = (e) => e.sort((a) => (a.server == null ? -1 : 1)),
-    runningDesc = (e) => e.sort((a) => (a.server == null ? 1 : -1));
 
   const [errorAlert, setErrorAlert] = useState(null);
   const [sortMethod, setSortMethod] = useState(null);
@@ -59,6 +45,8 @@ const ServerDashboard = (props) => {
     usePaginationParams();
 
   const name_filter = searchParams.get("name_filter") || "";
+  const sort = searchParams.get("sort") || "id";
+  const state_filter = searchParams.get("state") || "";
 
   const total = user_page ? user_page.total : undefined;
 
@@ -76,7 +64,13 @@ const ServerDashboard = (props) => {
   } = props;
 
   const dispatchPageUpdate = (data, page) => {
+    // trigger page update in state
+    // in response to fetching updated user list
+    // data is list of user records
+    // page is _pagination part of response
+    // persist page info in url query
     setPagination(page);
+    // persist user data, triggers rerender
     dispatch({
       type: "USER_PAGE",
       value: {
@@ -87,6 +81,8 @@ const ServerDashboard = (props) => {
   };
 
   const setNameFilter = (new_name_filter) => {
+    // persist ?name_filter parameter
+    // store in url param, clear when value is empty
     setSearchParams((params) => {
       // clear offset when name filter changes
       if (new_name_filter !== name_filter) {
@@ -101,25 +97,55 @@ const ServerDashboard = (props) => {
     });
   };
 
+  const setSort = (sort) => {
+    // persist ?sort parameter
+    // store in url param, clear when value is default ('id')
+    setSearchParams((params) => {
+      if (sort === "id") {
+        params.delete("id");
+      } else {
+        params.set("sort", sort);
+      }
+      return params;
+    });
+  };
+
+  const setStateFilter = (state_filter) => {
+    // persist ?state filter
+    // store in url param, clear when value is default ('')
+    setSearchParams((params) => {
+      if (!state_filter) {
+        params.delete("state");
+      } else {
+        params.set("state", state_filter);
+      }
+      return params;
+    });
+  };
+
+  // the callback to update the displayed user list
+  const updateUsersWithParams = () =>
+    updateUsers({
+      offset,
+      limit,
+      name_filter,
+      sort,
+      state: state_filter,
+    });
+
   useEffect(() => {
-    updateUsers(offset, limit, name_filter)
+    updateUsersWithParams()
       .then((data) => dispatchPageUpdate(data.items, data._pagination))
       .catch((err) => setErrorAlert("Failed to update user list."));
-  }, [offset, limit, name_filter]);
+  }, [offset, limit, name_filter, sort, state_filter]);
 
   if (!user_data || !user_page) {
     return <div data-testid="no-show"></div>;
   }
 
-  var slice = [offset, limit, name_filter];
-
   const handleSearch = debounce(async (event) => {
     setNameFilter(event.target.value);
   }, 300);
-
-  if (sortMethod != null) {
-    user_data = sortMethod(user_data);
-  }
 
   const ServerButton = ({ server, user, action, name, extraClass }) => {
     var [isDisabled, setIsDisabled] = useState(false);
@@ -132,7 +158,7 @@ const ServerDashboard = (props) => {
           action(user.name, server.name)
             .then((res) => {
               if (res.status < 300) {
-                updateUsers(...slice)
+                updateUsersWithParams()
                   .then((data) => {
                     dispatchPageUpdate(data.items, data._pagination);
                   })
@@ -417,42 +443,39 @@ const ServerDashboard = (props) => {
               <th id="user-header">
                 User{" "}
                 <SortHandler
-                  sorts={{ asc: usernameAsc, desc: usernameDesc }}
-                  callback={(method) => setSortMethod(() => method)}
+                  currentSort={sort}
+                  setSort={setSort}
+                  sortKey="name"
                   testid="user-sort"
                 />
               </th>
-              <th id="admin-header">
-                Admin{" "}
-                <SortHandler
-                  sorts={{ asc: adminAsc, desc: adminDesc }}
-                  callback={(method) => setSortMethod(() => method)}
-                  testid="admin-sort"
-                />
-              </th>
-              <th id="server-header">
-                Server{" "}
-                <SortHandler
-                  sorts={{ asc: usernameAsc, desc: usernameDesc }}
-                  callback={(method) => setSortMethod(() => method)}
-                  testid="server-sort"
-                />
-              </th>
+              <th id="admin-header">Admin</th>
+              <th id="server-header">Server</th>
               <th id="last-activity-header">
                 Last Activity{" "}
                 <SortHandler
-                  sorts={{ asc: dateAsc, desc: dateDesc }}
-                  callback={(method) => setSortMethod(() => method)}
+                  currentSort={sort}
+                  setSort={setSort}
+                  sortKey="last_activity"
                   testid="last-activity-sort"
                 />
               </th>
               <th id="running-status-header">
-                Running{" "}
-                <SortHandler
-                  sorts={{ asc: runningAsc, desc: runningDesc }}
-                  callback={(method) => setSortMethod(() => method)}
-                  testid="running-status-sort"
-                />
+                <label title="only show active servers">
+                  <Form.Check
+                    inline
+                    type="checkbox"
+                    name="active_servers"
+                    aria-label="only show active servers"
+                    checked={state_filter == "active"}
+                    onChange={(event) => {
+                      setStateFilter(event.target.checked ? "active" : null);
+                    }}
+                  />
+                  {state_filter == "active"
+                    ? " Active servers"
+                    : " All servers"}
+                </label>
               </th>
               <th id="actions-header">Actions</th>
             </tr>
@@ -490,7 +513,7 @@ const ServerDashboard = (props) => {
                         return res;
                       })
                       .then((res) => {
-                        updateUsers(...slice)
+                        updateUsersWithParams()
                           .then((data) => {
                             dispatchPageUpdate(data.items, data._pagination);
                           })
@@ -526,7 +549,7 @@ const ServerDashboard = (props) => {
                         return res;
                       })
                       .then((res) => {
-                        updateUsers(...slice)
+                        updateUsersWithParams()
                           .then((data) => {
                             dispatchPageUpdate(data.items, data._pagination);
                           })
@@ -590,30 +613,27 @@ ServerDashboard.propTypes = {
 };
 
 const SortHandler = (props) => {
-  var { sorts, callback, testid } = props;
+  const { currentSort, setSort, sortKey, testid } = props;
 
-  var [direction, setDirection] = useState(undefined);
-
+  const currentlySorted = currentSort && currentSort.endsWith(sortKey);
+  const descending = currentSort && currentSort.startsWith("-");
   return (
     <div
       className="sort-icon"
       data-testid={testid}
       onClick={() => {
-        if (!direction) {
-          callback(sorts.desc);
-          setDirection("desc");
-        } else if (direction == "asc") {
-          callback(sorts.desc);
-          setDirection("desc");
+        if (!currentlySorted) {
+          setSort(sortKey);
+        } else if (descending) {
+          setSort(sortKey);
         } else {
-          callback(sorts.asc);
-          setDirection("asc");
+          setSort("-" + sortKey);
         }
       }}
     >
-      {!direction ? (
+      {!currentlySorted ? (
         <FaSort />
-      ) : direction == "asc" ? (
+      ) : descending ? (
         <FaSortDown />
       ) : (
         <FaSortUp />
@@ -623,8 +643,9 @@ const SortHandler = (props) => {
 };
 
 SortHandler.propTypes = {
-  sorts: PropTypes.object,
-  callback: PropTypes.func,
+  currentSort: PropTypes.string,
+  setSort: PropTypes.func,
+  sortKey: PropTypes.string,
   testid: PropTypes.string,
 };
 

--- a/jsx/src/components/ServerDashboard/ServerDashboard.jsx
+++ b/jsx/src/components/ServerDashboard/ServerDashboard.jsx
@@ -35,7 +35,6 @@ const ServerDashboard = (props) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [errorAlert, setErrorAlert] = useState(null);
-  const [sortMethod, setSortMethod] = useState(null);
   const [collapseStates, setCollapseStates] = useState({});
 
   let user_data = useSelector((state) => state.user_data);
@@ -123,6 +122,7 @@ const ServerDashboard = (props) => {
       } else {
         params.set("state", new_state_filter);
       }
+      console.log("setting search params", params.toString());
       return params;
     });
   };
@@ -491,7 +491,7 @@ const ServerDashboard = (props) => {
                   </Button>
                 </Link>
               </td>
-              <td colspan="4" className="admin-header-buttons">
+              <td colSpan={4} className="admin-header-buttons">
                 {/* Start all servers */}
                 <Button
                   variant="primary"
@@ -566,7 +566,7 @@ const ServerDashboard = (props) => {
                   Stop All
                 </Button>
                 {/* spacing between start/stop and Shutdown */}
-                <span style={{ "margin-left": "56px" }}> </span>
+                <span style={{ marginLeft: "56px" }}> </span>
                 {/* Shutdown Jupyterhub */}
                 <Button
                   variant="danger"

--- a/jsx/src/components/ServerDashboard/server-dashboard.css
+++ b/jsx/src/components/ServerDashboard/server-dashboard.css
@@ -50,8 +50,8 @@ tr.noborder > td {
   vertical-align: inherit;
 }
 
-.user-row .actions > * {
-  margin-right: 5px;
+.user-row .actions button {
+  margin: 4px;
 }
 
 .admin-header-buttons {
@@ -87,5 +87,10 @@ goals:
 @media (max-width: 991px) {
   .admin-table-head #actions-header {
     width: 140px;
+  }
+  .user-row .actions button {
+    /* full-width buttons when they get collapsed into a single column */
+    margin: 4px 0px 4px 0px;
+    width: 100%;
   }
 }

--- a/jsx/src/components/ServerDashboard/server-dashboard.css
+++ b/jsx/src/components/ServerDashboard/server-dashboard.css
@@ -46,3 +46,51 @@ tr.noborder > td {
 .user-row .actions > * {
   margin-right: 5px;
 }
+
+.form-check-inline {
+  /* inline form check doesn't get inline css 
+  I _think_ this is because our bootstrap css is outdated
+  */
+  display: inline-block;
+}
+
+/* column widths for dashboard
+
+goals:
+
+- want stable width for running-status
+  so clicking the running filter doesn't cause a jump
+- shrink fixed-content columns (action, admin)
+- allow variable content columns (username, server name)
+  to claim remaining space
+
+*/
+
+.admin-table-head label {
+  /* clear margin-bottom to keep label on baseline */
+  margin-bottom: 0px;
+}
+
+.admin-table-head #user-header {
+}
+.admin-table-head #admin-header {
+  width: 64px;
+}
+.admin-table-head #server-header {
+}
+.admin-table-head #last-activity-header {
+  width: 180px;
+}
+.admin-table-head #running-status-header {
+  width: 300px;
+}
+.admin-table-head #actions-header {
+  width: 80px;
+}
+
+/* vertical stack server buttons on small windows */
+@media (max-width: 991px) {
+  .admin-table-head #running-status-header {
+    width: 140px;
+  }
+}

--- a/jsx/src/components/ServerDashboard/server-dashboard.css
+++ b/jsx/src/components/ServerDashboard/server-dashboard.css
@@ -7,6 +7,13 @@
   margin-left: auto;
 }
 
+.btn-light {
+  /* backport bs5 btn-light colors */
+  background-color: #f9fafb;
+  border-color: #f9fafb;
+  color: #000;
+}
+
 .server-dashboard-container .btn-light {
   border: 1px solid #ddd;
 }
@@ -47,11 +54,9 @@ tr.noborder > td {
   margin-right: 5px;
 }
 
-.form-check-inline {
-  /* inline form check doesn't get inline css 
-  I _think_ this is because our bootstrap css is outdated
-  */
-  display: inline-block;
+.admin-header-buttons {
+  /* float header action buttons to the right */
+  text-align: right;
 }
 
 /* column widths for dashboard
@@ -66,31 +71,21 @@ goals:
 
 */
 
-.admin-table-head label {
-  /* clear margin-bottom to keep label on baseline */
-  margin-bottom: 0px;
-}
-
 .admin-table-head #user-header {
 }
 .admin-table-head #admin-header {
   width: 64px;
 }
-.admin-table-head #server-header {
-}
 .admin-table-head #last-activity-header {
-  width: 180px;
-}
-.admin-table-head #running-status-header {
-  width: 300px;
+  min-width: 180px;
 }
 .admin-table-head #actions-header {
-  width: 80px;
+  width: 350px;
 }
 
 /* vertical stack server buttons on small windows */
 @media (max-width: 991px) {
-  .admin-table-head #running-status-header {
+  .admin-table-head #actions-header {
     width: 140px;
   }
 }

--- a/jsx/src/util/jhapiUtil.js
+++ b/jsx/src/util/jhapiUtil.js
@@ -3,14 +3,11 @@ const base_url = jhdata.base_url || "/";
 const xsrfToken = jhdata.xsrf_token;
 
 export const jhapiRequest = (endpoint, method, data) => {
-  let api_url = `${base_url}hub/api`;
-  let suffix = "";
+  let api_url = new URL(`${base_url}hub/api` + endpoint, location.origin);
   if (xsrfToken) {
-    // add xsrf token to url parameter
-    var sep = endpoint.indexOf("?") === -1 ? "?" : "&";
-    suffix = sep + "_xsrf=" + xsrfToken;
+    api_url.searchParams.set("_xsrf", xsrfToken);
   }
-  return fetch(api_url + endpoint + suffix, {
+  return fetch(api_url, {
     method: method,
     json: true,
     headers: {

--- a/jsx/src/util/paginationParams.js
+++ b/jsx/src/util/paginationParams.js
@@ -17,7 +17,7 @@ export const usePaginationParams = () => {
     }
   };
   const _setLimit = (params, limit) => {
-    if (limit < 10) limit = 10;
+    if (limit < 1) limit = 1;
     if (limit === window.api_page_limit) {
       params.delete("limit");
     } else {

--- a/jsx/src/util/withAPI.js
+++ b/jsx/src/util/withAPI.js
@@ -2,13 +2,16 @@ import { withProps } from "recompose";
 import { jhapiRequest } from "./jhapiUtil";
 
 const withAPI = withProps(() => ({
-  updateUsers: (offset, limit, name_filter) =>
-    jhapiRequest(
-      `/users?include_stopped_servers&offset=${offset}&limit=${limit}&name_filter=${
-        name_filter || ""
-      }`,
-      "GET",
-    ).then((data) => data.json()),
+  updateUsers: (options) => {
+    let params = new URLSearchParams();
+    params["include_stopped_servers"] = "1";
+    for (let key in options) {
+      params.set(key, options[key]);
+    }
+    return jhapiRequest(`/users?${params.toString()}`, "GET").then((data) =>
+      data.json(),
+    );
+  },
   updateGroups: (offset, limit) =>
     jhapiRequest(`/groups?offset=${offset}&limit=${limit}`, "GET").then(
       (data) => data.json(),

--- a/jsx/src/util/withAPI.js
+++ b/jsx/src/util/withAPI.js
@@ -4,7 +4,7 @@ import { jhapiRequest } from "./jhapiUtil";
 const withAPI = withProps(() => ({
   updateUsers: (options) => {
     let params = new URLSearchParams();
-    params["include_stopped_servers"] = "1";
+    params.set("include_stopped_servers", "1");
     for (let key in options) {
       params.set(key, options[key]);
     }

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -352,6 +352,10 @@ class APIHandler(BaseHandler):
             if include_stopped_servers:
                 # add any stopped servers in the db
                 seen = set(servers.keys())
+                if isinstance(user, orm.User):
+                    # need high-level User wrapper for spawner model
+                    # FIXME: this shouldn't be needed!
+                    user = self.users[user]
                 for name, orm_spawner in user.orm_spawners.items():
                     if name not in seen and scope_filter(orm_spawner, kind='server'):
                         servers[name] = self.server_model(orm_spawner, user=user)

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -1116,8 +1116,9 @@ async def test_search_on_admin_page(
     displaying = browser.get_by_text("Displaying")
     if users_count_db_filtered <= 50:
         await expect(filtered_list_on_page).to_have_count(users_count_db_filtered)
+        start = 1 if users_count_db_filtered else 0
         await expect(displaying).to_contain_text(
-            re.compile(f"1-{users_count_db_filtered}")
+            re.compile(f"{start}-{users_count_db_filtered}")
         )
         # check that users names contain the search value in the filtered list
         for element in await filtered_list_on_page.get_by_test_id(


### PR DESCRIPTION
removes all in-page sort, which removes sort by admin, server name, sort by running, as those are not available from the API.

This builds on #4720 and #4721 to use the new `sort` parameter in the [GET /users API](https://jupyterhub.readthedocs.io/en/latest/reference/rest-api.html#operation/get-users) and persist it in the new view state.

This means sort, etc. are always global, no matter how many users there are (closes #3816)

Running column switches from sort to _filter_, matching the `?state` query parameter in the API (closes #4482). So while you can't show running servers _first_, you can show _only_ running servers.

needed some CSS on the column widths to avoid jumps when toggling active server filter.

demo:

https://github.com/jupyterhub/jupyterhub/assets/151929/1de74b6a-b30f-4fde-9b43-0b983668512b


draft because I haven't updated the tests, but it works