### PR TITLE
switch to ruff for lint, format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,34 +14,19 @@ ci:
   autoupdate_schedule: monthly
 
 repos:
-  # Autoformat: Python code, syntax patterns are modernized
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+  # autoformat and lint Python code
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
     hooks:
-      - id: pyupgrade
-        args:
-          - --py37-plus
-
-  # Autoformat: Python code
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
-    hooks:
-      - id: autoflake
-        # args ref: https://github.com/PyCQA/autoflake#advanced-usage
-        args:
-          - --in-place
-
-  # Autoformat: Python code
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
-  # Autoformat: Python code
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-      - id: black
+      - id: ruff
+        types_or:
+          - python
+          - jupyter
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format
+        types_or:
+          - python
+          - jupyter
 
   # Autoformat: markdown, yaml, javascript (see the file .prettierignore)
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -58,9 +43,3 @@ repos:
       - id: requirements-txt-fixer
       - id: check-case-conflict
       - id: check-executables-have-shebangs
-
-  # Linting: Python code (see the file .flake8)
-  - repo: https://github.com/PyCQA/flake8
-    rev: "7.0.0"
-    hooks:
-      - id: flake8

--- a/bower-lite
+++ b/bower-lite
@@ -7,6 +7,7 @@ bower-lite
 Since Bower's on its way out,
 stage frontend dependencies from node_modules into components
 """
+
 import json
 import os
 import shutil

--- a/demo-image/jupyterhub_config.py
+++ b/demo-image/jupyterhub_config.py
@@ -1,6 +1,6 @@
 # Configuration file for jupyterhub-demo
 
-c = get_config()
+c = get_config()  # noqa
 
 # Use DummyAuthenticator and SimpleSpawner
 c.JupyterHub.spawner_class = "simple"

--- a/examples/bootstrap-script/jupyterhub_config.py
+++ b/examples/bootstrap-script/jupyterhub_config.py
@@ -27,9 +27,9 @@ def clean_dir_hook(spawner):
     if os.path.exists(temp_path) and os.path.isdir(temp_path):
         shutil.rmtree(temp_path)
 
+c = get_config()  # noqa
 
 # attach the hook functions to the spawner
-# pylint: disable=undefined-variable
 c.Spawner.pre_spawn_hook = create_dir_hook
 c.Spawner.post_stop_hook = clean_dir_hook
 

--- a/examples/bootstrap-script/jupyterhub_config.py
+++ b/examples/bootstrap-script/jupyterhub_config.py
@@ -27,6 +27,7 @@ def clean_dir_hook(spawner):
     if os.path.exists(temp_path) and os.path.isdir(temp_path):
         shutil.rmtree(temp_path)
 
+
 c = get_config()  # noqa
 
 # attach the hook functions to the spawner

--- a/examples/external-oauth/jupyterhub_config.py
+++ b/examples/external-oauth/jupyterhub_config.py
@@ -8,6 +8,7 @@ if not api_token:
         "Make sure to `export JUPYTERHUB_API_TOKEN=$(openssl rand -hex 32)`"
     )
 
+c = get_config()  # noqa
 # tell JupyterHub to register the service as an external oauth client
 c.JupyterHub.services = [
     {

--- a/examples/postgres/hub/jupyterhub_config.py
+++ b/examples/postgres/hub/jupyterhub_config.py
@@ -25,6 +25,4 @@ import os
 
 pg_pass = os.getenv('POSTGRES_ENV_JPY_PSQL_PASSWORD')
 pg_host = os.getenv('POSTGRES_PORT_5432_TCP_ADDR')
-c.JupyterHub.db_url = 'postgresql://jupyterhub:{}@{}:5432/jupyterhub'.format(
-    pg_pass, pg_host
-)
+c.JupyterHub.db_url = f'postgresql://jupyterhub:{pg_pass}@{pg_host}:5432/jupyterhub'

--- a/examples/server-api/start-stop-server.py
+++ b/examples/server-api/start-stop-server.py
@@ -9,6 +9,7 @@ Example of starting/stopping a server via the JupyterHub API
 5. stop server via API
 6. wait for server to finish stopping
 """
+
 import json
 import logging
 import pathlib

--- a/examples/service-announcement/jupyterhub_config.py
+++ b/examples/service-announcement/jupyterhub_config.py
@@ -1,6 +1,6 @@
 import sys
 
-c = get_config()
+c = get_config()  # noqa
 
 # To run the announcement service managed by the hub, add this.
 

--- a/examples/service-fastapi/jupyterhub_config.py
+++ b/examples/service-fastapi/jupyterhub_config.py
@@ -19,6 +19,8 @@ else:
 service_name = "fastapi"
 oauth_redirect_uri = f"{public_host}/services/{service_name}/oauth_callback"
 
+
+c = get_config()  # noqa
 c.JupyterHub.services = [
     {
         "name": service_name,

--- a/examples/service-notebook/external/jupyterhub_config.py
+++ b/examples/service-notebook/external/jupyterhub_config.py
@@ -1,3 +1,5 @@
+c = get_config()  # noqa
+
 # our user list
 c.Authenticator.allowed_users = ['minrk', 'ellisonbg', 'willingc']
 

--- a/examples/service-notebook/managed/jupyterhub_config.py
+++ b/examples/service-notebook/managed/jupyterhub_config.py
@@ -1,3 +1,5 @@
+c = get_config()  # noqa
+
 # our user list
 c.Authenticator.allowed_users = ['minrk', 'ellisonbg', 'willingc']
 

--- a/examples/service-whoami-flask/jupyterhub_config.py
+++ b/examples/service-whoami-flask/jupyterhub_config.py
@@ -1,3 +1,5 @@
+c = get_config()  # noqa
+
 c.JupyterHub.services = [
     {
         'name': 'whoami',

--- a/examples/service-whoami-flask/whoami-flask.py
+++ b/examples/service-whoami-flask/whoami-flask.py
@@ -2,6 +2,7 @@
 """
 whoami service authentication with the Hub
 """
+
 import json
 import os
 import secrets

--- a/examples/service-whoami/jupyterhub_config.py
+++ b/examples/service-whoami/jupyterhub_config.py
@@ -1,5 +1,7 @@
 import sys
 
+c = get_config()  # noqa
+
 c.JupyterHub.services = [
     {
         'name': 'whoami-api',

--- a/examples/spawn-form/jupyterhub_config.py
+++ b/examples/spawn-form/jupyterhub_config.py
@@ -11,7 +11,7 @@ c = get_config()  # noqa
 class DemoFormSpawner(LocalProcessSpawner):
     def _options_form_default(self):
         default_env = "YOURNAME=%s\n" % self.user.name
-        return """
+        return f"""
         <div class="form-group">
             <label for="args">Extra notebook CLI arguments</label>
             <input name="args" class="form-control"
@@ -19,11 +19,9 @@ class DemoFormSpawner(LocalProcessSpawner):
         </div>
         <div class="form-group">
             <label for="env">Environment variables (one per line)</label>
-            <textarea class="form-control" name="env">{env}</textarea>
+            <textarea class="form-control" name="env">{default_env}</textarea>
         </div>
-        """.format(
-            env=default_env
-        )
+        """
 
     def options_from_form(self, formdata):
         options = {}

--- a/examples/spawn-form/jupyterhub_config.py
+++ b/examples/spawn-form/jupyterhub_config.py
@@ -6,6 +6,7 @@ import shlex
 
 from jupyterhub.spawner import LocalProcessSpawner
 
+c = get_config()  # noqa
 
 class DemoFormSpawner(LocalProcessSpawner):
     def _options_form_default(self):

--- a/examples/spawn-form/jupyterhub_config.py
+++ b/examples/spawn-form/jupyterhub_config.py
@@ -8,6 +8,7 @@ from jupyterhub.spawner import LocalProcessSpawner
 
 c = get_config()  # noqa
 
+
 class DemoFormSpawner(LocalProcessSpawner):
     def _options_form_default(self):
         default_env = "YOURNAME=%s\n" % self.user.name

--- a/examples/user-sharing/share-api.ipynb
+++ b/examples/user-sharing/share-api.ipynb
@@ -254,14 +254,15 @@
     }
    ],
    "source": [
-    "from IPython.display import display, HTML\n",
+    "from IPython.display import HTML, display\n",
+    "\n",
     "full_accept_url = f\"{hub_host}{code_info['accept_url']}\"\n",
     "\n",
     "display(\n",
     "    HTML(f\"\"\"\n",
     "    <a href='{full_accept_url}'>share this link to grant access</a>\n",
     "    \"\"\")\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -347,7 +348,9 @@
     "from urllib.parse import urlencode\n",
     "\n",
     "this_notebook_url = server_base_url + \"lab/tree/share-api.ipynb\"\n",
-    "this_notebook_accept_url = full_accept_url + \"&\" + urlencode({\"next\": this_notebook_url})\n",
+    "this_notebook_accept_url = (\n",
+    "    full_accept_url + \"&\" + urlencode({\"next\": this_notebook_url})\n",
+    ")\n",
     "print(this_notebook_accept_url)\n",
     "\n",
     "display(\n",
@@ -355,7 +358,7 @@
     "    share <a href='{this_notebook_accept_url}'>this link</a>\n",
     "    to grant access and direct users to this notebook\n",
     "    \"\"\")\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -488,16 +491,16 @@
     "import json\n",
     "\n",
     "options = {\n",
-    "  \"scopes\": [\n",
-    "    f\"access:servers!server={user_server}\", # access the server (default)\n",
-    "    f\"servers!server={user_server}\", # start/stop the server\n",
-    "    f\"shares!server={user_server}\", # further share the server with others\n",
-    "  ],\n",
-    "  \"expires_in\": 3600, # code expires in one hour\n",
+    "    \"scopes\": [\n",
+    "        f\"access:servers!server={user_server}\",  # access the server (default)\n",
+    "        f\"servers!server={user_server}\",  # start/stop the server\n",
+    "        f\"shares!server={user_server}\",  # further share the server with others\n",
+    "    ],\n",
+    "    \"expires_in\": 3600,  # code expires in one hour\n",
     "}\n",
     "\n",
     "\n",
-    "session.post(share_codes_url, data=json.dumps(options))\n"
+    "session.post(share_codes_url, data=json.dumps(options))"
    ]
   },
   {
@@ -598,7 +601,7 @@
     "    \"user\": \"shared-with\",\n",
     "}\n",
     "\n",
-    "session.patch(shares_url, data=json.dumps(options))\n"
+    "session.patch(shares_url, data=json.dumps(options))"
    ]
   },
   {

--- a/jupyterhub/alembic/versions/19c0846f6344_base_revision_for_0_5.py
+++ b/jupyterhub/alembic/versions/19c0846f6344_base_revision_for_0_5.py
@@ -1,7 +1,7 @@
 """base revision for 0.5
 
 Revision ID: 19c0846f6344
-Revises: 
+Revises:
 Create Date: 2016-04-11 16:05:34.873288
 
 """

--- a/jupyterhub/alembic/versions/99a28a4418e1_user_created.py
+++ b/jupyterhub/alembic/versions/99a28a4418e1_user_created.py
@@ -29,11 +29,10 @@ def upgrade():
     # fill created date with current time
     now = utcnow()
     c.execute(
-        """
+        f"""
         UPDATE users
-        SET created='%s'
+        SET created='{now}'
         """
-        % (now,)
     )
 
     tables = sa.inspect(c.engine).get_table_names()
@@ -42,12 +41,11 @@ def upgrade():
         op.add_column('spawners', sa.Column('started', sa.DateTime, nullable=True))
         # fill started value with now for running servers
         c.execute(
-            """
+            f"""
             UPDATE spawners
-            SET started='%s'
+            SET started='{now}'
             WHERE server_id IS NOT NULL
             """
-            % (now,)
         )
 
 

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -40,7 +40,7 @@ class APIHandler(BaseHandler):
         return 'application/json'
 
     @property
-    @lru_cache()
+    @lru_cache
     def accepts_pagination(self):
         """Return whether the client accepts the pagination preview media type"""
         accept_header = self.request.headers.get("Accept", "")
@@ -460,8 +460,7 @@ class APIHandler(BaseHandler):
             if not isinstance(value, model_types[key]):
                 raise web.HTTPError(
                     400,
-                    "%s.%s must be %s, not: %r"
-                    % (name, key, model_types[key], type(value)),
+                    f"{name}.{key} must be {model_types[key]}, not: {type(value)!r}",
                 )
 
     def _check_user_model(self, model):

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -593,10 +593,8 @@ class UserServerAPIHandler(APIHandler):
                 if named_server_limit_per_user <= len(named_spawners):
                     raise web.HTTPError(
                         400,
-                        "User {} already has the maximum of {} named servers."
-                        "  One must be deleted before a new server can be created".format(
-                            user_name, named_server_limit_per_user
-                        ),
+                        f"User {user_name} already has the maximum of {named_server_limit_per_user} named servers."
+                        "  One must be deleted before a new server can be created",
                     )
         spawner = user.get_spawner(server_name, replace_failed=True)
         pending = spawner.pending

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -782,7 +782,7 @@ class SpawnProgressAPIHandler(APIHandler):
                 'progress': 100,
                 'ready': True,
                 'message': f"Server ready at {url}",
-                'html_message': 'Server ready at <a href="{0}">{0}</a>'.format(url),
+                'html_message': f'Server ready at <a href="{url}">{url}</a>',
                 'url': url,
             }
             original_ready_event = ready_event.copy()
@@ -881,9 +881,7 @@ def _parse_timestamp(timestamp):
     if (dt - now) > timedelta(minutes=59):
         raise web.HTTPError(
             400,
-            "Rejecting activity from more than an hour in the future: {}".format(
-                isoformat(dt)
-            ),
+            f"Rejecting activity from more than an hour in the future: {isoformat(dt)}",
         )
     return dt
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -24,8 +24,6 @@ from textwrap import dedent
 from typing import Optional
 from urllib.parse import unquote, urlparse, urlunparse
 
-if sys.version_info[:2] < (3, 3):
-    raise ValueError("Python < 3.3 not supported: %s" % sys.version)
 
 import tornado.httpserver
 import tornado.options
@@ -385,9 +383,7 @@ class JupyterHub(Application):
     def _validate_config_file(self, proposal):
         if not self.generate_config and not os.path.isfile(proposal.value):
             print(
-                "ERROR: Failed to find specified config file: {}".format(
-                    proposal.value
-                ),
+                f"ERROR: Failed to find specified config file: {proposal.value}",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -1581,7 +1577,7 @@ class JupyterHub(Application):
         if change.new:
             self.log.warning(
                 dedent(
-                    """
+                    f"""
                 extra_log_file is DEPRECATED in jupyterhub-0.8.2.
 
                 extra_log_file only redirects logs of the Hub itself,
@@ -1591,10 +1587,8 @@ class JupyterHub(Application):
                 It is STRONGLY recommended that you redirect process
                 output instead, e.g.
 
-                    jupyterhub &>> '{}'
-            """.format(
-                        change.new
-                    )
+                    jupyterhub &>> '{change.new}'
+            """
                 )
             )
 
@@ -1962,9 +1956,7 @@ class JupyterHub(Application):
         if urlinfo.password:
             # avoid logging the database password
             urlinfo = urlinfo._replace(
-                netloc='{}:[redacted]@{}:{}'.format(
-                    urlinfo.username, urlinfo.hostname, urlinfo.port
-                )
+                netloc=f'{urlinfo.username}:[redacted]@{urlinfo.hostname}:{urlinfo.port}'
             )
             db_log_url = urlinfo.geturl()
         else:
@@ -3496,9 +3488,7 @@ class JupyterHub(Application):
                 self.internal_ssl = True
             self.init_internal_ssl()
             self.log.info(
-                "Certificates written to directory `{}`".format(
-                    self.internal_certs_location
-                )
+                f"Certificates written to directory `{self.internal_certs_location}`"
             )
             loop.stop()
             return

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """The multi-user notebook application"""
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio
@@ -23,7 +24,6 @@ from operator import itemgetter
 from textwrap import dedent
 from typing import Optional
 from urllib.parse import unquote, urlparse, urlunparse
-
 
 import tornado.httpserver
 import tornado.options
@@ -3315,9 +3315,7 @@ class JupyterHub(Application):
         config_file_dir = os.path.dirname(os.path.abspath(self.config_file))
         if not os.path.isdir(config_file_dir):
             self.exit(
-                "{} does not exist. The destination directory must exist before generating config file.".format(
-                    config_file_dir
-                )
+                f"{config_file_dir} does not exist. The destination directory must exist before generating config file."
             )
         if os.path.exists(self.config_file) and not self.answer_yes:
             answer = ''

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -820,13 +820,8 @@ def _deprecated_method(old_name, new_name, version):
     def deprecated(self, *args, **kwargs):
         warnings.warn(
             (
-                "{cls}.{old_name} is deprecated in JupyterHub {version}."
-                " Please use {cls}.{new_name} instead."
-            ).format(
-                cls=self.__class__.__name__,
-                old_name=old_name,
-                new_name=new_name,
-                version=version,
+                f"{self.__class__.__name__}.{old_name} is deprecated in JupyterHub {version}."
+                f" Please use {self.__class__.__name__}.{new_name} instead."
             ),
             DeprecationWarning,
             stacklevel=2,
@@ -961,11 +956,9 @@ class LocalAuthenticator(Authenticator):
                 await maybe_future(self.add_system_user(user))
             else:
                 raise KeyError(
-                    "User {} does not exist on the system."
+                    f"User {user.name} does not exist on the system."
                     " Set LocalAuthenticator.create_system_users=True"
-                    " to automatically create system users from jupyterhub users.".format(
-                        user.name
-                    )
+                    " to automatically create system users from jupyterhub users."
                 )
 
         await maybe_future(super().add_user(user))

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -196,12 +196,7 @@ class Authenticator(LoggingConfigurable):
             # protects backward-compatible config from warnings
             # if they set the same value under both names
             self.log.warning(
-                "{cls}.{old} is deprecated in JupyterHub {version}, use {cls}.{new} instead".format(
-                    cls=self.__class__.__name__,
-                    old=old_attr,
-                    new=new_attr,
-                    version=version,
-                )
+                f"{self.__class__.__name__}.{old_attr} is deprecated in JupyterHub {version}, use {self.__class__.__name__}.{new_attr} instead"
             )
             setattr(self, new_attr, change.new)
 
@@ -377,9 +372,7 @@ class Authenticator(LoggingConfigurable):
                     break
                 if has_old_name and not has_new_name:
                     warnings.warn(
-                        "{0}.{1} should be renamed to {0}.{2} for JupyterHub >= 1.2".format(
-                            cls.__name__, old_name, new_name
-                        ),
+                        f"{cls.__name__}.{old_name} should be renamed to {cls.__name__}.{new_name} for JupyterHub >= 1.2",
                         DeprecationWarning,
                     )
 
@@ -399,19 +392,17 @@ class Authenticator(LoggingConfigurable):
             ):
                 # adapt to pre-1.0 signature for compatibility
                 warnings.warn(
-                    """
-                    {0}.{1} does not support the authentication argument,
-                    added in JupyterHub 1.0. and is renamed to {2} in JupyterHub 1.2.
+                    f"""
+                    {self.__class__.__name__}.{old_name} does not support the authentication argument,
+                    added in JupyterHub 1.0. and is renamed to {new_name} in JupyterHub 1.2.
 
                     It should have the signature:
 
-                    def {2}(self, username, authentication=None):
+                    def {new_name}(self, username, authentication=None):
                         ...
 
                     Adapting for compatibility.
-                    """.format(
-                        self.__class__.__name__, old_name, new_name
-                    ),
+                    """,
                     DeprecationWarning,
                 )
 

--- a/jupyterhub/dbutil.py
+++ b/jupyterhub/dbutil.py
@@ -121,9 +121,7 @@ def upgrade_if_needed(db_url, backup=True, log=None):
     if urlinfo.password:
         # avoid logging the database password
         urlinfo = urlinfo._replace(
-            netloc='{}:[redacted]@{}:{}'.format(
-                urlinfo.username, urlinfo.hostname, urlinfo.port
-            )
+            netloc=f'{urlinfo.username}:[redacted]@{urlinfo.hostname}:{urlinfo.port}'
         )
         db_log_url = urlinfo.geturl()
     else:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -372,7 +372,7 @@ class BaseHandler(RequestHandler):
             auth_info['auth_state'] = await user.get_auth_state()
         return await self.auth_to_user(auth_info, user)
 
-    @functools.lru_cache()
+    @functools.lru_cache
     def get_token(self):
         """get token from authorization header"""
         token = self.get_auth_token()
@@ -473,7 +473,7 @@ class BaseHandler(RequestHandler):
                 self.expanded_scopes = scopes.get_scopes_for(self.current_user)
         self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
 
-    @functools.lru_cache()
+    @functools.lru_cache
     def get_scope_filter(self, req_scope):
         """Produce a filter function for req_scope on resources
 
@@ -981,9 +981,7 @@ class BaseHandler(RequestHandler):
             )
             err = web.HTTPError(
                 429,
-                "Too many users trying to log in right now. Try again in {}.".format(
-                    human_retry_time
-                ),
+                f"Too many users trying to log in right now. Try again in {human_retry_time}.",
             )
             # can't call set_header directly here because it gets ignored
             # when errors are raised
@@ -1155,8 +1153,7 @@ class BaseHandler(RequestHandler):
 
                 raise web.HTTPError(
                     500,
-                    "Spawner failed to start [status=%s]. The logs for %s may contain details."
-                    % (status, spawner._log_name),
+                    f"Spawner failed to start [status={status}]. The logs for {spawner._log_name} may contain details.",
                 )
 
             if spawner._waiting_for_response:
@@ -1295,7 +1292,7 @@ class BaseHandler(RequestHandler):
         home = url_path_join(self.hub.base_url, 'home')
         return (
             "You can try restarting your server from the "
-            "<a href='{home}'>home page</a>.".format(home=home)
+            f"<a href='{home}'>home page</a>."
         )
 
     def get_template(self, name, sync=False):

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1519,9 +1519,9 @@ class UserUrlHandler(BaseHandler):
             json.dumps(
                 {
                     "message": (
-                        "JupyterHub server no longer running at {}."
-                        " Restart the server at {}"
-                    ).format(self.request.path[len(self.hub.base_url) - 1 :], spawn_url)
+                        f"JupyterHub server no longer running at {self.request.path[len(self.hub.base_url) - 1 :]}."
+                        f" Restart the server at {spawn_url}"
+                    )
                 }
             )
         )

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1251,7 +1251,7 @@ class BaseHandler(RequestHandler):
                         'servername': server_name,
                     },
                 )
-            except:
+            except Exception:
                 PROXY_DELETE_DURATION_SECONDS.labels(
                     status=ProxyDeleteStatus.failure
                 ).observe(time.perf_counter() - tic)
@@ -1425,7 +1425,7 @@ class BaseHandler(RequestHandler):
             self.log.debug("No template for %d", status_code)
             try:
                 html = self.render_template('error.html', sync=True, **ns)
-            except:
+            except Exception:
                 # In this case, any side effect must be avoided.
                 ns['no_spawner_check'] = True
                 html = self.render_template('error.html', sync=True, **ns)

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -142,10 +142,8 @@ class SpawnHandler(BaseHandler):
                 if named_server_limit_per_user <= len(named_spawners):
                     raise web.HTTPError(
                         400,
-                        "User {} already has the maximum of {} named servers."
-                        "  One must be deleted before a new server can be created".format(
-                            user.name, named_server_limit_per_user
-                        ),
+                        f"User {user.name} already has the maximum of {named_server_limit_per_user} named servers."
+                        "  One must be deleted before a new server can be created",
                     )
 
         if not self.allow_named_servers and user.running:
@@ -554,7 +552,6 @@ class TokenPageHandler(BaseHandler):
 
 
 class AcceptShareHandler(BaseHandler):
-
     def _get_next_url(self, owner, spawner):
         """Get next_url for a given owner/spawner"""
         next_url = self.get_argument("next", "")

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -163,9 +163,7 @@ class Server(HasTraits):
         return f"{self.host}{self.base_url}"
 
     def __repr__(self):
-        return "{name}(url={url}, bind_url={bind})".format(
-            name=self.__class__.__name__, url=self.url, bind=self.bind_url
-        )
+        return f"{self.__class__.__name__}(url={self.url}, bind_url={self.bind_url})"
 
     def wait_up(self, timeout=10, http=False, ssl_context=None, extra_path=""):
         """Wait for this server to come up"""

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -730,7 +730,7 @@ class _Share:
         return cls._apply_filter(frozenset(scopes), spawner.user.name, spawner.name)
 
     @staticmethod
-    @lru_cache()
+    @lru_cache
     def _apply_filter(scopes, owner_name, server_name):
         """
         implementation of Share.apply_filter
@@ -1518,11 +1518,9 @@ def check_db_revision(engine):
         app_log.debug("database schema version found: %s", alembic_revision)
     else:
         raise DatabaseSchemaMismatch(
-            "Found database schema version {found} != {head}. "
+            f"Found database schema version {alembic_revision} != {head}. "
             "Backup your database and run `jupyterhub upgrade-db`"
-            " to upgrade to the latest schema.".format(
-                found=alembic_revision, head=head
-            )
+            " to upgrade to the latest schema."
         )
 
 

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -202,12 +202,7 @@ class Role(Base):
     groups = relationship('Group', secondary='group_role_map', back_populates='roles')
 
     def __repr__(self):
-        return "<{} {} ({}) - scopes: {}>".format(
-            self.__class__.__name__,
-            self.name,
-            self.description,
-            self.scopes,
-        )
+        return f"<{self.__class__.__name__} {self.name} ({self.description}) - scopes: {self.scopes}>"
 
     @classmethod
     def find(cls, db, name):
@@ -365,12 +360,7 @@ class User(Base):
     kind = "user"
 
     def __repr__(self):
-        return "<{cls}({name} {running}/{total} running)>".format(
-            cls=self.__class__.__name__,
-            name=self.name,
-            total=len(self._orm_spawners),
-            running=sum(bool(s.server) for s in self._orm_spawners),
-        )
+        return f"<{self.__class__.__name__}({self.name} {sum(bool(s.server) for s in self._orm_spawners)}/{len(self._orm_spawners)} running)>"
 
     def new_api_token(self, token=None, **kwargs):
         """Create a new API token
@@ -1098,13 +1088,7 @@ class APIToken(Hashed, Base):
             # this shouldn't happen
             kind = 'owner'
             name = 'unknown'
-        return "<{cls}('{pre}...', {kind}='{name}', client_id={client_id!r})>".format(
-            cls=self.__class__.__name__,
-            pre=self.prefix,
-            kind=kind,
-            name=name,
-            client_id=self.client_id,
-        )
+        return f"<{self.__class__.__name__}('{self.prefix}...', {kind}='{name}', client_id={self.client_id!r})>"
 
     @classmethod
     def find(cls, db, token, *, kind=None):

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -686,7 +686,9 @@ class ConfigurableHTTPProxy(Proxy):
         cmd = []
         proxy_api = 'proxy-api'
         proxy_client = 'proxy-client'
-        api_key = self.app.internal_proxy_certs[proxy_api][
+        api_key = self.app.internal_proxy_certs[
+            proxy_api
+        ][
             'keyfile'
         ]  # Check content in next test and just patch manulaly or in the config of the file
         api_cert = self.app.internal_proxy_certs[proxy_api]['certfile']

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -337,8 +337,7 @@ class Proxy(LoggingConfigurable):
 
         if spawner.pending and spawner.pending != 'spawn':
             raise RuntimeError(
-                "%s is pending %s, shouldn't be added to the proxy yet!"
-                % (spawner._log_name, spawner.pending)
+                f"{spawner._log_name} is pending {spawner.pending}, shouldn't be added to the proxy yet!"
             )
 
         await self.add_route(
@@ -941,9 +940,7 @@ class ConfigurableHTTPProxy(Proxy):
                 # errors.
                 if e.code >= 500:
                     self.log.warning(
-                        "api_request to the proxy failed with status code {}, retrying...".format(
-                            e.code
-                        )
+                        f"api_request to the proxy failed with status code {e.code}, retrying..."
                     )
                     return False  # a falsy return value make exponential_backoff retry
                 else:

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -212,7 +212,7 @@ def _intersect_expanded_scopes(scopes_a, scopes_b, db=None):
     scopes_b = frozenset(scopes_b)
 
     # cached lookups for group membership of users and servers
-    @lru_cache()
+    @lru_cache
     def groups_for_user(username):
         """Get set of group names for a given username"""
         # if we need a group lookup, the result is not cacheable
@@ -225,7 +225,7 @@ def _intersect_expanded_scopes(scopes_a, scopes_b, db=None):
         )
         return {row[0] for row in group_query}
 
-    @lru_cache()
+    @lru_cache
     def groups_for_server(server):
         """Get set of group names for a given server"""
         username, _, servername = server.partition("/")
@@ -456,7 +456,7 @@ def expand_share_scopes(share):
     )
 
 
-@lru_cache()
+@lru_cache
 def _expand_self_scope(username):
     """
     Users have a metascope 'self' that should be expanded to standard user privileges.

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -1270,9 +1270,7 @@ def define_custom_scopes(scopes):
                 },
             }
         )
-    """ % indent(
-        _custom_scope_description, " " * 8
-    )
+    """ % indent(_custom_scope_description, " " * 8)
     for scope, scope_definition in scopes.items():
         if scope in scope_definitions and scope_definitions[scope] != scope_definition:
             raise ValueError(

--- a/jupyterhub/singleuser/_disable_user_config.py
+++ b/jupyterhub/singleuser/_disable_user_config.py
@@ -82,7 +82,10 @@ def _disable_user_config(serverapp):
     assert serverapp.config_file_paths == config_file_paths
 
     # patch jupyter_path to exclude $HOME
-    global _original_jupyter_paths, _jupyter_paths_without_home, _original_jupyter_config_dir
+    global \
+        _original_jupyter_paths, \
+        _jupyter_paths_without_home, \
+        _original_jupyter_config_dir
     _original_jupyter_paths = paths.jupyter_path()
     _jupyter_paths_without_home = list(_exclude_home(_original_jupyter_paths))
 

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -6,6 +6,7 @@ Meant to be compatible with jupyter_server and classic notebook
 Use make_singleuser_app to create a compatible Application class
 with JupyterHub authentication mixins enabled.
 """
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -1194,7 +1194,7 @@ async def test_progress(request, app, no_patience, slow_spawn):
     assert evt == {
         'progress': 100,
         'message': f'Server ready at {url}',
-        'html_message': 'Server ready at <a href="{0}">{0}</a>'.format(url),
+        'html_message': f'Server ready at <a href="{url}">{url}</a>',
         'url': url,
         'ready': True,
     }
@@ -1307,7 +1307,7 @@ async def test_progress_ready_hook_async_func_exception(request, app):
     db = app.db
     name = 'saga'
     app_user = add_user(db, app=app, name=name)
-    html_message = 'Server ready at <a href="{0}">{0}</a>'.format(app_user.url)
+    html_message = f'Server ready at <a href="{app_user.url}">{app_user.url}</a>'
     spawner = app_user.spawner
 
     async def custom_progress_ready_hook(spawner, ready_event):

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -85,9 +85,7 @@ async def test_default_server(app, named_servers):
                     'pending': None,
                     'ready': True,
                     'stopped': False,
-                    'progress_url': 'PREFIX/hub/api/users/{}/server/progress'.format(
-                        username
-                    ),
+                    'progress_url': f'PREFIX/hub/api/users/{username}/server/progress',
                     'state': {'pid': 0},
                     'user_options': {},
                 }

--- a/jupyterhub/tests/test_named_servers.py
+++ b/jupyterhub/tests/test_named_servers.py
@@ -172,9 +172,7 @@ async def test_create_named_server(
                     'pending': None,
                     'ready': True,
                     'stopped': False,
-                    'progress_url': 'PREFIX/hub/api/users/{}/servers/{}/progress'.format(
-                        username, escapedname
-                    ),
+                    'progress_url': f'PREFIX/hub/api/users/{username}/servers/{escapedname}/progress',
                     'state': {'pid': 0},
                     'user_options': {},
                 }

--- a/jupyterhub/tests/test_orm.py
+++ b/jupyterhub/tests/test_orm.py
@@ -73,13 +73,13 @@ def test_user(db):
 
 
 def test_user_escaping(db):
-    orm_user = orm.User(name='company\\user@company.com,\"quoted\"')
+    orm_user = orm.User(name='company\\user@company.com,"quoted"')
     db.add(orm_user)
     db.commit()
     user = User(orm_user)
-    assert user.name == 'company\\user@company.com,\"quoted\"'
+    assert user.name == 'company\\user@company.com,"quoted"'
     assert user.escaped_name == 'company%5Cuser@company.com%2C%22quoted%22'
-    assert user.json_escaped_name == 'company\\\\user@company.com,\\\"quoted\\\"'
+    assert user.json_escaped_name == 'company\\\\user@company.com,\\"quoted\\"'
 
 
 def test_tokens(db):

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -10,9 +10,8 @@ import pytest
 from traitlets import TraitError
 from traitlets.config import Config
 
-from ..utils import random_port
+from ..utils import random_port, wait_for_http_server
 from ..utils import url_path_join as ujoin
-from ..utils import wait_for_http_server
 from .mocking import MockHub
 from .test_api import add_user, api_request
 from .utils import skip_if_ssl

--- a/jupyterhub/traitlets.py
+++ b/jupyterhub/traitlets.py
@@ -82,16 +82,12 @@ class ByteSpecification(Integer):
             num = float(value[:-1])
         except ValueError:
             raise TraitError(
-                '{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(
-                    val=value
-                )
+                f'{value} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'
             )
         suffix = value[-1]
         if suffix not in self.UNIT_SUFFIXES:
             raise TraitError(
-                '{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(
-                    val=value
-                )
+                f'{value} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'
             )
         else:
             return int(float(num) * self.UNIT_SUFFIXES[suffix])

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -1025,7 +1025,7 @@ class User:
             # trigger post-stop hook
             try:
                 await maybe_future(spawner.run_post_stop_hook())
-            except:
+            except Exception:
                 self.log.exception("Error in Spawner.post_stop_hook for %s", self)
             spawner.clear_state()
             spawner.orm_spawner.state = spawner.get_state()

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -954,9 +954,7 @@ class User:
             else:
                 e.reason = 'error'
                 self.log.exception(
-                    "Unhandled error waiting for {user}'s server to show up at {url}: {error}".format(
-                        user=self.name, url=server.url, error=e
-                    )
+                    f"Unhandled error waiting for {self.name}'s server to show up at {server.url}: {e}"
                 )
                 self.settings['statsd'].incr('spawner.failure.http_error')
             try:

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -897,9 +897,7 @@ class User:
                 self.settings['statsd'].incr('spawner.failure.timeout')
             else:
                 self.log.exception(
-                    "Unhandled error starting {user}'s server: {error}".format(
-                        user=self.name, error=e
-                    )
+                    f"Unhandled error starting {self.name}'s server: {e}"
                 )
                 self.settings['statsd'].incr('spawner.failure.error')
                 e.reason = 'error'
@@ -907,9 +905,7 @@ class User:
                 await self.stop(spawner.name)
             except Exception:
                 self.log.exception(
-                    "Failed to cleanup {user}'s server that failed to start".format(
-                        user=self.name
-                    ),
+                    f"Failed to cleanup {self.name}'s server that failed to start",
                     exc_info=True,
                 )
             # raise original exception
@@ -967,9 +963,7 @@ class User:
                 await self.stop(spawner.name)
             except Exception:
                 self.log.exception(
-                    "Failed to cleanup {user}'s server that failed to start".format(
-                        user=self.name
-                    ),
+                    f"Failed to cleanup {self.name}'s server that failed to start",
                     exc_info=True,
                 )
             # raise original TimeoutError

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -253,9 +253,7 @@ async def wait_for_server(ip, port, timeout=10):
     tic = time.perf_counter()
     await exponential_backoff(
         lambda: can_connect(ip, port),
-        "Server at {ip}:{port} didn't respond in {timeout} seconds".format(
-            ip=ip, port=port, timeout=timeout
-        ),
+        f"Server at {ip}:{port} didn't respond in {timeout} seconds",
         timeout=timeout,
     )
     toc = time.perf_counter()
@@ -301,9 +299,7 @@ async def wait_for_http_server(url, timeout=10, ssl_context=None):
 
     re = await exponential_backoff(
         is_reachable,
-        "Server at {url} didn't respond in {timeout} seconds".format(
-            url=url, timeout=timeout
-        ),
+        f"Server at {url} didn't respond in {timeout} seconds",
         timeout=timeout,
     )
     toc = time.perf_counter()
@@ -507,14 +503,12 @@ def print_ps_info(file=sys.stderr):
     threadlen = len('threads')
 
     print(
-        "%s %s %s %s"
-        % ('%CPU'.ljust(cpulen), 'MEM'.ljust(memlen), 'FDs'.ljust(fdlen), 'threads'),
+        "{} {} {} {}".format('%CPU'.ljust(cpulen), 'MEM'.ljust(memlen), 'FDs'.ljust(fdlen), 'threads'),
         file=file,
     )
 
     print(
-        "%s %s %s %s"
-        % (
+        "{} {} {} {}".format(
             cpu_s.ljust(cpulen),
             mem_s.ljust(memlen),
             fd_s.ljust(fdlen),
@@ -788,7 +782,7 @@ _dns_safe = set(string.ascii_letters + string.digits + '-.')
 _dns_needs_replace = _dns_safe | {"%"}
 
 
-@lru_cache()
+@lru_cache
 def _dns_quote(name):
     """Escape a name for use in a dns label
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -503,17 +503,14 @@ def print_ps_info(file=sys.stderr):
     threadlen = len('threads')
 
     print(
-        "{} {} {} {}".format('%CPU'.ljust(cpulen), 'MEM'.ljust(memlen), 'FDs'.ljust(fdlen), 'threads'),
+        "{} {} {} {}".format(
+            '%CPU'.ljust(cpulen), 'MEM'.ljust(memlen), 'FDs'.ljust(fdlen), 'threads'
+        ),
         file=file,
     )
 
     print(
-        "{} {} {} {}".format(
-            cpu_s.ljust(cpulen),
-            mem_s.ljust(memlen),
-            fd_s.ljust(fdlen),
-            str(p.num_threads()).ljust(7),
-        ),
+        f"{cpu_s.ljust(cpulen)} {mem_s.ljust(memlen)} {fd_s.ljust(fdlen)} {str(p.num_threads()).ljust(7)}",
         file=file,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ skip-string-normalization = true
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
 target_version = [
-    "py37",
     "py38",
     "py39",
     "py310",
@@ -141,6 +140,21 @@ target_version = [
     "py312",
 ]
 
+# ruff is our linter and formatter
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint]
+ignore = [
+    "F841", # unused variable
+]
+select = [
+    "E9", # syntax
+    "I", # isort
+    "UP", # pyupgrade
+    "F", # flake8
+]
 
 # tbump is used to simplify and standardize the release process when updating
 # the version, making a git commit and tag, and pushing changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,42 +104,6 @@ fallback_version = "0.0.0"
 # [tool.setuptools.data-files]
 # "share/jupyterhub" = ["share/jupyterhub/**"]
 
-
-# autoflake is used for autoformatting Python code
-#
-# ref: https://github.com/PyCQA/autoflake#readme
-#
-[tool.autoflake]
-ignore-init-module-imports = true
-remove-all-unused-imports = true
-remove-duplicate-keys = true
-#remove-unused-variables = true
-
-
-# isort is used for autoformatting Python code
-#
-# ref: https://pycqa.github.io/isort/
-#
-[tool.isort]
-profile = "black"
-
-
-# black is used for autoformatting Python code
-#
-# ref: https://black.readthedocs.io/en/stable/
-#
-[tool.black]
-skip-string-normalization = true
-# target-version should be all supported versions, see
-# https://github.com/psf/black/issues/751#issuecomment-473066811
-target_version = [
-    "py38",
-    "py39",
-    "py310",
-    "py311",
-    "py312",
-]
-
 # ruff is our linter and formatter
 
 [tool.ruff.format]


### PR DESCRIPTION
seems to be the popular tool these days, and it's quite a bit quicker to run (one hook for several steps, etc.)

minor differences in some formatting, and a few lint rules that caught code that could be improved. Otherwise, no change.

ruff has lots more lint rules we could consider opting in to, but this keeps our lint rules _almost_ unchanged.