### PR TITLE
Fix typo in the `rest-api.yml`

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1062,7 +1062,7 @@ paths:
       responses:
         204:
           description: |
-            All shares for teh server have been deleted
+            All shares for the server have been deleted
       security:
         - oauth2:
             - shares


### PR DESCRIPTION
Minor typo, just noticed here: https://jupyterhub.readthedocs.io/en/latest/reference/rest-api.html#operation/delete-shares-server

cc @minrk 