### PR TITLE
Catch ValueError while waiting for server to be reachable

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -288,7 +288,14 @@ async def wait_for_http_server(url, timeout=10, ssl_context=None):
             else:
                 app_log.debug("Server at %s responded with %s", url, e.code)
                 return e.response
-        except Exception as e:
+        except OSError as e:
+            if e.errno not in {
+                errno.ECONNABORTED,
+                errno.ECONNREFUSED,
+                errno.ECONNRESET,
+            }:
+                app_log.warning("Failed to connect to %s (%s)", url, e)
+        except ValueError as e:
             app_log.warning("Error while waiting for server %s (%s)", url, e)
         return False
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -295,7 +295,7 @@ async def wait_for_http_server(url, timeout=10, ssl_context=None):
                 errno.ECONNRESET,
             }:
                 app_log.warning("Failed to connect to %s (%s)", url, e)
-        except ValueError as e:
+        except Exception as e:
             app_log.warning("Error while waiting for server %s (%s)", url, e)
         return False
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -288,14 +288,7 @@ async def wait_for_http_server(url, timeout=10, ssl_context=None):
             else:
                 app_log.debug("Server at %s responded with %s", url, e.code)
                 return e.response
-        except OSError as e:
-            if e.errno not in {
-                errno.ECONNABORTED,
-                errno.ECONNREFUSED,
-                errno.ECONNRESET,
-            }:
-                app_log.warning("Failed to connect to %s (%s)", url, e)
-        except ValueError as e:
+        except Exception as e:
             app_log.warning("Error while waiting for server %s (%s)", url, e)
         return False
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -295,6 +295,8 @@ async def wait_for_http_server(url, timeout=10, ssl_context=None):
                 errno.ECONNRESET,
             }:
                 app_log.warning("Failed to connect to %s (%s)", url, e)
+        except ValueError as e:
+            app_log.warning("Error while waiting for server %s (%s)", url, e)
         return False
 
     re = await exponential_backoff(


### PR DESCRIPTION
closes #4732

This is the patch we've added to our JupyterHub setup, to avoid the failed start attempts described in the issue.