### PR TITLE
Bump required Python version in contributing setup to 3.8

### DIFF
--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -12,7 +12,7 @@ development.
 ### Install Python
 
 JupyterHub is written in the [Python](https://python.org) programming language and
-requires you have at least version 3.6 installed locally. If you haven’t
+requires you have at least version 3.8 installed locally. If you haven’t
 installed Python before, the recommended way to install it is to use
 [Miniforge](https://github.com/conda-forge/miniforge#download).
 
@@ -59,7 +59,7 @@ a more detailed discussion.
    python -V
    ```
 
-   This should return a version number greater than or equal to 3.6.
+   This should return a version number greater than or equal to 3.8.
 
    ```bash
    npm -v


### PR DESCRIPTION
Since https://github.com/jupyterhub/jupyterhub/pull/4495 the required Python version is 3.8 or greater:

https://github.com/jupyterhub/jupyterhub/blob/1db5e5e95cf5201e7b524223e8468545d35abaa1/pyproject.toml#L18

The contributing documentation still mentioned 3.6. This bumps it to 3.8