### PR TITLE
avoid duplicate jupyterhub installation for docs

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install -r docs/requirements.txt pytest
+          pip install -e . -r docs/requirements.txt pytest
 
       - name: pytest docs/
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
 
 python:
   install:
+    - path: .
     - requirements: docs/requirements.txt
 
 formats:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,13 +1,6 @@
-# We install the jupyterhub package to help autodoc-traits inspect it and
-# generate documentation.
-#
-# FIXME: If there is a way for this requirements.txt file to pass a flag that
-#        the build system can intercept to not build the javascript artifacts,
-#        then do so so. That would mean that installing the documentation can
-#        avoid needing node/npm installed.
-#
---editable .
-
+# docs also require jupyterhub itself to be installed
+# don't depend on it here, as that often results in a duplicate
+# installation of jupyterhub that's already installed
 autodoc-traits
 jupyterhub-sphinx-theme
 myst-parser>=0.19


### PR DESCRIPTION
almost every time installing docs/requirements.txt happens, JupyterHub is already installed. Adding an `--editable` here ensures a full rebuild happens every time even when the dependency is satisfied, which is very slow.

We could, instead, have `jupyterhub` here, to ensure JupyterHub is present, but I think it's better to explicitly require that jupyterhub be installed in its own step, which has almost always happened already, because if `jupyterhub` pulls in the stable version, there's a very good chance the version is wrong.