### PR TITLE
respect jupyter-server disable_check_xsrf setting

### DIFF
--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -931,7 +931,9 @@ class HubOAuth(HubAuth):
 
         Applies JupyterHub check_xsrf_cookie if not token authenticated
         """
-        if getattr(handler, '_token_authenticated', False):
+        if getattr(handler, '_token_authenticated', False) or handler.settings.get(
+            "disable_check_xsrf", False
+        ):
             return
         check_xsrf_cookie(handler)
 


### PR DESCRIPTION
allows user-specified global disable of xsrf checks in single-user servers

This is basically the same as #4745 where our insertion comes at the wrong priority, but the user override comes from another source.

closes #4752 