### PR TITLE
avoid xsrf check on navigate GET requests

### DIFF
--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -157,7 +157,7 @@ async def test_permission_error_messages(app, user, auth, expected_message):
             params["_xsrf"] = cookies["_xsrf"]
         if auth == "cookie_xsrf_mismatch":
             params["_xsrf"] = "somethingelse"
-
+    headers['Sec-Fetch-Mode'] = 'cors'
     r = await async_requests.get(url, **kwargs)
     assert r.status_code == 403
     response = r.json()


### PR DESCRIPTION
sevices.auth prevents calling check_xsrf_cookie for navigate GET requests (regular page views), but if the Handler itself still calls it, the newly strict check would still be applied.

this ensures regular page views are allowed, even if the XSRF check is applied, such as Jupyter Server's nbconvert handlers.

Fixes https://github.com/jupyterlab/jupyterlab/issues/16040