### PR TITLE
clarify error template debug log

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1510,7 +1510,7 @@ class BaseHandler(RequestHandler):
         try:
             html = self.render_template('%s.html' % status_code, sync=True, **ns)
         except TemplateNotFound:
-            self.log.debug("No template for %d", status_code)
+            self.log.debug("Using default error template for %d", status_code)
             try:
                 html = self.render_template('error.html', sync=True, **ns)
             except Exception:

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -657,7 +657,7 @@ class ProxyErrorHandler(BaseHandler):
         try:
             html = await self.render_template('%s.html' % status_code, **ns)
         except TemplateNotFound:
-            self.log.debug("No template for %d", status_code)
+            self.log.debug("Using default error template for %d", status_code)
             html = await self.render_template('error.html', **ns)
 
         self.write(html)


### PR DESCRIPTION
'No template for 404' looks like something's wrong, when all it means to convey is that it doesn't get _special_ treatment and the default error page is enough.