### PR TITLE
test: avoid producing '[group]' string in output

### DIFF
--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -213,7 +213,9 @@ async def test_spawn_handler_access(app):
     r.raise_for_status()
 
 
-@pytest.mark.parametrize("has_access", ["all", "user", "group", False])
+@pytest.mark.parametrize(
+    "has_access", ["all", "user", (pytest.param("group", id="in-group")), False]
+)
 async def test_spawn_other_user(
     app, user, username, group, create_temp_role, has_access
 ):
@@ -300,7 +302,9 @@ async def test_spawn_page_falsy_callable(app):
     assert history[1] == ujoin(public_url(app), "hub/spawn-pending/erik")
 
 
-@pytest.mark.parametrize("has_access", ["all", "user", "group", False])
+@pytest.mark.parametrize(
+    "has_access", ["all", "user", (pytest.param("group", id="in-group")), False]
+)
 async def test_spawn_page_access(
     app, has_access, group, username, user, create_temp_role
 ):
@@ -403,7 +407,9 @@ async def test_spawn_form(app):
         }
 
 
-@pytest.mark.parametrize("has_access", ["all", "user", "group", False])
+@pytest.mark.parametrize(
+    "has_access", ["all", "user", (pytest.param("group", id="in-group")), False]
+)
 async def test_spawn_form_other_user(
     app, username, user, group, create_temp_role, has_access
 ):
@@ -624,7 +630,9 @@ async def test_user_redirect_hook(app, username):
     assert redirected_url.path == ujoin(app.base_url, 'user', username, 'terminals/1')
 
 
-@pytest.mark.parametrize("has_access", ["all", "user", "group", False])
+@pytest.mark.parametrize(
+    "has_access", ["all", "user", (pytest.param("group", id="in-group")), False]
+)
 async def test_other_user_url(app, username, user, group, create_temp_role, has_access):
     """Test accessing /user/someonelse/ URLs when the server is not running
 

--- a/jupyterhub/tests/test_shares.py
+++ b/jupyterhub/tests/test_shares.py
@@ -159,7 +159,9 @@ def expand_scopes(scope_str, user, group=None, share_with=None):
     return scopes
 
 
-@pytest.mark.parametrize("share_with", ["user", "group"])
+@pytest.mark.parametrize(
+    "share_with", ["user", pytest.param("group", id="share_with=group")]
+)
 def test_create_share(app, user, share_user, group, share_with):
     db = app.db
     spawner = user.spawner.orm_spawner
@@ -427,7 +429,7 @@ def test_share_code_expires(app, user, share_user):
     "kind",
     [
         ("user"),
-        ("group"),
+        (pytest.param("group", id="kind=group")),
     ],
 )
 async def test_shares_api_user_group_doesnt_exist(


### PR DESCRIPTION
GitHub Actions starts a log expansion group when it sees the string `[group]`, which happens when that is an argument to `pytest.parametrize`, which results in collapsing all subsequent test outputs:


<img width="643" alt="Screenshot 2024-04-10 at 13 29 57" src="https://github.com/jupyterhub/jupyterhub/assets/151929/ec500c0c-84e0-418b-b4a4-d32f85b02726">

Solution: use a different string, since it's arbitrary anyway