### PR TITLE
Token UI: move button to after form fields

### DIFF
--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -6,11 +6,6 @@
   <h1 class="sr-only">Manage JupyterHub Tokens</h1>
   <div class="row">
     <form id="request-token-form" class="col-md-offset-3 col-md-6">
-      <div class="text-center">
-        <button type="submit" class="btn btn-lg btn-jupyter">
-          Request new API token
-        </button>
-      </div>
       <div class="form-group">
         <label for="token-note">Note</label>
         <input
@@ -43,6 +38,11 @@
           If none are specified, the token will have permission to do everything you can do.
           See the <a href="https://jupyterhub.readthedocs.io/en/stable/rbac/scopes.html#available-scopes">JupyterHub documentation for a list of available scopes</a>.
         </small>
+      </div>
+      <div class="text-center">
+        <button type="submit" class="btn btn-lg btn-jupyter">
+          Request new API token
+        </button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
I think it's more natural to have the button at the end of the form.

Before:
![image](https://github.com/jupyterhub/jupyterhub/assets/1644105/f8bf8404-4d5e-48ff-aba6-88d2821937f8)

After:
![image](https://github.com/jupyterhub/jupyterhub/assets/1644105/63fb4ed5-b65a-4627-bc0a-1b7317955b05)
