### PR TITLE
doc: list/get token response is different from post

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -553,9 +553,12 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Token"
+                type: object
+                properties:
+                  api_tokens:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Token"
         401:
           description: Authentication/Authorization error
           content: {}
@@ -614,7 +617,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Token"
+                $ref: "#/components/schemas/NewToken"
         400:
           description: Body must be a JSON dict or empty
           content: {}
@@ -639,7 +642,7 @@ paths:
             type: string
       responses:
         200:
-          description: The info for the new token
+          description: The info for the token
           content:
             application/json:
               schema:
@@ -1930,12 +1933,7 @@ components:
 
     Token:
       type: object
-      properties:
-        token:
-          type: string
-          description:
-            The token itself. Only present in responses to requests for
-            a new token.
+      properties: &components-schemas-token-properties
         id:
           type: string
           description:
@@ -1989,6 +1987,18 @@ components:
             Only used for tokens set during oauth flows.
 
             Added in 2.0.
+
+    NewToken:
+      type: object
+      properties:
+        <<:
+          - *components-schemas-token-properties
+          - token:
+            type: string
+            description:
+              The token itself. Only present in responses to requests for
+              a new token.
+
   securitySchemes:
     token:
       type: http

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -574,7 +574,7 @@ paths:
       description: |
         Creates a new token owned by the user.
         Permissions can be limited by specifying a list of `scopes` in the JSON request body
-        (starting in JupyerHub 3.0; previously, permissions could be specified as `roles`,
+        (starting in JupyterHub 3.0; previously, permissions could be specified as `roles`,
         which is deprecated in 3.0).
       parameters:
         - $ref: "#/components/parameters/userName"
@@ -1176,7 +1176,7 @@ paths:
                         example: abc123
                       accept_url:
                         type: string
-                        description: The URL for acepting the code
+                        description: The URL for accepting the code
                         example: /hub/accept-share?code=abc123
       security:
         - oauth2:
@@ -1521,7 +1521,7 @@ paths:
           description: Shutdown successful
           content: {}
         400:
-          description: Unexpeced value for proxy or servers
+          description: Unexpected value for proxy or servers
           content: {}
       security:
         - oauth2:
@@ -1956,7 +1956,7 @@ components:
           type: array
           description:
             List of scopes this token has been assigned. New in JupyterHub
-            3. In JupyterHub 2.x, tokens were assigned 'roles' insead of scopes.
+            3. In JupyterHub 2.x, tokens were assigned 'roles' instead of scopes.
           items:
             type: string
         note:

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1992,13 +1992,11 @@ components:
       type: object
       properties:
         <<:
-          - *components-schemas-token-properties
-          - token:
-            type: string
-            description:
-              The token itself. Only present in responses to requests for
-              a new token.
-
+          [
+            *components-schemas-token-properties,
+            { token: null, type: string, description: The
+                token itself. Only present in responses to requests for a new token. },
+          ]
   securitySchemes:
     token:
       type: http

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1933,7 +1933,7 @@ components:
 
     Token:
       type: object
-      properties: &components-schemas-token-properties
+      properties:
         id:
           type: string
           description:
@@ -1991,12 +1991,65 @@ components:
     NewToken:
       type: object
       properties:
-        <<:
-          [
-            *components-schemas-token-properties,
-            { token: null, type: string, description: The
-                token itself. Only present in responses to requests for a new token. },
-          ]
+        token:
+          type: string
+          description:
+            The token itself. Only present in responses to requests for
+            a new token.
+        id:
+          type: string
+          description:
+            The id of the API token. Used for modifying or deleting the
+            token.
+        user:
+          type: string
+          description: The user that owns a token (undefined if owned by a service)
+        service:
+          type: string
+          description: The service that owns the token (undefined of owned by a user)
+        roles:
+          type: array
+          description:
+            Deprecated in JupyterHub 3, always an empty list. Tokens have
+            'scopes' starting from JupyterHub 3.
+          items:
+            type: string
+        scopes:
+          type: array
+          description:
+            List of scopes this token has been assigned. New in JupyterHub
+            3. In JupyterHub 2.x, tokens were assigned 'roles' instead of scopes.
+          items:
+            type: string
+        note:
+          type: string
+          description:
+            A note about the token, typically describing what it was created
+            for.
+        created:
+          type: string
+          description: Timestamp when this token was created
+          format: date-time
+        expires_at:
+          type: string
+          description: Timestamp when this token expires. Null if there is no expiry.
+          format: date-time
+        last_activity:
+          type: string
+          description: |
+            Timestamp of last-seen activity using this token.
+            Can be null if token has never been used.
+          format: date-time
+        session_id:
+          type:
+            - string
+            - "null"
+          description: |
+            The session id associated with the token, if any.
+            Only used for tokens set during oauth flows.
+
+            Added in 2.0.
+
   securitySchemes:
     token:
       type: http


### PR DESCRIPTION
The description for the `token` field says it's only included in new token requests, but this isn't shown in the summary response.
https://discourse.jupyter.org/t/token-to-token-id-rest-api-with-jupyterhub/24971/5

I've used YAML anchors/merges to avoid duplication https://stackoverflow.com/questions/64224811/yaml-merge-multiply-anchors-into-the-same-map
I don't know whether it's officially supported, but it seems to work with redoc locally (though apparently not on CI/RTD).

Also fixes the list tokens response to be wrapped by an `api_tokens` object, and some miscellaneous typos.