### PR TITLE
add token_id to `/api/user`

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -1774,6 +1774,16 @@ components:
               example:
                 - "read:users"
                 - "access:servers!user=name"
+            token_id:
+              type:
+                - string
+                - "null"
+              description: |
+                The id of the token authorizing the request, if any.
+                This id can be used to revoke the token via the API.
+                Null if the request is not authorized with a token.
+
+                Added in 5.0.
     Group:
       type: object
       properties:

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -63,10 +63,13 @@ class SelfAPIHandler(APIHandler):
 
         # add session_id associated with token
         # added in 2.0
+        # token_id added in 5.0
         token = self.get_token()
         if token:
+            model["token_id"] = token.api_id
             model["session_id"] = token.session_id
         else:
+            model["token_id"] = None
             model["session_id"] = None
 
         # add scopes to identify model,

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -600,6 +600,7 @@ async def test_get_self(app):
     r.raise_for_status()
     model = r.json()
     assert model['name'] == u.name
+    assert model["token_id"] == oauth_token.api_id
 
     # invalid auth gets 403
     r = await api_request(


### PR DESCRIPTION
makes it easier to identify the token you have for use with the tokens API, e.g. revocation.

suggested in https://discourse.jupyter.org/t/token-to-token-id-rest-api-with-jupyterhub/24971/5