### PR TITLE
increase docker build timeout to 30 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     services:
       # So that we can test this in PRs/branches


### PR DESCRIPTION
apt step is taking a super long time sometimes