### PR TITLE
Fix rest API djlint auto-formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
       - id: djlint-reformat-jinja
         files: ".*templates/.*.html"
         types_or: ["html"]
+        exclude: redoc.html
       - id: djlint-jinja
         files: ".*templates/.*.html"
         types_or: ["html"]

--- a/docs/source/_templates/redoc.html
+++ b/docs/source/_templates/redoc.html
@@ -1,3 +1,4 @@
+{# djlint: off #}
 {%- extends "!layout.html" %}
 {# not sure why, but theme CSS prevents scrolling within redoc content
  # If this were fixed, we could keep the navbar and footer
@@ -8,9 +9,7 @@
 {% endblock docs_navbar %}
 {% block footer %}
 {% endblock footer %}
-{# djlint: off #}
 {%- block body_tag -%}<body>{%- endblock body_tag %}
-{# djlint: on #}
 {%- block extrahead %}
   {{ super() }}
   <link href="{{ pathto('_static/redoc-fonts.css', 1) }}" rel="stylesheet" />
@@ -23,14 +22,11 @@
       document.body.innerText = "Rendered API specification doesn't work with file: protocol. Use sphinx-autobuild to do local builds of the docs, served over HTTP."
     } else {
       Redoc.init(
-        "{{ pathto('_static/rest-api.yml', 1) }}", {
-          {
-            meta.redoc_options |
-              default ({})
-          }
-        },
+        "{{ pathto('_static/rest-api.yml', 1) }}",
+          {{ meta.redoc_options | default ({}) }},
         document.getElementById("redoc-spec"),
       );
     }
   </script>
 {%- endblock content %}
+{# djlint: on #}


### PR DESCRIPTION
https://jupyterhub.readthedocs.io/en/latest/reference/rest-api.html#jupyterhub-rest-api
is currently broken because djlint treated `{{ ... }}` as javascript instead of a template.

I tried adding `{# djlint: off #} ... {# djlint: on #}` around just the `script` block, but there seems to be a [bug where it still partially auto-formats the content](https://github.com/djlint/djLint/issues/824), so after some trial and error I've disabled it in pre-commit.