### PR TITLE
403 instead of redirect for token-only HubAuth

### DIFF
--- a/examples/service-whoami/jupyterhub_config.py
+++ b/examples/service-whoami/jupyterhub_config.py
@@ -7,6 +7,7 @@ c.JupyterHub.services = [
         'name': 'whoami-api',
         'url': 'http://127.0.0.1:10101',
         'command': [sys.executable, './whoami.py'],
+        'display': False,
     },
     {
         'name': 'whoami-oauth',
@@ -36,3 +37,5 @@ c.JupyterHub.load_roles = [
 c.JupyterHub.authenticator_class = 'dummy'
 c.JupyterHub.spawner_class = 'simple'
 c.JupyterHub.ip = '127.0.0.1'  # let's just run on localhost while dummy auth is enabled
+# default to home page, since we don't want to start servers for this demo
+c.JupyterHub.default_url = "/hub/home"

--- a/jupyterhub/tests/test_services_auth.py
+++ b/jupyterhub/tests/test_services_auth.py
@@ -91,11 +91,7 @@ async def test_hubauth_token(app, mockservice_url, create_user_with_scopes):
         public_url(app, mockservice_url) + '/whoami/?token=%s' % token,
         allow_redirects=False,
     )
-    assert r.status_code == 302
-    assert 'Location' in r.headers
-    location = r.headers['Location']
-    path = urlparse(location).path
-    assert path.endswith('/hub/login')
+    assert r.status_code == 403
 
 
 @pytest.mark.parametrize(
@@ -177,11 +173,7 @@ async def test_hubauth_service_token(request, app, mockservice_url, scopes, allo
         public_url(app, mockservice_url) + 'whoami/?token=%s' % token,
         allow_redirects=False,
     )
-    assert r.status_code == 302
-    assert 'Location' in r.headers
-    location = r.headers['Location']
-    path = urlparse(location).path
-    assert path.endswith('/hub/login')
+    assert r.status_code == 403
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #4777 

A browser request to `/whoami-api` request will not work, as described in the readme for the example, but the result should be a  clearer 403, rather than a redirect loop because login via redirect cannot succeed.