### PR TITLE
Relax dependency on async_generator

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -5,9 +5,14 @@
 import asyncio
 import inspect
 import json
+import sys
 from datetime import timedelta, timezone
 
-from async_generator import aclosing
+if sys.version_info >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
 from dateutil.parser import parse as parse_date
 from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload, raiseload, selectinload  # noqa

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -18,7 +18,11 @@ from tempfile import mkdtemp
 from textwrap import dedent
 from urllib.parse import urlparse
 
-from async_generator import aclosing
+if sys.version_info >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
 from sqlalchemy import inspect
 from tornado.ioloop import PeriodicCallback
 from traitlets import (

--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -3,9 +3,8 @@
 import os
 import sys
 from binascii import hexlify
+from contextlib import asynccontextmanager
 from subprocess import Popen
-
-from async_generator import asynccontextmanager
 
 from ..utils import (
     exponential_backoff,

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -1,12 +1,17 @@
 """Tests for utilities"""
 
 import asyncio
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock
 
+if sys.version_info >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
 import pytest
-from async_generator import aclosing
 from tornado import gen
 from tornado.concurrent import run_on_executor
 from tornado.httpserver import HTTPRequest

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -27,8 +27,12 @@ from hmac import compare_digest
 from operator import itemgetter
 from urllib.parse import quote
 
+if sys.version_info >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
 import idna
-from async_generator import aclosing
 from sqlalchemy.exc import SQLAlchemyError
 from tornado import gen, ioloop, web
 from tornado.httpclient import AsyncHTTPClient, HTTPError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 alembic>=1.4
-async_generator>=1.9
+async_generator>=1.9; python_version < '3.10'
 certipy>=0.1.2
 idna
 importlib_metadata>=3.6; python_version < '3.10'


### PR DESCRIPTION
async_generator was written as a compatibility library for Python 3.5 and 3.6. The <s>aclosing</s> and asynccontextmanager objects are available in the standard contextlib module since Pyhton 3.7, JupyterHub already requires at least Python 3.8.

See also https://github.com/python-trio/async_generator/issues/35