### PR TITLE
Allow overriding spawner config based on user group membership

### DIFF
--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -323,8 +323,7 @@ class Spawner(LoggingConfigurable):
           applied to their server before spawning.
         - *spawner_override* - a dictionary with overrides to apply to the Spawner
           settings. Each value can be either the final value to change or a callable that
-          take the `KubeSpawner` instance as parameter and return the final value. This can
-          be further overridden by 'profile_options'
+          take the `Spawner` instance as parameter and return the final value.
           If the traitlet being overriden is a *dictionary*, the dictionary
           will be *recursively updated*, rather than overriden. If you want to
           remove a key, set its value to `None`

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -330,23 +330,23 @@ class Spawner(LoggingConfigurable):
 
         The following example config will:
 
-        1. Add the environment variable "AM_I_USER" to everyone in the "user" group
-        2. Add the environment variable "AM_I_ADMIN" to everyone in the "admin" group.
-           If a user is part of both "user" and "admin", they will get *both* these env
+        1. Add the environment variable "AM_I_GROUP_ALPHA" to everyone in the "group-alpha" group
+        2. Add the environment variable "AM_I_GROUP_BETA" to everyone in the "group-beta" group.
+           If a user is part of both "group-beta" and "group-alpha", they will get *both* these env
            vars, due to the dictionary merging functionality.
-        3. Add a higher memory limit for everyone in the "admin" group.
+        3. Add a higher memory limit for everyone in the "group-beta" group.
 
         c.Spawner.group_overrides = {
-            "01-admin-env-add": {
-                "groups": ["admin"],
-                "spawner_override": {"environment": {"AM_I_ADMIN": "yes"}},
+            "01-group-alpha-env-add": {
+                "groups": ["group-alpha"],
+                "spawner_override": {"environment": {"AM_I_GROUP_ALPHA": "yes"}},
             },
-            "02-user-env-add": {
-                "groups": ["user"],
-                "spawner_override": {"environment": {"AM_I_USER": "yes"}},
+            "02-group-beta-env-add": {
+                "groups": ["group-beta"],
+                "spawner_override": {"environment": {"AM_I_GROUP_BETA": "yes"}},
             },
-            "03-admin-mem-limit": {
-                "groups": ["admin"],
+            "03-group-beta-mem-limit": {
+                "groups": ["group-beta"],
                 "spawner_override": {"mem_limit": "2G"}
             }
         }

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1542,7 +1542,9 @@ class Spawner(LoggingConfigurable):
                 # If there is *any* overlap between the groups user is in
                 # and the groups for this override, apply overrides
                 self._apply_overrides(go['spawner_override'])
-                self.log.info(f"Applying group_override {key} for {self.user.name}, modifying config keys: {' '.join(go['spawner_override'].keys())}")
+                self.log.info(
+                    f"Applying group_override {key} for {self.user.name}, modifying config keys: {' '.join(go['spawner_override'].keys())}"
+                )
 
 
 def _try_setcwd(path):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -327,6 +327,29 @@ class Spawner(LoggingConfigurable):
           If the traitlet being overriden is a *dictionary*, the dictionary
           will be *recursively updated*, rather than overriden. If you want to
           remove a key, set its value to `None`
+
+        The following example config will:
+
+        1. Add the environment variable "AM_I_USER" to everyone in the "user" group
+        2. Add the environment variable "AM_I_ADMIN" to everyone in the "admin" group.
+           If a user is part of both "user" and "admin", they will get *both* these env
+           vars, due to the dictionary merging functionality.
+        3. Add a higher memory limit for everyone in the "admin" group.
+
+        c.Spawner.group_overrides = {
+            "01-admin-env-add": {
+                "groups": ["admin"],
+                "spawner_override": {"environment": {"AM_I_ADMIN": "yes"}},
+            },
+            "02-user-env-add": {
+                "groups": ["user"],
+                "spawner_override": {"environment": {"AM_I_USER": "yes"}},
+            },
+            "03-admin-mem-limit": {
+                "groups": ["admin"],
+                "spawner_override": {"mem_limit": "2G"}
+            }
+        }
         """,
         config=True,
     )

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -323,7 +323,7 @@ class Spawner(LoggingConfigurable):
           applied to their server before spawning.
         - *spawner_override* - a dictionary with overrides to apply to the Spawner
           settings. Each value can be either the final value to change or a callable that
-          take the `Spawner` instance as parameter and return the final value.
+          take the `Spawner` instance as parameter and returns the final value.
           If the traitlet being overriden is a *dictionary*, the dictionary
           will be *recursively updated*, rather than overriden. If you want to
           remove a key, set its value to `None`

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -312,8 +312,8 @@ class Spawner(LoggingConfigurable):
         help="""
         Override specific traitlets based on group membership of the user.
 
-        This can be a dict, or a callable that returns a dict. The key of the dict
-        is *only* used for lexicographical sorting, to guarantee a consistent
+        This can be a dict, or a callable that returns a dict. The keys of the dict
+        are *only* used for lexicographical sorting, to guarantee consistent
         ordering of the overrides. If it is a callable, it may be async, and will
         be passed one parameter - the spawner instance. It should return a dictionary.
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1564,10 +1564,10 @@ class Spawner(LoggingConfigurable):
             if user_group_names & set(go['groups']):
                 # If there is *any* overlap between the groups user is in
                 # and the groups for this override, apply overrides
-                self._apply_overrides(go['spawner_override'])
                 self.log.info(
                     f"Applying group_override {key} for {self.user.name}, modifying config keys: {' '.join(go['spawner_override'].keys())}"
                 )
+                self._apply_overrides(go['spawner_override'])
 
 
 def _try_setcwd(path):

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1517,15 +1517,6 @@ class Spawner(LoggingConfigurable):
         for k, v in spawner_override.items():
             if callable(v):
                 v = v(self)
-                self.log.info(
-                    f".. overriding {self.__class__.__name__} value %s=%s (callable result)",
-                    k,
-                    v,
-                )
-            else:
-                self.log.info(
-                    f".. overriding {self.__class__.__name__} value %s=%s", k, v
-                )
 
             # If v is a dict, *merge* it with existing values, rather than completely
             # resetting it. This allows *adding* things like environment variables rather
@@ -1551,6 +1542,7 @@ class Spawner(LoggingConfigurable):
                 # If there is *any* overlap between the groups user is in
                 # and the groups for this override, apply overrides
                 self._apply_overrides(go['spawner_override'])
+                self.log.info(f"Applying group_override {key} for {self.user.name}, modifying config keys: {' '.join(go['spawner_override'].keys())}")
 
 
 def _try_setcwd(path):

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -688,6 +688,7 @@ async def test_group_override_dict_merging(app):
     assert s.environment["AM_I_USER"] == "yes"
     assert "AM_I_ADMIN" not in s.environment
 
+
 async def test_group_override_callable(app):
     app.load_groups = {
         "admin": {"users": ["admin"]},

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -23,8 +23,7 @@ from ..spawner import SimpleLocalProcessSpawner, Spawner
 from ..user import User
 from ..utils import AnyTimeoutError, maybe_future, new_token, url_path_join
 from .mocking import public_url
-from .test_api import add_user
-from .utils import async_requests
+from .utils import add_user, async_requests, find_user
 
 _echo_sleep = """
 import sys, time
@@ -598,3 +597,90 @@ def test_spawner_server(db):
     spawner.server = Server.from_url("http://1.2.3.4")
     assert spawner.server is not None
     assert spawner.server.ip == "1.2.3.4"
+
+
+async def test_group_override(app):
+    app.load_groups = {
+        "admin": {"users": ["admin"]},
+        "user": {"users": ["admin", "user"]},
+    }
+    await app.init_groups()
+
+    group_overrides = {
+        "01-admin-mem-limit": {
+            "groups": ["admin"],
+            "spawner_override": {"start_timeout": 120},
+        }
+    }
+
+    admin_user = find_user(app.db, "admin")
+    s = Spawner(user=admin_user)
+    s.start_timeout = 60
+    s.group_overrides = group_overrides
+    await s.apply_group_overrides()
+    assert s.start_timeout == 120
+
+    non_admin_user = find_user(app.db, "user")
+    s = Spawner(user=non_admin_user)
+    s.start_timeout = 60
+    s.group_overrides = group_overrides
+    await s.apply_group_overrides()
+    assert s.start_timeout == 60
+
+
+async def test_group_override_lexical_ordering(app):
+    app.load_groups = {
+        "admin": {"users": ["admin"]},
+        "user": {"users": ["admin", "user"]},
+    }
+    await app.init_groups()
+
+    group_overrides = {
+        # this should be applied last, even though it is specified first,
+        # due to lexical ordering based on key names
+        "02-admin-mem-limit": {
+            "groups": ["admin"],
+            "spawner_override": {"start_timeout": 300},
+        },
+        "01-admin-mem-limit": {
+            "groups": ["admin"],
+            "spawner_override": {"start_timeout": 120},
+        },
+    }
+
+    admin_user = find_user(app.db, "admin")
+    s = Spawner(user=admin_user)
+    s.start_timeout = 60
+    s.group_overrides = group_overrides
+    await s.apply_group_overrides()
+    assert s.start_timeout == 300
+
+
+async def test_group_override_callable(app):
+    app.load_groups = {
+        "admin": {"users": ["admin"]},
+        "user": {"users": ["admin", "user"]},
+    }
+    await app.init_groups()
+
+    def group_overrides(spawner):
+        return {
+            "01-admin-mem-limit": {
+                "groups": ["admin"],
+                "spawner_override": {"start_timeout": 120},
+            }
+        }
+
+    admin_user = find_user(app.db, "admin")
+    s = Spawner(user=admin_user)
+    s.start_timeout = 60
+    s.group_overrides = group_overrides
+    await s.apply_group_overrides()
+    assert s.start_timeout == 120
+
+    non_admin_user = find_user(app.db, "user")
+    s = Spawner(user=non_admin_user)
+    s.start_timeout = 60
+    s.group_overrides = group_overrides
+    await s.apply_group_overrides()
+    assert s.start_timeout == 60

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -905,6 +905,7 @@ class User:
             # wait for spawner.start to return
             # run optional preparation work to bootstrap the notebook
             await maybe_future(spawner.run_pre_spawn_hook())
+            await spawner.apply_group_overrides()
             if self.settings.get('internal_ssl'):
                 self.log.debug("Creating internal SSL certs for %s", spawner._log_name)
                 hub_paths = await maybe_future(spawner.create_certs())

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -904,8 +904,8 @@ class User:
             db.commit()
             # wait for spawner.start to return
             # run optional preparation work to bootstrap the notebook
-            await maybe_future(spawner.run_pre_spawn_hook())
             await spawner.apply_group_overrides()
+            await maybe_future(spawner.run_pre_spawn_hook())
             if self.settings.get('internal_ssl'):
                 self.log.debug("Creating internal SSL certs for %s", spawner._log_name)
                 hub_paths = await maybe_future(spawner.create_certs())

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -942,3 +942,23 @@ def subdomain_hook_idna(name, domain, kind):
     else:
         suffix = f"--{kind}"
     return f"{safe_name}{suffix}.{domain}"
+
+
+# From https://github.com/jupyter-server/jupyter_server/blob/fc0ac3236fdd92778ea765db6e8982212c8389ee/jupyter_server/config_manager.py#L14
+def recursive_update(target, new):
+    """
+    Recursively update one dictionary in-place using another.
+
+    None values will delete their keys.
+    """
+    for k, v in new.items():
+        if isinstance(v, dict):
+            if k not in target:
+                target[k] = {}
+            recursive_update(target[k], v)
+
+        elif v is None:
+            target.pop(k, None)
+
+        else:
+            target[k] = v


### PR DESCRIPTION
Similar to 'kubespawner_override' in KubeSpawner, this allows admins to selectivel override spawner configuration based on groups a user belongs to. This allows for low maintenance but extremely powerful customization based on group membership. This is particularly powerful when combined with
https://github.com/jupyterhub/oauthenticator/pull/735

## Dictionary vs List

Ordering is important here, but still I choose to implement this configuration as a dictionary of dictionaries vs a list. This is primarily to allow for easy overriding in z2jh (and similar places), where Lists are just really hard to override. Ordering is provided by lexicographically sorting the keys, similar to how we do it in z2jh.

## Merging config

The merging code is literally copied from KubeSpawner, and provides the exact same behavior. Documentation of how it acts is also copied.