### PR TITLE
Fix wording for `read:users` scope description

### DIFF
--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -2124,8 +2124,9 @@ components:
               and authentication state).
             delete:users: Delete users.
             list:users: List users, including at least their names.
-            read:users: Read user models (including servers, tokens and
-              authentication state).
+            read:users:
+              Read user models (including servers, tokens and authentication
+              state).
             read:users:name: Read names of users.
             read:users:groups: Read users’ group membership.
             read:users:activity: Read time of last user activity.

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -2124,8 +2124,7 @@ components:
               and authentication state).
             delete:users: Delete users.
             list:users: List users, including at least their names.
-            read:users:
-              Read user models (excluding including servers, tokens and
+            read:users: Read user models (including servers, tokens and
               authentication state).
             read:users:name: Read names of users.
             read:users:groups: Read users’ group membership.

--- a/jupyterhub/scopes.py
+++ b/jupyterhub/scopes.py
@@ -64,7 +64,7 @@ scope_definitions = {
         'subscopes': ['read:users:name'],
     },
     'read:users': {
-        'description': 'Read user models (excluding including servers, tokens and authentication state).',
+        'description': 'Read user models (including servers, tokens and authentication state).',
         'subscopes': [
             'read:users:name',
             'read:users:groups',


### PR DESCRIPTION
Looks like there was a typo in the original description.