### PR TITLE
Add token_expires_in_max_seconds configuration

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -489,10 +489,29 @@ class UserTokenListAPIHandler(APIHandler):
                     400, f"token {key} must be null or a list of strings, not {value!r}"
                 )
 
+        expires_in = body.get('expires_in', None)
+        if not (expires_in is None or isinstance(expires_in, int)):
+            raise web.HTTPError(
+                400,
+                f"token expires_in must be null or integer, not {expires_in!r}",
+            )
+        expires_in_max = self.settings.get("token_expires_in_max_seconds", 0)
+        if expires_in_max:
+            # validate expires_in against limit
+            if expires_in is None:
+                # expiration unspecified, use max value
+                # (default before max limit was introduced was 'never', this is closest equivalent)
+                expires_in = expires_in_max
+            elif expires_in > expires_in_max:
+                raise web.HTTPError(
+                    400,
+                    f"token expires_in: {expires_in} must not exceed {expires_in_max}",
+                )
+
         try:
             api_token = user.new_api_token(
                 note=note,
-                expires_in=body.get('expires_in', None),
+                expires_in=expires_in,
                 roles=token_roles,
                 scopes=token_scopes,
             )

--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -495,7 +495,7 @@ class UserTokenListAPIHandler(APIHandler):
                 400,
                 f"token expires_in must be null or integer, not {expires_in!r}",
             )
-        expires_in_max = self.settings.get("token_expires_in_max_seconds", 0)
+        expires_in_max = self.settings["token_expires_in_max_seconds"]
         if expires_in_max:
             # validate expires_in against limit
             if expires_in is None:

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -464,6 +464,26 @@ class JupyterHub(Application):
         # convert cookie max age days to seconds
         return int(self.cookie_max_age_days * 24 * 3600)
 
+    token_expires_in_max_seconds = Integer(
+        0,
+        config=True,
+        help="""
+        Set the maximum expiration (in seconds) of tokens created via the API.
+
+        Set to any positive value to disallow creation of tokens with no expiration.
+
+        0 (default) = no limit.
+        
+        Does not affect:
+        
+        - Server API tokens ($JUPYTERHUB_API_TOKEN is tied to lifetime of the server)
+        - Tokens issued during oauth (use `oauth_token_expires_in`)
+        - Tokens created via the API before configuring this limit
+        
+        .. versionadded:: 5.1
+        """,
+    )
+
     redirect_to_server = Bool(
         True, help="Redirect user to server (if running), instead of control panel."
     ).tag(config=True)
@@ -3192,6 +3212,7 @@ class JupyterHub(Application):
             static_path=os.path.join(self.data_files_path, 'static'),
             static_url_prefix=url_path_join(self.hub.base_url, 'static/'),
             static_handler_class=CacheControlStaticFilesHandler,
+            token_expires_in_max_seconds=self.token_expires_in_max_seconds,
             subdomain_hook=self.subdomain_hook,
             template_path=self.template_paths,
             template_vars=self.template_vars,

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -542,7 +542,7 @@ class TokenPageHandler(BaseHandler):
         oauth_clients = sorted(oauth_clients, key=sort_key, reverse=True)
 
         auth_state = await self.current_user.get_auth_state()
-        expires_in_max = self.settings.get("token_expires_in_max_seconds", 0)
+        expires_in_max = self.settings["token_expires_in_max_seconds"]
         options = [
             (3600, "1 Hour"),
             (86400, "1 Day"),

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -13,13 +13,7 @@
           <br />
           <label for="token-expiration-seconds" class="form-label">Token expires in</label>
           {% block expiration_options %}
-            <select id="token-expiration-seconds" class="form-select">
-              <!-- unit used for each value is `seconds` -->
-              <option value="3600">1 Hour</option>
-              <option value="86400">1 Day</option>
-              <option value="604800">1 Week</option>
-              <option value="" selected="selected">Never</option>
-            </select>
+            <select id="token-expiration-seconds" class="form-select">{{ token_expires_in_options_html | safe }}</select>
           {% endblock expiration_options %}
           <small id="note-expires-at" class="form-text">You can configure when your token will expire.</small>
           <br />


### PR DESCRIPTION
Allows limiting max expiration of tokens created via the API / form.

Only affects the POST /api/tokens endpoint, not tokens issued by other means or created prior to config, which can be revoked after-the-fact via db query or API requests. This avoids introducing the problems around applying the limit to server tokens, which don't have deadline-based expiration, but are revoked when the server stops.

closes #1772

this addresses part of #4028, but lots of options are discussed there. I'll let @rcthomas decide if this is sufficient to close #4028 or not.