### PR TITLE
reduce cost of event_loop_interval metric

### DIFF
--- a/docs/source/reference/monitoring.md
+++ b/docs/source/reference/monitoring.md
@@ -32,3 +32,11 @@ export JUPYTERHUB_METRICS_PREFIX=jupyterhub_prod
 ```
 
 would result in the metric `jupyterhub_prod_active_users`, etc.
+
+## Configuring metrics
+
+```{eval-rst}
+.. currentmodule:: jupyterhub.metrics
+
+.. autoconfigurable:: PeriodicMetricsCollector
+```

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -22,6 +22,7 @@ them manually here.
     added ``jupyterhub_`` prefix to metric names.
 """
 
+import asyncio
 import os
 import time
 from datetime import timedelta
@@ -29,7 +30,7 @@ from enum import Enum
 
 from prometheus_client import Gauge, Histogram
 from tornado.ioloop import PeriodicCallback
-from traitlets import Any, Bool, Dict, Float, Integer
+from traitlets import Any, Bool, Dict, Float, Integer, default
 from traitlets.config import LoggingConfigurable
 
 from . import orm
@@ -236,17 +237,17 @@ EVENT_LOOP_INTERVAL_SECONDS = Histogram(
     'event_loop_interval_seconds',
     'Distribution of measured event loop intervals',
     namespace=metrics_prefix,
-    # Increase resolution to 5ms below 50ms
+    # don't measure below 50ms, our default
+    # Increase resolution to 5ms below 75ms
     # because this is where we are most sensitive.
-    # No need to have buckets below 25, since we only measure every 20ms.
+    # No need to have buckets below 50, since we only measure every 50ms.
     buckets=[
-        # 5ms from 25-50ms
-        25e-3,
-        30e-3,
-        35e-3,
-        40e-3,
-        45e-3,
+        # 5ms from 50-75ms
         50e-3,
+        55e-3,
+        60e-3,
+        65e-3,
+        70e-3,
         # from here, default prometheus buckets
         75e-3,
         0.1,
@@ -323,19 +324,20 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         """,
     )
     event_loop_interval_resolution = Float(
-        0.02,
+        0.05,
         config=True,
         help="""
         Interval (in seconds) on which to measure the event loop interval.
         
-        This is the _sensitivity_ of the event_loop_interval metric.
+        This is the _sensitivity_ of the `event_loop_interval` metric.
         Setting it too low (e.g. below 20ms) can end up slowing down the whole event loop
         by measuring too often,
         while setting it too high (e.g. above a few seconds) may limit its resolution and usefulness.
         The Prometheus Histogram populated by this metric
         doesn't resolve differences below 25ms,
         so setting this below ~20ms won't result in increased resolution of the histogram metric,
-        except for the average value, computed by:
+        except for the average value, computed by::
+
             event_loop_interval_seconds_sum / event_loop_interval_seconds_count
         """,
     )
@@ -345,8 +347,15 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         help="""Log when the event loop blocks for at least this many seconds.""",
     )
 
+    @default("event_loop_interval_log_threshold")
+    def _default_log_threshold(self):
+        # default lower bound is 1s,
+        # but don't warn on every tick by default
+        # if measurement interval is longer than that
+        return max(1, 2 * self.event_loop_interval_resolution)
+
     # internal state
-    _last_tick = Float()
+    _tasks = Dict()
     _periodic_callbacks = Dict()
 
     db = Any(help="SQLAlchemy db session to use for performing queries")
@@ -371,18 +380,26 @@ class PeriodicMetricsCollector(LoggingConfigurable):
             self.log.info(f'Found {value} active users in the last {period}')
             ACTIVE_USERS.labels(period=period.value).set(value)
 
-    def _event_loop_tick(self):
-        """Measure a single tick of the event loop
+    async def _measure_event_loop_interval(self):
+        """Measure the event loop responsiveness
 
-        This measures the time since the last tick
+        A single long-running coroutine because PeriodicCallback is too expensive
+        to measure small intervals.
         """
-        now = time.perf_counter()
-        tick_duration = now - self._last_tick
-        self._last_tick = now
-        EVENT_LOOP_INTERVAL_SECONDS.observe(tick_duration)
-        if tick_duration >= self.event_loop_interval_log_threshold:
-            # warn about slow ticks
-            self.log.warning("Event loop was unresponsive for %.2fs!", tick_duration)
+        tick = time.perf_counter
+
+        last_tick = tick()
+        while True:
+            await asyncio.sleep(self.event_loop_interval_resolution)
+            now = tick()
+            tick_duration = now - last_tick
+            last_tick = now
+            EVENT_LOOP_INTERVAL_SECONDS.observe(tick_duration)
+            if tick_duration >= self.event_loop_interval_log_threshold:
+                # warn about slow ticks
+                self.log.warning(
+                    "Event loop was unresponsive for %.2fs!", tick_duration
+                )
 
     def start(self):
         """
@@ -400,12 +417,8 @@ class PeriodicMetricsCollector(LoggingConfigurable):
             self.update_active_users()
 
         if self.event_loop_interval_enabled:
-            now = time.perf_counter()
-            self._last_tick = self._last_tick_collect = now
-            self._tick_durations = []
-            self._periodic_callbacks["event_loop_tick"] = PeriodicCallback(
-                self._event_loop_tick,
-                self.event_loop_interval_resolution * 1000,
+            self._tasks["event_loop_tick"] = asyncio.create_task(
+                self._measure_event_loop_interval()
             )
 
         # start callbacks
@@ -418,3 +431,5 @@ class PeriodicMetricsCollector(LoggingConfigurable):
         """
         for pc in self._periodic_callbacks.values():
             pc.stop()
+        for task in self._tasks.values():
+            task.cancel()


### PR DESCRIPTION
also makes sure the PeriodicMetrics config is in the docs, so disable config can be found.

- trade PeriodicCallback for single coroutine (saves ~50% in measurements)
- increase default interval from 20ms to 50ms (and adjust metric buckets to match)
- measure `delay` instead of the overall tick duration (more below) for more strictly defined measurements

Table of [measurements](https://gist.github.com/minrk/12ad941d945bf41d92d607e274c2a3cb) (90% means 90% of samples measured at least this cpu usage, i.e. the 10th percentile)

before:

| interval | avg_cpu | 90%  | 75%  |
| ----- | ------- | ---- | ---- |
| disabled    | 0.0%    | 0.0% | 0.0% | 
| 0.02 (default)  | 2.1%    | 1.8% | 2.1% | 
| 0.05  | 1.1%    | 0.9% | 1.0% | 
| 0.1   | 0.7%    | 0.5% | 0.6% | 
| 0.2   | 0.4%    | 0.0% | 0.3% | 
| 0.5   | 0.2%    | 0.0% | 0.0% |

after:

| interval | avg_cpu | 90%  | 75%  |
| -------- | ------- | ---- | ---- |
| 0.02     | 0.9%    | 0.7% | 0.9% | 
| 0.05 (default)     | 0.4%    | 0.4% | 0.4% | 
| 0.1      | 0.2%    | 0.2% | 0.2% | 
| 0.2      | 0.1%    | 0.0% | 0.2% | 
| 0.5      | 0.1%    | 0.0% | 0.0% |


The question that remains is what should the buckets be, since it no longer makes sense to keep 25-50ms. I've spent entirely too long thinking about this, and I wish the answer were clearer.

Since the measurement is really "how long does it take to wait `interval`", not a direct measurement of the event loop interval itself (too expensive), the event loop duration is really anywhere on the range `[measurement - interval, measurement]`, so for a measurement of 55ms and an interval of 50ms, we know that the event loop blocked for between 5ms and 55ms, but don't know any more than that. In that way, it doesn't make a whole lot of sense to distinguish measurements smaller than 2 * the interval, since they aren't super meaningful. That said, we can infer from statistics that if 99% of measurements at 50ms are less than 55ms, one can reasonably conclude that the actual event loop interval is below 5 ms.

As we have right now, the metric records an _upper_ bound on the responsiveness (i.e. we know with confidence that 90% of ticks are below 50ms and 95% are below 60ms, but that does _not_ mean 5% are between 50ms and 60ms, which would be true in a typical histogram metric).

An alternate definition of the metric is the _delay_, which sets a _lower_ bound, i.e. we know the event loop blocked for at least `delay = measurement - interval` seconds. The advantage of this is it more reliably reports what we do know. The disadvantage is it could under-report actual delays by up to `interval` (in aggregate, the expectation value of this over/under estimate would be `interval / 2`, either way).

My current thinking is:

- record only the delay
- report all delays < threshold as threshold exactly

which this PR currently reflects

alternately, we could keep the same rounding but use the upper bound, i.e. record the same value we have now, but report every measurement below 2 * interval as 2 * interval (i.e. the actual upper bound). That's technically the same information as the truncated delay, but the number reported is bigger by `interval` and represents an actual strict upper bound.

Advantage of delay: "we know it blocked at least this much"; disadvantage: under-estimates actual blocking events by up to resolution / 2 on average
Advantage of upper bound: "we know it did not block more than this"; disadvantage: over-estimates by up to resolution / 2 on average
Advantage of either rounded scheme: far more measurements will be in the lowest bucket and with confidence, rather than smearing not-actually-resolved measurements between `[resolution, resolution * 2]`

Advantage of current scheme: each individual measurement is really an upper bound, there is _some_ information in measurements between `[resolution, resolution * 2]`, at least in aggregate; disadvantage: buckets aren't mutually exclusive (55ms could be 6ms or 54ms)

The reason I like `delay` is that the vast majority of the time in practice, the actual number we are measuring is 0, so rounding up doesn't feel right. The overestimate issue is on measurements _where the loop is blocked_, not all measurements in general.

I feel like I've spent far too long on this, since we're talking about measurements around 20-100ms when the real events we want to notice are 10-100 times that, all of which will show up equivalently in all of the above schemes, except that `delay` will report a 1s delay as `0.95-1`, while the others will report it as `1-1.05`.

closes #4834