### PR TITLE
Show insecure login warning when not in a secure context

### DIFF
--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -91,7 +91,7 @@
 {% block script %}
   {{ super() }}
   <script>
-    if (window.location.protocol === "http:") {
+    if (!window.isSecureContext) {
       // unhide http warning
       var warning = document.getElementById('insecure-login-warning');
       warning.className = warning.className.replace(/\bhidden\b/, '');


### PR DESCRIPTION
Secure contexts are a more robust way of checking that a browsing context is authenticated and confidential. Compared to comparing the scheme this covers cases where the connection is encrypted, but using a broken algorithm.

Notably, localhost is considered a secure context, even over HTTP.

For more detail on secure contexts, see:
https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts

Fixes #4855 