### PR TITLE
Pass `kwargs` down to `initialize()` call of the server

### DIFF
--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -588,7 +588,7 @@ class SingleUserNotebookAppMixin(Configurable):
             self.log.warning("Enabling jupyterhub test extension")
             self.jpserver_extensions["jupyterhub.tests.extension"] = True
 
-    def initialize(self, argv=None):
+    def initialize(self, argv=None, **kwargs):
         if self.disable_user_config:
             _disable_user_config(self)
         # disable trash by default
@@ -605,7 +605,7 @@ class SingleUserNotebookAppMixin(Configurable):
         # jupyter-server calls it too late, notebook doesn't define it yet
         # only called in jupyter-server >= 1.9
         self.init_ioloop()
-        super().initialize(argv)
+        super().initialize(argv, **kwargs)
         self.patch_templates()
 
     def init_ioloop(self):


### PR DESCRIPTION
Addresses https://github.com/jupyterhub/jupyterhub/issues/4857#issuecomment-2254090841

Of note the child class already does it well:

https://github.com/jupyterhub/jupyterhub/blob/0cd5e51dd4f8f0079f7391e9f831dd202877e999/jupyterhub/singleuser/mixins.py#L952-L962
