### PR TITLE
Add PAMAuthenticator.executor_threads configurable, increase default to 4

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1230,7 +1230,20 @@ class PAMAuthenticator(LocalAuthenticator):
 
     @default('executor')
     def _default_executor(self):
-        return ThreadPoolExecutor(1)
+        return ThreadPoolExecutor(self.executor_threads)
+
+    executor_threads = Integer(
+        1,
+        config=True,
+        help="""
+        Number of executor threads.
+
+        PAM auth requests happen in this thread, so it is mostly
+        waiting for the pam stack. One thread is usually enough,
+        unless your pam stack is doing something slow like network
+        requests
+        """,
+    )
 
     encoding = Unicode(
         'utf8',

--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -1233,7 +1233,7 @@ class PAMAuthenticator(LocalAuthenticator):
         return ThreadPoolExecutor(self.executor_threads)
 
     executor_threads = Integer(
-        1,
+        4,
         config=True,
         help="""
         Number of executor threads.


### PR DESCRIPTION
Following the testing described [here](https://github.com/Will-Shanks/jupyterhub_auth_repro) and a discussion with @manics on [discourse](https://discourse.jupyter.org/t/configuring-pamauthenticator-executor/27436/7) I opened this PR to make the thread pool size used by the PAMAuthenticator configurable.

This is a simple change modeled after this [OAuthenticator](https://github.com/jupyterhub/oauthenticator/blob/cd00a8d6e5a8a6a97088b4a1e73ccb419f197257/oauthenticator/mediawiki.py#L96). After some simple testing with our production environment (~100 active users) adding more threads to this pool has had a significant affect on our hub stability, that we expect could help other sites too.