### PR TITLE
singleuser: fix shutdown mixin

### DIFF
--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -361,9 +361,8 @@ class SingleUserNotebookAppMixin(Configurable):
         """override default log format to include time"""
         return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"
 
-    def _confirm_exit(self):
-        # disable the exit confirmation for background notebook processes
-        self.io_loop.add_callback_from_signal(self.io_loop.stop)
+    def _handle_sigint(self, *args, **kwargs):
+        self._signal_stop(*args, **kwargs)
 
     def migrate_config(self):
         if self.disable_user_config:


### PR DESCRIPTION
The server shutdown mechanism isn't working as intended at the moment with the following consequences:

* Nothing happens for 10 seconds (default) after issuing the stop request.
* The server is ultimately killed with SIGKILL (rather than SIGINT).
* The Jupyter Server cleanup logic is not called.

In some situations this can lead to orphan processes being left behind.

#### Quick Explanation

This PR changes the singleuser mixin to call the shutdown logic in Jupyter Server when SIGINT is received.

This removes the 10 second delay and ensures the Jupyter Server shutdown logic is called correctly.

When this is working correctly, the following log messages should be emitted by Jupyter Server:

```
[C <HubApp> serverapp:2450] received signal 2, stopping
[I <HubApp> serverapp:2792] Shutting down <x> extensions
```

#### Detailed Explanation

Jupyter Server captures [two signals](https://github.com/jupyter-server/jupyter_server/blob/bf2d177df6250cdb1790f4608f65e0072093dcb2/jupyter_server/serverapp.py#L1310-L1312):

* `SIGINT` causes `_handle_sigint` to be called.
  * This issues an interactive prompt asking the user for confirmation before shutting down.
  * It also redirects `SIGINT` to `_signal_stop` to handle `CTRL+C` being pressed twice.
* `SIGTERM` causes `_signal_stop` to be called.
  * This calls the appropriate cleanup interfaces to be called ([`_signal_stop`](https://github.com/jupyter-server/jupyter_server/blob/535d7df3c0b358e31f514842c5509ca6ce64f056/jupyter_server/serverapp.py#L2448-L2451) -> [`stop`](https://github.com/jupyter-server/jupyter_server/blob/535d7df3c0b358e31f514842c5509ca6ce64f056/jupyter_server/serverapp.py#L3129-L3142) -> [`_stop`](https://github.com/jupyter-server/jupyter_server/blob/535d7df3c0b358e31f514842c5509ca6ce64f056/jupyter_server/serverapp.py#L3123-L3127) -> `_cleanup`).

Since the interactive prompt does not make sense in the Jupyter Hub context, the singleuser mixin is attempting to bypass jupyter_server's interactive prompt on shutdown by stopping the IO loop.

https://github.com/jupyterhub/jupyterhub/blob/49aaf5050f92ee678b8248107fd243786ac17d32/jupyterhub/singleuser/mixins.py#L364-L366

This disables the interactive prompt, however, that's all it does, it doesn't actually action shutdown. As a result, SIGINT is caught and ignored, the server process continues running.

For the `LocalProcessSpawner` the SIGINT is then elevated to SIGTERM after the configured timeout (default 10s).

https://github.com/jupyterhub/jupyterhub/blob/49aaf5050f92ee678b8248107fd243786ac17d32/jupyterhub/spawner.py#L1916-L1930

(the behaviour of other spawners may differ)

As a result of this timeout, we see the following message in the JupyterHub log:

```
User <user>: server is slow to stop (timeout=10)
```

Finally, the SIGTERM is elevated to SIGKILL by this logic:

https://github.com/jupyterhub/jupyterhub/blob/49aaf5050f92ee678b8248107fd243786ac17d32/jupyterhub/spawner.py#L1932-L1943

This causes the server to be forcibly killed, bypassing the intended shutdown logic.

#### Example series of events (before)

Example series of events using `LocalProcessSpawner`.

1) Shutdown request received
2) SIGINT sent
3) SIGTERM sent
4) SIGTERM received
5) Slow shutdown detected
6) SIGKILL sent
7) Server killed after ~15 seconds (10s SIGINT timeout + 5s SIGTERM timeout)

```log
(1) [I JupyterHub proxy:356] Removing user <user> from proxy (/user/<user>/)
    [D JupyterHub proxy:925] Proxy: Fetching DELETE http://127.0.0.1:8001/api/routes/user/<user>
    [ConfigProxy] info: Removing route /user/<user>
    [ConfigProxy] info: 204 DELETE /api/routes/user/<user> 
    [D JupyterHub user:1100] Stopping <user>
(2) [D JupyterHub spawner:1920] Interrupting 53455
(3) [D JupyterHub spawner:1928] Terminating 53455
(4) [C <HubApp> serverapp:2450] received signal 15, stopping
(5) [W JupyterHub base:1365] User <user>: server is slow to stop (timeout=10)
    [I JupyterHub log:192] 202 DELETE /hub/api/users/<user>/server?_xsrf=[secret] (<user>@::ffff:127.0.0.1) 10050.47ms
(6) [D JupyterHub spawner:1936] Killing 53455
    [D JupyterHub user:1122] Deleting oauth client jupyterhub-user-<user>
    [D JupyterHub user:1125] Finished stopping <user>
(7) [I JupyterHub base:1333] User <user> server took 15.360 seconds to stop
```

#### Example series of events (after)

Example series of events using `LocalProcessSpawner`.

1) Shutdown request received
2) SIGINT sent
3) SIGINT received
4) Cleanup logic run
5) Server killed after ~1 second

```
(1) [I JupyterHub proxy:356] Removing user <user> from proxy (/user/<user>/)
    [D JupyterHub proxy:925] Proxy: Fetching DELETE http://127.0.0.1:8001/api/routes/user/<user>
    [ConfigProxy] info: Removing route /user/<user>
    [ConfigProxy] info: 204 DELETE /api/routes/user/<user> 
    [D JupyterHub user:1100] Stopping <user>
(2) [D JupyterHub spawner:1920] Interrupting 56605
(3) [C <HubApp> serverapp:2450] received signal 2, stopping
(4) [I <HubApp> serverapp:2792] Shutting down 2 extensions
    [D JupyterHub user:1122] Deleting oauth client jupyterhub-user-<user>
    [DJupyterHub user:1125] Finished stopping <user>
(5) [I JupyterHub base:1333] User <user> server took 1.762 seconds to stop
```

#### Back Compatibility

The `_handle_sigint` and `_signal_stop` interfaces date back to Jupyter Server 0.0.1:

https://github.com/jupyter-server/jupyter_server/blob/0.0.1/jupyter_server/serverapp.py#L1310-L1312