### PR TITLE
Revoke all permissions from Authenticator.blocked_users

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -300,6 +300,14 @@ class Authenticator(LoggingConfigurable):
         If empty, does not perform any additional restriction.
 
         .. versionadded: 0.9
+        
+        .. versionchanged:: 5.2
+            Users blocked via `blocked_users` that may have logged in in the past
+            have all permissions and group membership revoked
+            and all servers stopped at JupyterHub startup.
+            Previously, User permissions (e.g. API tokens)
+            and servers were unaffected and required additional
+            administrator operations to block after a user is added to `blocked_users`.
 
         .. versionchanged:: 1.2
             `Authenticator.blacklist` renamed to `blocked_users`

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -1234,6 +1234,8 @@ class APIToken(Hashed, Base):
             orm_token.expires_at = cls.now() + timedelta(seconds=expires_in)
 
         db.commit()
+        if return_orm:
+            return orm_token
         return token
 
     def update_scopes(self, new_scopes):

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -1141,7 +1141,6 @@ class APIToken(Hashed, Base):
         expires_in=None,
         client_id=None,
         oauth_client=None,
-        return_orm=False,
     ):
         """Generate a new API token for a user or service"""
         assert user or service
@@ -1234,8 +1233,6 @@ class APIToken(Hashed, Base):
             orm_token.expires_at = cls.now() + timedelta(seconds=expires_in)
 
         db.commit()
-        if return_orm:
-            return orm_token
         return token
 
     def update_scopes(self, new_scopes):

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -308,17 +308,6 @@ def new_hub(request, tmpdir, persist_db):
 
 
 async def test_resume_spawners(tmpdir, request, new_hub):
-    async def new_hub():
-        kwargs = {}
-        ssl_enabled = getattr(request.module, "ssl_enabled", False)
-        if ssl_enabled:
-            kwargs['internal_certs_location'] = str(tmpdir)
-        app = MockHub(test_clean_db=False, **kwargs)
-        app.config.ConfigurableHTTPProxy.should_start = False
-        app.config.ConfigurableHTTPProxy.auth_token = 'unused'
-        await app.initialize([])
-        return app
-
     app = await new_hub()
     db = app.db
     # spawn a user's server
@@ -541,7 +530,7 @@ async def test_recreate_service_from_database(
     assert service_name not in app._service_map
 
 
-async def test_revoke_blocked_users(app, username, groupname, new_hub):
+async def test_revoke_blocked_users(username, groupname, new_hub):
     config = Config()
     config.Authenticator.admin_users = {username}
     kept_username = username + "-kept"
@@ -609,3 +598,4 @@ async def test_revoke_blocked_users(app, username, groupname, new_hub):
     # (sanity check) didn't lose other user
     kept_user = app2.users[kept_username]
     assert 'user' in [r.name for r in kept_user.roles]
+    app2.stop()


### PR DESCRIPTION
rather than only disabling login, fully block the user from Hub operations by removing all group membership and role assignments

This is not optional because I think it's what people generally expect. The previous behavior: block login, but leave user active and able to act with existing credentials and running servers makes _theoretical_ sense, but not really in practice, so I don't feel the need to keep it as default or even possible.

The downside of special treatment for `blocked_users` is that other mechanisms by which `check_blocked` might get info will not get this treatment. However, those mechanisms _cannot be called_ during Hub startup, because they may require non-persisted information from the authentication process. That's harder to communicate about. Authenticator-managed roles are a possibility, but only if the `users` role is auth-managed and can be _completely_ specified (i.e. all members can be specified at once) is the only way to revoke membership by omission.

closes #4861 