### PR TITLE
Admin pages: use inherited base_url from render_template

### DIFF
--- a/jsx/src/util/jhapiUtil.js
+++ b/jsx/src/util/jhapiUtil.js
@@ -3,7 +3,7 @@ const base_url = jhdata.base_url || "/";
 const xsrfToken = jhdata.xsrf_token;
 
 export const jhapiRequest = (endpoint, method, data) => {
-  let api_url = new URL(`${base_url}hub/api` + endpoint, location.origin);
+  let api_url = new URL(`${base_url}api` + endpoint, location.origin);
   if (xsrfToken) {
     api_url.searchParams.set("_xsrf", xsrfToken);
   }

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -466,7 +466,6 @@ class AdminHandler(BaseHandler):
             named_server_limit_per_user=await self.get_current_user_named_server_limit(),
             server_version=f'{__version__} {self.version_hash}',
             api_page_limit=self.settings["api_page_default_limit"],
-            base_url=self.settings["base_url"],
         )
         self.finish(html)
 


### PR DESCRIPTION
`base_url` for `pages.html` is set to `/hub` in
https://github.com/jupyterhub/jupyterhub/blob/a377f8bc7f906a556b7b89317a068c18a92d81aa/jupyterhub/handlers/base.py#L1428

Closes https://github.com/jupyterhub/jupyterhub/issues/4622