### PR TITLE
bump require.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,9 +251,10 @@
       }
     },
     "node_modules/requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
+      "license": "MIT",
       "bin": {
         "r_js": "bin/r.js",
         "r.js": "bin/r.js"


### PR DESCRIPTION
bundled r.js 2.3.6 has a CVE attached, so scanners may flag it. Though JupyterHub's use of r.js is not affected, so there's no real pressure here. The only affected case is untrusted code passed to `requirejs.config()`, which doesn't happen in JupyterHub.