### PR TITLE
add dependabot config for npm

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,25 @@ updates:
       interval: monthly
       time: "05:00"
       timezone: Etc/UTC
+  - package-ecosystem: npm
+    directory: /
+    groups:
+      # one big pull request
+      npm:
+        patterns:
+          - "*"
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC
+  - package-ecosystem: npm
+    directory: /jsx
+    groups:
+      # one big pull request
+      jsx:
+        patterns:
+          - "*"
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC


### PR DESCRIPTION
should start bumping dependencies for top-level and jsx