### PR TITLE
fix python3 -m jupyterhub.app

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3948,4 +3948,8 @@ UpgradeDB.classes.append(JupyterHub)
 main = JupyterHub.launch_instance
 
 if __name__ == "__main__":
-    main()
+    # don't invoke __main__.main here because __main__.JupyterHub
+    # is not jupyterhub.app.JupyterHub. There will be two!
+    from jupyterhub import app
+
+    app.JupyterHub.launch_instance()


### PR DESCRIPTION
`python3 -m jupyterhub.app` means _both_ jupyterhub.app and `__main__` modules are defined and are not the same, so instance/isinstance checks don't work because `__main__.JupyterHub` is not `jupyterhub.app.JupyterHub`.

Lesson learned: don't put `if __name__ == "__main__"` in modules that might be imported by other modules.

discovered in https://github.com/jupyterhub/the-littlest-jupyterhub/issues/987