### PR TITLE
Display Sphinx linkcheck output in a more readable format

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -81,10 +81,12 @@ jobs:
           cd docs
           make html
 
+      # Output broken and permanently redirected links in a readable format
       - name: check links
-        run: |
-          cd docs
-          make linkcheck
+        uses: manics/action-sphinx-linkcheck-summary@main
+        with:
+          docs-dir: docs
+          build-dir: docs/_build
 
       # make rediraffecheckdiff compares files for different changesets
       # these diff targets aren't always available


### PR DESCRIPTION
I've copied https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/77e9df64f926582417ce8389cc55d58849ce4aff/ci/summarise-linkcheck-output#L1-L23 into an action:
https://github.com/manics/action-sphinx-linkcheck-summary

Example output:
![image](https://github.com/user-attachments/assets/8d6e3578-a4e8-4043-93b5-5ba5dececa2d)

Without this PR:
![image](https://github.com/user-attachments/assets/3751a195-61c5-4602-a887-e48ff31c4abd)
