### PR TITLE
only group minor dependencies in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,22 +17,41 @@ updates:
   - package-ecosystem: npm
     directory: /
     groups:
-      # one big pull request
-      npm:
+      # one big pull request for minor bumps
+      npm-minor:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: monthly
-      time: "05:00"
-      timezone: Etc/UTC
   - package-ecosystem: npm
     directory: /jsx
     groups:
-      # one big pull request
-      jsx:
+      # one big pull request for minor bumps
+      jsx-minor:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+      # group major bumps of react-related
+      jsx-react:
+        patterns:
+          - "react*"
+          - "redux*"
+          - "*react"
+          - "recompose"
+        update-types:
+          - major
+      # group major bumps of webpack-related
+      jsx-webpack:
+        patterns:
+          - "webpack*"
+          - "@babel/*"
+          - "*-loader"
+        update-type:
+          - major
     schedule:
       interval: monthly
-      time: "05:00"
-      timezone: Etc/UTC


### PR DESCRIPTION
should exclude major bumps from PRs like #4873 