### PR TITLE
docs: remove some outdated links

### DIFF
--- a/docs/source/faq/troubleshooting.md
+++ b/docs/source/faq/troubleshooting.md
@@ -276,17 +276,6 @@ the entire filesystem and set the default to the user's home directory.
     c.Spawner.notebook_dir = '/'
     c.Spawner.default_url = '/home/%U' # %U will be replaced with the username
 
-### How do I increase the number of pySpark executors on YARN?
-
-From the command line, pySpark executors can be configured using a command
-similar to this one:
-
-    pyspark --total-executor-cores 2 --executor-memory 1G
-
-[Cloudera documentation for configuring spark on YARN applications](https://www.cloudera.com/documentation/enterprise/latest/topics/cdh_ig_running_spark_on_yarn.html#spark_on_yarn_config_apps)
-provides additional information. The [pySpark configuration documentation](https://spark.apache.org/docs/0.9.0/configuration.html)
-is also helpful for programmatic configuration examples.
-
 ### How do I use JupyterLab's pre-release version with JupyterHub?
 
 While JupyterLab is still under active development, we have had users

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -82,15 +82,6 @@ Within CERN, there are two noteworthy JupyterHub deployments in operation:
 - Advanced Computing
   - [Palmetto cluster and JupyterHub](https://citi.sites.clemson.edu/2016/08/18/JupyterHub-for-Palmetto-Cluster.html)
 
-### University of Colorado Boulder
-
-- (CU Research Computing) CURC
-
-  - [JupyterHub User Guide](https://curc.readthedocs.io/en/latest/gateways/jupyterhub.html)
-    - Slurm job dispatched on Crestone compute cluster
-    - log troubleshooting
-    - Profiles in IPython Clusters tab
-
 ### ETH Zurich
 
 [ETH Zurich](https://ethz.ch/en.html), (Federal Institute of Technology Zurich), is a public research university in Zürich, Switzerland, with focus on science, technology, engineering, and mathematics, although its 16 departments span a variety of disciplines and subjects.


### PR DESCRIPTION
- CURC no longer uses JupyterHub
- outdated faq links to spark/yarn docs doesn't reflect current usage, I think

found via nice format in #4881 