### PR TITLE
add University of Portland to sample orgs

### DIFF
--- a/docs/source/faq/institutional-faq.md
+++ b/docs/source/faq/institutional-faq.md
@@ -66,7 +66,7 @@ industry, and government research labs. It is most-commonly used by two kinds of
 Here is a sample of organizations that use JupyterHub:
 
 - **Universities and colleges**: UC Berkeley, UC San Diego, Cal Poly SLO, Harvard University, University of Chicago,
-  University of Oslo, University of Sheffield, Université Paris Sud, University of Versailles
+  University of Oslo, University of Sheffield, Université Paris Sud, University of Versailles, University of Portland
 - **Research laboratories**: NASA, NCAR, NOAA, the Large Synoptic Survey Telescope, Brookhaven National Lab,
   Minnesota Supercomputing Institute, ALCF, CERN, Lawrence Livermore National Laboratory, HUNT
 - **Online communities**: Pangeo, Quantopian, mybinder.org, MathHub, Open Humans


### PR DESCRIPTION
As part of summer undergraduate research, I was involved in a project where I successfully implemented a JupyterHub deployment for one of our core computer science courses. This system is now being used by over 30 students. So, I'd like to add the University of Portland to the list of institutions!

Please let me know the best way to proceed with this and if there any questions!