### PR TITLE
Fix incorrect rounding function

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1064,7 +1064,7 @@ class BaseHandler(RequestHandler):
                 human_retry_time = "%i0 seconds" % math.ceil(retry_time / 10.0)
             else:
                 # round number of minutes
-                human_retry_time = "%i minutes" % math.round(retry_time / 60.0)
+                human_retry_time = "%i minutes" % round(retry_time / 60.0)
 
             self.log.warning(
                 '%s pending spawns, throttling. Suggested retry in %s seconds.',


### PR DESCRIPTION
# PR Summary
The [`math`](https://docs.python.org/3/library/math.html) module in Python does not include a round function. Instead, the built-in Python [`round`](https://docs.python.org/3/library/functions.html#round) function should be used for rounding values.