### PR TITLE
Abort jupyterhub startup only if managed services fail

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3654,7 +3654,6 @@ class JupyterHub(Application):
                         "Cannot connect to %s service %s",
                         service_name,
                         service.kind,
-                        exc_info=True,
                     )
                 else:
                     self.log.warning(


### PR DESCRIPTION
Fixes #4929 which includes misc discussion about this. I think this is a regression, where desired behavior is that managed services specifically is ensured to startup properly, while external services failing to be accessible is just a warning kind of event during startup and later.