### PR TITLE
enable PKCE for internal OAuth

### DIFF
--- a/jupyterhub/alembic/versions/afd65840b69e_pkce.py
+++ b/jupyterhub/alembic/versions/afd65840b69e_pkce.py
@@ -1,0 +1,40 @@
+"""pkce
+
+Revision ID: afd65840b69e
+Revises: 4621fec11365
+Create Date: 2024-10-21 11:14:43.079782
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'afd65840b69e'
+down_revision = '4621fec11365'
+branch_labels = None
+depends_on = None
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    engine = op.get_bind().engine
+    tables = sa.inspect(engine).get_table_names()
+    if 'oauth_codes' not in tables:
+        return
+    op.add_column(
+        'oauth_codes',
+        sa.Column('code_challenge', sa.Unicode(length=255), nullable=True),
+    )
+    op.add_column(
+        'oauth_codes',
+        sa.Column('code_challenge_method', sa.Unicode(length=64), nullable=True),
+    )
+
+
+def downgrade():
+    engine = op.get_bind().engine
+    tables = sa.inspect(engine).get_table_names()
+    if 'oauth_codes' not in tables:
+        return
+    op.drop_column('oauth_codes', 'code_challenge_method')
+    op.drop_column('oauth_codes', 'code_challenge')

--- a/jupyterhub/oauth/provider.py
+++ b/jupyterhub/oauth/provider.py
@@ -259,6 +259,8 @@ class JupyterHubRequestValidator(RequestValidator):
 
         orm_code = orm.OAuthCode(
             code=code['code'],
+            code_challenge=request.code_challenge,
+            code_challenge_method=request.code_challenge_method,
             # oauth has 5 minutes to complete
             expires_at=int(orm.OAuthCode.now() + 300),
             scopes=list(request.scopes),
@@ -463,7 +465,88 @@ class JupyterHubRequestValidator(RequestValidator):
         request.user = orm_code.user
         request.session_id = orm_code.session_id
         request.scopes = orm_code.scopes
+        # attach PKCE attributes
+        request.code_challenge = orm_code.code_challenge
+        request.code_challenge_method = orm_code.code_challenge_method
         return True
+
+    def is_pkce_required(self, client_id, request):
+        """Determine if current request requires PKCE. Default, False.
+        This is called for both "authorization" and "token" requests.
+
+        Override this method by ``return True`` to enable PKCE for everyone.
+        You might want to enable it only for public clients.
+        Note that PKCE can also be used in addition of a client authentication.
+
+        OAuth 2.0 public clients utilizing the Authorization Code Grant are
+        susceptible to the authorization code interception attack.  This
+        specification describes the attack as well as a technique to mitigate
+        against the threat through the use of Proof Key for Code Exchange
+        (PKCE, pronounced "pixy"). See `RFC7636`_.
+
+        :param client_id: Client identifier.
+        :param request: OAuthlib request.
+        :type request: oauthlib.common.Request
+        :rtype: True or False
+
+        Method is used by:
+            - Authorization Code Grant
+
+        .. _`RFC7636`: https://tools.ietf.org/html/rfc7636
+        """
+        # TODO: add config to enforce PKCE
+        return False
+
+    def get_code_challenge(self, code, request):
+        """Is called for every "token" requests.
+
+        When the server issues the authorization code in the authorization
+        response, it MUST associate the ``code_challenge`` and
+        ``code_challenge_method`` values with the authorization code so it can
+        be verified later.
+
+        Typically, the ``code_challenge`` and ``code_challenge_method`` values
+        are stored in encrypted form in the ``code`` itself but could
+        alternatively be stored on the server associated with the code.  The
+        server MUST NOT include the ``code_challenge`` value in client requests
+        in a form that other entities can extract.
+
+        Return the ``code_challenge`` associated to the code.
+        If ``None`` is returned, code is considered to not be associated to any
+        challenges.
+
+        :param code: Authorization code.
+        :param request: OAuthlib request.
+        :type request: oauthlib.common.Request
+        :rtype: code_challenge string
+
+        Method is used by:
+            - Authorization Code Grant - when PKCE is active
+
+        """
+        # attached in validate_code
+        return request.code_challenge
+
+    def get_code_challenge_method(self, code, request):
+        """Is called during the "token" request processing, when a
+        ``code_verifier`` and a ``code_challenge`` has been provided.
+
+        See ``.get_code_challenge``.
+
+        Must return ``plain`` or ``S256``. You can return a custom value if you have
+        implemented your own ``AuthorizationCodeGrant`` class.
+
+        :param code: Authorization code.
+        :param request: OAuthlib request.
+        :type request: oauthlib.common.Request
+        :rtype: code_challenge_method string
+
+        Method is used by:
+            - Authorization Code Grant - when PKCE is active
+
+        """
+        # persisted in validate_code
+        return request.code_challenge_method
 
     def validate_grant_type(
         self, client_id, grant_type, client, request, *args, **kwargs

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -1270,6 +1270,10 @@ class OAuthCode(Expiring, Base):
 
     scopes = Column(JSONList, default=[])
 
+    # PKCE added in 5.3
+    code_challenge = Column(Unicode(255), nullable=True)
+    code_challenge_method = Column(Unicode(64), nullable=True)
+
     @staticmethod
     def now():
         return utcnow(with_tz=True).timestamp()

--- a/jupyterhub/services/auth.py
+++ b/jupyterhub/services/auth.py
@@ -25,6 +25,7 @@ A tornado implementation is provided in :class:`HubOAuthCallbackHandler`.
 """
 
 import asyncio
+import base64
 import hashlib
 import json
 import os
@@ -1075,7 +1076,26 @@ class HubOAuth(HubAuth):
     def _token_url(self):
         return url_path_join(self.api_url, 'oauth2/token')
 
-    def token_for_code(self, code, *, sync=True):
+    def generate_pkce_code_challenge(self, method="S256"):
+        """
+        Return `(code_verifier, code_challenge, code_challenge_method)` for PKCE
+
+        .. versionadded:: 5.3
+
+        .. seealso::
+
+            https://datatracker.ietf.org/doc/html/rfc7636#section-4
+        """
+        code_verifier = secrets.token_urlsafe(32)
+        if method != "S256":
+            raise ValueError(f"Only method='S256' is supported, not {method!r}")
+        code_challenge = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+        code_challenge_base64 = (
+            base64.urlsafe_b64encode(code_challenge).decode("utf-8").rstrip("=")
+        )
+        return code_verifier, code_challenge_base64, method
+
+    def token_for_code(self, code, *, code_verifier=None, sync=True):
         """Get token for OAuth temporary code
 
         This is the last step of OAuth login.
@@ -1086,9 +1106,9 @@ class HubOAuth(HubAuth):
         Returns:
             token (str): JupyterHub API Token
         """
-        return self._call_coroutine(sync, self._token_for_code, code)
+        return self._call_coroutine(sync, self._token_for_code, code, code_verifier)
 
-    async def _token_for_code(self, code):
+    async def _token_for_code(self, code, code_verifier=None):
         # GitHub specifies a POST request yet requires URL parameters
         params = dict(
             client_id=self.oauth_client_id,
@@ -1097,6 +1117,8 @@ class HubOAuth(HubAuth):
             code=code,
             redirect_uri=self.oauth_redirect_uri,
         )
+        if code_verifier:
+            params["code_verifier"] = code_verifier
 
         token_reply = await self._api_request(
             'POST',
@@ -1134,7 +1156,7 @@ class HubOAuth(HubAuth):
     def _default_oauth_states(self):
         return _ExpiringDict(max_age=self.oauth_state_max_age)
 
-    def set_state_cookie(self, handler, next_url=None):
+    def set_state_cookie(self, handler, next_url=None, code_verifier=None):
         """Generate an OAuth state and store it in a cookie
 
         Parameters
@@ -1143,6 +1165,8 @@ class HubOAuth(HubAuth):
             A tornado RequestHandler
         next_url : str
             The page to redirect to on successful login
+        code_verifier : str
+            The PKCE code verifier
 
         Returns
         -------
@@ -1150,6 +1174,8 @@ class HubOAuth(HubAuth):
             The OAuth state that has been stored in the cookie (url safe, base64-encoded)
         """
         extra_state = {}
+        if code_verifier:
+            extra_state["code_verifier"] = code_verifier
         if handler.get_cookie(self.state_cookie_name):
             # oauth state cookie is already set
             # use a randomized cookie suffix to avoid collisions
@@ -1235,6 +1261,11 @@ class HubOAuth(HubAuth):
         """Get the next_url for redirection, given an encoded OAuth state"""
         state = self._decode_state(state_id)
         return state.get('next_url') or self.base_url
+
+    def get_code_verifier(self, state_id='', /):
+        """Get the PKCE code_verifier, given an encoded OAuth state"""
+        state = self._decode_state(state_id)
+        return state.get('code_verifier')
 
     def get_state_cookie_name(self, state_id='', /):
         """Get the cookie name for oauth state, given an encoded OAuth state
@@ -1401,8 +1432,20 @@ class HubAuthenticated:
             # add state argument to OAuth url
             # must do this _after_ allowing get_login_url to raise
             # so we don't set unused cookies
-            state = self.hub_auth.set_state_cookie(self, next_url=self.request.uri)
-            login_url = url_concat(login_url, {'state': state})
+            code_verifier, code_challenge, code_challenge_method = (
+                self.hub_auth.generate_pkce_code_challenge()
+            )
+            state = self.hub_auth.set_state_cookie(
+                self, next_url=self.request.uri, code_verifier=code_verifier
+            )
+            login_url = url_concat(
+                login_url,
+                {
+                    'state': state,
+                    'code_challenge': code_challenge,
+                    'code_challenge_method': code_challenge_method,
+                },
+            )
         self._hub_login_url = login_url
         return login_url
 
@@ -1597,6 +1640,7 @@ class HubOAuthCallbackHandler(HubOAuthenticated, RequestHandler):
             )
             raise HTTPError(403, "oauth state does not match. Try logging in again.")
         next_url = self.hub_auth.get_next_url(cookie_state)
+        code_verifier = self.hub_auth.get_code_verifier(cookie_state)
         # clear consumed state from _oauth_states cache now that we're done with it
         self.hub_auth.clear_oauth_state(cookie_state)
         # clear _all_ oauth state cookies on success
@@ -1604,7 +1648,9 @@ class HubOAuthCallbackHandler(HubOAuthenticated, RequestHandler):
         # which is probably okay.
         self.hub_auth.clear_oauth_state_cookies(self)
 
-        token = await self.hub_auth.token_for_code(code, sync=False)
+        token = await self.hub_auth.token_for_code(
+            code, sync=False, code_verifier=code_verifier
+        )
         session_id = self.hub_auth.get_session_id(self)
         user_model = await self.hub_auth.user_for_token(
             token, session_id=session_id, sync=False

--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -148,10 +148,20 @@ class JupyterHubIdentityProvider(IdentityProvider):
             # add state argument to OAuth url
             # must do this _after_ allowing get_login_url to raise
             # so we don't set unused cookies
-            state = self.hub_auth.set_state_cookie(
-                handler, next_url=handler.request.uri
+            code_verifier, code_challenge, code_challenge_method = (
+                self.hub_auth.generate_pkce_code_challenge()
             )
-            _hub_login_url = url_concat(login_url, {'state': state})
+            state = self.hub_auth.set_state_cookie(
+                self, next_url=self.request.uri, code_verifier=code_verifier
+            )
+            _hub_login_url = url_concat(
+                login_url,
+                {
+                    'state': state,
+                    'code_challenge': code_challenge,
+                    'code_challenge_method': code_challenge_method,
+                },
+            )
             return _hub_login_url
 
         handler.get_login_url = get_login_url


### PR DESCRIPTION
see https://github.com/jupyterhub/oauthenticator/pull/765 for implementing PKCE in OAuthenticator. This does the same in jupyterhub's oauth clients and adds what is needed for the provider side (oauthlib implements the verification, we only need to implement the db persistence of the challenge)

PKCE is currently optional for backward-compatibility

Since this adds db columns, this means a major version bump according to #3982

TODO:

- [ ] opt-in config to _enforce_ PKCE
- [ ] tests
  - [ ] failed PKCE validation
  - [ ] missing PKCE works when not required
  - [ ] missing PKCE doesn't work when PKCE is required
- [ ] explore backward-compatibility implications in HubOAuth defaults

It would be nice for PKCE to happen by default, but we need to make sure that existing code will either transparently send both the challenge and the verifier or neither, because e.g. sending the challenge but not the verifier will cause every oauth to fail. Sending neither is still okay as long as `require_pkce` is not enabled, which will be opt-in.


