### PR TITLE
Introducing JupyterHub Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/jupyterhub/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue?logo=gitter)](https://gitter.im/jupyterhub/jupyterhub)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20JupyterHub%20Guru-006BFF)](https://gurubase.io/g/jupyterhub)
 
 With [JupyterHub](https://jupyterhub.readthedocs.io) you can create a
 **multi-user Hub** that spawns, manages, and proxies multiple instances of the


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [JupyterHub Guru](https://gurubase.io/g/jupyterhub) to Gurubase. JupyterHub Guru uses the data from this repo and data from the [docs](https://jupyterhub.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "JupyterHub Guru", which highlights that JupyterHub now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable JupyterHub Guru in Gurubase, just let me know that's totally fine.
