### PR TITLE
add traitlets default import to auth allow_all override example for completeness

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -223,6 +223,7 @@ class Authenticator(LoggingConfigurable):
 
         Authenticator subclasses may override the default with e.g.::
 
+            from traitlets import default
             @default("allow_all")
             def _default_allow_all(self):
                 # if _any_ auth config (depends on the Authenticator)


### PR DESCRIPTION
adds `from traitlets import default` to example code for overriding authenticator `allow_all` such that the example can be used "out of the box" in a config file.