### PR TITLE
Use intersphinx-registry to keep intersphinx URLs up to date.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@
 # don't depend on it here, as that often results in a duplicate
 # installation of jupyterhub that's already installed
 autodoc-traits
+intersphinx-registry
 jupyterhub-sphinx-theme
 myst-parser>=0.19
 pre-commit

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 from docutils import nodes
+from intersphinx_registry import get_intersphinx_mapping
 from ruamel.yaml import YAML
 from sphinx.directives.other import SphinxDirective
 from sphinx.util import logging
@@ -303,12 +304,15 @@ linkcheck_anchors_ignore = [
 # -- Intersphinx -------------------------------------------------------------
 # ref: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 #
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "tornado": ("https://www.tornadoweb.org/en/stable/", None),
-    "jupyter-server": ("https://jupyter-server.readthedocs.io/en/stable/", None),
-    "nbgitpuller": ("https://nbgitpuller.readthedocs.io/en/latest", None),
-}
+
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={
+        "python",
+        "tornado",
+        "jupyter-server",
+        "nbgitpuller",
+    }
+)
 
 # -- Options for the opengraph extension -------------------------------------
 # ref: https://github.com/wpilibsuite/sphinxext-opengraph#options


### PR DESCRIPTION
This allows to update the intersphinx url in a single location when those move, an make it a tiny-bit easier to add existing packages than having to figure out where their docs are.