### PR TITLE
Fixed code formatting for implicit_spawn_seconds (#4949)

### DIFF
--- a/share/jupyterhub/templates/not_running.html
+++ b/share/jupyterhub/templates/not_running.html
@@ -56,6 +56,7 @@
 {% block script %}
   {{ super () }}
   {% if implicit_spawn_seconds %}
+    {# djlint:off #}
     <script type="text/javascript">
       var spawn_url = "{{ spawn_url }}";
       var implicit_spawn_seconds = {{ implicit_spawn_seconds }};
@@ -65,7 +66,8 @@
         },
         1000 * implicit_spawn_seconds
       );
-    </script>
+</script>
+    {# djlint:on #}
   {% endif %}
   <script type="text/javascript">
     require(["not_running"]);

--- a/share/jupyterhub/templates/not_running.html
+++ b/share/jupyterhub/templates/not_running.html
@@ -58,11 +58,7 @@
   {% if implicit_spawn_seconds %}
     <script type="text/javascript">
       var spawn_url = "{{ spawn_url }}";
-      var implicit_spawn_seconds = {
-        {
-          implicit_spawn_seconds
-        }
-      };
+      var implicit_spawn_seconds = {{ implicit_spawn_seconds }};
       setTimeout(function() {
           console.log("redirecting to spawn at", spawn_url);
           window.location = spawn_url;


### PR DESCRIPTION
A linter appears to have broken the templating in of `implicit_wait_seconds`. This fixes the code formatting so the interpolation can happen correctly.