### PR TITLE
allow launch with expired auth if initiated by another user

### DIFF
--- a/jupyterhub/tests/test_auth_expiry.py
+++ b/jupyterhub/tests/test_auth_expiry.py
@@ -168,10 +168,12 @@ async def test_refresh_pre_spawn_expired_admin_request(
     await app.login_user(admin_user.name)
     user._auth_refreshed -= 10
 
-    # auth needs refresh but can't without a new login; spawn should fail
+    # auth needs refresh but can't without a new login
     user._auth_refreshed -= app.authenticator.auth_refresh_age
+    before = user._auth_refreshed
     r = await api_request(
         app, 'users', user.name, 'server', method='post', name=admin_user.name
     )
-    # api requests can't do login redirects
-    assert r.status_code == 403
+    # admins can still launch with expired auth
+    assert 200 <= r.status_code < 300
+    assert user._auth_refreshed == before


### PR DESCRIPTION
Without this, when using `refresh_pre_spawn`, if the target user doesn't have fresh auth, it is impossible for other users to launch until the original user logs in to get fresh credentials.

Cases where this might come up:

1. 'fake' users, such as those 2i2c uses for health checks, which cannot ever have fresh auth
2. pre-launch of user servers before their first login (they won't have credentials, but that may be okay in some circumstances)

Choices:

1. allow launch without refreshing auth with a warning, as long as the requesting user is not the owner (this PR) (note: warning is only in logs, since there isn't really a mechanism to show it to the user)
3. don't allow launching at all by anyone until user logs in again (status quo)
4. expose this as an option somehow
5. handle it at the Authenticator level (e.g. allow fully empty `auth_state` to pass refresh, i.e. don't force a _first_ login for any user via `refresh_user`)

cc @GeorgianaElena this is the cause of the health check failure in https://github.com/2i2c-org/infrastructure/pull/5217