### PR TITLE
Allow CORS requests to /hub/api by default

### DIFF
--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -58,15 +58,10 @@ class RootAPIHandler(APIHandler):
 
         Also responsible for setting content-type header
         """
-        old_headers = self.settings.get("headers", {})
-        new_headers = {**old_headers}
-        new_headers.setdefault('Access-Control-Allow-Origin', '*')
-        try:
-            self.settings['headers'] = new_headers
-            super().set_default_headers()
-        finally:
-            self.settings['headers'] = old_headers
-
+        if 'Access-Control-Allow-Origin' not in self.settings.get("headers", {}):
+            # allow CORS requests to this endpoint by default
+            self.set_header('Access-Control-Allow-Origin', '*')
+        super().set_default_headers()
     def check_xsrf_cookie(self):
         return
 

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -6,7 +6,6 @@ import json
 import sys
 
 from tornado import web
-from tornado.httputil import HTTPHeaders
 
 from .._version import __version__
 from ..scopes import needs_scope
@@ -53,13 +52,12 @@ class ShutdownAPIHandler(APIHandler):
 
 
 class RootAPIHandler(APIHandler):
-
     def set_default_headers(self):
         """
         Set any headers passed as tornado_settings['headers'].
 
         Also responsible for setting content-type header
-        """    
+        """
         old_headers = self.settings.get("headers", {})
         new_headers = {**old_headers}
         new_headers.setdefault('Access-Control-Allow-Origin', '*')

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -59,27 +59,15 @@ class RootAPIHandler(APIHandler):
         Set any headers passed as tornado_settings['headers'].
 
         Also responsible for setting content-type header
-        """
-        # wrap in HTTPHeaders for case-insensitivity
-        headers = HTTPHeaders(self.settings.get('headers', {}))
-        headers.setdefault("X-JupyterHub-Version", __version__)
-
-        for header_name, header_content in headers.items():
-            self.set_header(header_name, header_content)
-
-        if 'Access-Control-Allow-Headers' not in headers:
-            self.set_header(
-                'Access-Control-Allow-Headers', 'accept, content-type, authorization'
-            )
-        if 'Content-Security-Policy' not in headers:
-            self.set_header('Content-Security-Policy', self.content_security_policy)
-        self.set_header('Content-Type', self.get_content_type())
-
-        # Allow any origin to query the root handler (CORS)
-        if 'Access-Control-Allow-Origin' not in headers:
-            self.set_header(
-                'Access-Control-Allow-Origin', '*'
-            )
+        """    
+        old_headers = self.settings.get("headers", {})
+        new_headers = {**old_headers}
+        new_headers.setdefault('Access-Control-Allow-Origin', '*')
+        try:
+            self.settings['headers'] = new_headers
+            super().set_default_headers()
+        finally:
+            self.settings['headers'] = old_headers
 
     def check_xsrf_cookie(self):
         return

--- a/jupyterhub/apihandlers/hub.py
+++ b/jupyterhub/apihandlers/hub.py
@@ -62,6 +62,7 @@ class RootAPIHandler(APIHandler):
             # allow CORS requests to this endpoint by default
             self.set_header('Access-Control-Allow-Origin', '*')
         super().set_default_headers()
+
     def check_xsrf_cookie(self):
         return
 

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -246,10 +246,6 @@ class BaseHandler(RequestHandler):
             self.set_header(
                 'Access-Control-Allow-Headers', 'accept, content-type, authorization'
             )
-        if 'Access-Control-Allow-Origin' not in headers:
-            self.set_header(
-                'Access-Control-Allow-Origin', '*'
-            )
         if 'Content-Security-Policy' not in headers:
             self.set_header('Content-Security-Policy', self.content_security_policy)
         self.set_header('Content-Type', self.get_content_type())

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -246,6 +246,10 @@ class BaseHandler(RequestHandler):
             self.set_header(
                 'Access-Control-Allow-Headers', 'accept, content-type, authorization'
             )
+        if 'Access-Control-Allow-Origin' not in headers:
+            self.set_header(
+                'Access-Control-Allow-Origin', '*'
+            )
         if 'Content-Security-Policy' not in headers:
             self.set_header('Content-Security-Policy', self.content_security_policy)
         self.set_header('Content-Type', self.get_content_type())


### PR DESCRIPTION
## Context
In <https://mystmd.org>, we have a "launch" button that builds a URL for interacting with deployed content on a BinderHub or JupyterHub. The user can provide a URL via a text-input field for each provider type:

![image](https://github.com/user-attachments/assets/cf798098-4551-4992-b561-3df30b28dacc)


We would like to simplify the UI by having a single text-input field, which requires that we can interrogate the given URL to determine what kind of provider it is. This will then enable us to build the proper links.

Unfortunately, in a browser context, the response from the hubs that I've seen in the wild does not include the necessary `Access-Control-Allow-Origin` header required by the browser:

<details><summary>Browser</summary>

```shell
$ await fetch("https://showcase.2i2c.cloud/hub/api/", {redirect: "follow"}) 

Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://showcase.2i2c.cloud/hub/api/. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing). Status code: 404.
```

</details>

<details><summary>Shell</summary>

```shell
$ curl -v https://showcase.2i2c.cloud/hub/api/
* Host showcase.2i2c.cloud:443 was resolved.
* IPv6: (none)
* IPv4: 52.26.150.118, 34.214.185.121
*   Trying 52.26.150.118:443...
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / x25519 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=showcase.2i2c.cloud
*  start date: Dec 17 04:59:19 2024 GMT
*  expire date: Mar 17 04:59:18 2025 GMT
*  subjectAltName: host "showcase.2i2c.cloud" matched cert's "showcase.2i2c.cloud"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 2: Public key type RSA (4096/152 Bits/secBits), signed using sha256WithRSAEncryption
* Connected to showcase.2i2c.cloud (52.26.150.118) port 443
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://showcase.2i2c.cloud/hub/api/
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: showcase.2i2c.cloud]
* [HTTP/2] [1] [:path: /hub/api/]
* [HTTP/2] [1] [user-agent: curl/8.11.0]
* [HTTP/2] [1] [accept: */*]
> GET /hub/api/ HTTP/2
> Host: showcase.2i2c.cloud
> User-Agent: curl/8.11.0
> Accept: */*
>
* Request completely sent off
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 200
< date: Tue, 17 Dec 2024 15:03:41 GMT
< content-type: application/json
< content-length: 20
< x-jupyterhub-version: 4.1.5
< access-control-allow-headers: accept, content-type, authorization
< content-security-policy: frame-ancestors 'none'; report-uri /hub/security/csp-report; default-src 'none'
< etag: "7be5fa0f046b27260a0e4da97272cb7eaf74e88c"
< strict-transport-security: max-age=31536000; includeSubDomains
<
* Connection #0 to host showcase.2i2c.cloud left intact
{"version": "4.1.5"}
```

</details> 

## Fix
This PR sets the `access-control-allow-origin` header to `*` for `GET /hub/api/`, which permits _any_ origin to make requests of the given hub's endpoint. 

> [!NOTE]
> The _original_ version of this PR was a draft that changed this heading for _all_ requests. Following some discussion, I've marked as ready-for-review, and scoped the change to a single API-version end-point.
