### PR TITLE
Fix bug in `GroupEdit`: Users being reset when clicking the button to edit a group

### DIFF
--- a/jsx/src/components/GroupEdit/GroupEdit.jsx
+++ b/jsx/src/components/GroupEdit/GroupEdit.jsx
@@ -42,6 +42,10 @@ const GroupEdit = (props) => {
     }
   }, [location]);
 
+  useEffect(() => {
+    setSelected(group_data.users);
+  }, []);
+
   const { group_data } = location.state || {};
   if (!group_data) return <div></div>;
   const [propobject, setProp] = useState(group_data.properties);


### PR DESCRIPTION
a bug was found in the `GroupEdit` component where users were reset when clicking the button to edit a group.

If the `selected` array was not properly initialized, all `group_data.users` were copied into `removed_users`, causing the group's users to be cleared, as shown in the following code.  
https://github.com/jupyterhub/jupyterhub/blob/0d57ce2e337a13d69bb302e81304701b712af4e9/jsx/src/components/GroupEdit/GroupEdit.jsx#L100-L102

This fix ensures that the `selected` array is correctly initialized to prevent clearing of users in a group.