### PR TITLE
make insecure-login-warning visible in dark mode

### DIFF
--- a/share/jupyterhub/static/scss/login.scss
+++ b/share/jupyterhub/static/scss/login.scss
@@ -3,7 +3,6 @@
   height: 80vh;
 
   & #insecure-login-warning {
-    background-color: $warning-bg-subtle;
     padding: 10px;
   }
 

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -12,7 +12,7 @@
           {{ custom_html | safe }}
         {% elif login_service %}
           <div class="service-login">
-            <p id='insecure-login-warning' class='hidden'>
+            <p id='insecure-login-warning' class='hidden alert alert-warning'>
               Warning: JupyterHub seems to be served over an unsecured HTTP connection.
               We strongly recommend enabling HTTPS for JupyterHub.
             </p>
@@ -28,7 +28,7 @@
               <h1>Sign in</h1>
             </div>
             <div class='auth-form-body m-auto'>
-              <p id='insecure-login-warning' class='hidden'>
+              <p id='insecure-login-warning' class='hidden alert alert-warning'>
                 Warning: JupyterHub seems to be served over an unsecured HTTP connection.
                 We strongly recommend enabling HTTPS for JupyterHub.
               </p>


### PR DESCRIPTION
In dark mode the "insecure login warning" on the login page changes the text colour but not the background colour. Both are quite light and make the text very hard to read:

Light mode:
![image](https://github.com/user-attachments/assets/dfc584ed-c065-41b5-b9a0-d28777f54639)


Dark mode:
![image](https://github.com/user-attachments/assets/922abb21-f83f-4f0a-b5f1-b6edc89abe28)

This PR adds the `alert alert-warning` css classes to the `insecure-login-warning` element so that the element styling is consistent with other warnings. This makes the warning much easier to read in dark mode:

Light mode:

![image](https://github.com/user-attachments/assets/c3fcbb79-f84b-41a4-8399-581dff25fc98)

Dark mode:

![image](https://github.com/user-attachments/assets/912516b1-2d53-4263-bac7-1938d03dc90f)

> [!Note]
> This also changes the border of the warning alert. I'm going to assume that this is OK since it makes it consistent with other warnings but if that is not desired, let me know and I can revert the borders to how they were.
