### PR TITLE
close tornado FDs without closing asyncio loop

### DIFF
--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -175,7 +175,9 @@ async def io_loop(request):
     assert io_loop.asyncio_loop is event_loop
 
     def _close():
-        io_loop.close(all_fds=True)
+        # close tornado resources without closing underlying event loop
+        with mock.patch.object(event_loop, "close", return_value=None):
+            io_loop.close(all_fds=True)
 
     request.addfinalizer(_close)
     return io_loop


### PR DESCRIPTION
pytest-asyncio 0.25.2 introduces a bug causing errors if anything closes the event loop (https://github.com/pytest-dev/pytest-asyncio/issues/1040), <del>but I don't _think_ we need this anyway with current versions of things</del>.

We want to close tornado resources, but don't need to close the underlying event loop. Tornado doesn't offer an API to do one without the other, so instead disable asyncio loop closing while closing tornado.