### PR TITLE
Singleuser: listen on IPv4 and IPv6 if ip==""

### DIFF
--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -518,7 +518,8 @@ class JupyterHubSingleUser(ExtensionApp):
         if url.hostname:
             cfg.ip = url.hostname
         else:
-            cfg.ip = "127.0.0.1"
+            # All interfaces (ipv4+ipv6)
+            cfg.ip = ""
 
         cfg.base_url = os.environ.get('JUPYTERHUB_SERVICE_PREFIX') or '/'
 

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -288,6 +288,8 @@ class SingleUserNotebookAppMixin(Configurable):
             url = urlparse(os.environ['JUPYTERHUB_SERVICE_URL'])
             if url.hostname:
                 return url.hostname
+            # All interfaces (ipv4+ipv6)
+            return ""
         return '127.0.0.1'
 
     # disable some single-user configurables


### PR DESCRIPTION
If `Spawner.ip = ""` listen on all interfaces instead of only `127.0.0.1`.
This matches the behaviour of `jupyter-server --ip=""`

Closes https://github.com/jupyterhub/jupyterhub/issues/4985