### PR TITLE
More IPv6: Use bare IPv6 for configuration, use `[ipv6]` when displaying IPv6 outputs

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1922,7 +1922,11 @@ class JupyterHub(Application):
                 self.internal_ssl_components_trust
             )
 
-            default_alt_names = ["IP:127.0.0.1", "DNS:localhost"]
+            default_alt_names = [
+                "IP:127.0.0.1",
+                "IP:0:0:0:0:0:0:0:1",
+                "DNS:localhost",
+            ]
             if self.subdomain_host:
                 default_alt_names.append(
                     f"DNS:{urlparse(self.subdomain_host).hostname}"

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -49,7 +49,10 @@ class Server(HasTraits):
         Never used in APIs, only logging,
         since it can be non-connectable value, such as '', meaning all interfaces.
         """
-        if self.ip in {'', '0.0.0.0', '::'}:
+        ip = self.ip
+        if ":" in ip:
+            ip = f"[{ip}]"
+        if ip in {'', '0.0.0.0', '[::]'}:
             return self.url.replace(self._connect_ip, self.ip or '*', 1)
         return self.url
 

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -12,6 +12,7 @@ from . import orm
 from .traitlets import URLPrefix
 from .utils import (
     can_connect,
+    fmt_ip_url,
     make_ssl_context,
     random_port,
     url_path_join,
@@ -49,11 +50,8 @@ class Server(HasTraits):
         Never used in APIs, only logging,
         since it can be non-connectable value, such as '', meaning all interfaces.
         """
-        ip = self.ip
-        if ":" in ip:
-            ip = f"[{ip}]"
-        if ip in {'', '0.0.0.0', '[::]'}:
-            return self.url.replace(self._connect_ip, self.ip or '*', 1)
+        if self.ip in {'', '0.0.0.0', '::'}:
+            return self.url.replace(self._connect_ip, fmt_ip_url(self.ip) or '*', 1)
         return self.url
 
     @observe('bind_url')
@@ -219,5 +217,4 @@ class Hub(Server):
         return url_path_join(self.url, 'api')
 
     def __repr__(self):
-        ip = f"[{self.ip}]" if ":" in self.ip else self.ip
-        return f"<{self.__class__.__name__} {ip}:{self.port}>"
+        return f"<{self.__class__.__name__} {fmt_ip_url(self.ip)}:{self.port}>"

--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -219,4 +219,5 @@ class Hub(Server):
         return url_path_join(self.url, 'api')
 
     def __repr__(self):
-        return f"<{self.__class__.__name__} {self.ip}:{self.port}>"
+        ip = f"[{self.ip}]" if ":" in self.ip else self.ip
+        return f"<{self.__class__.__name__} {ip}:{self.port}>"

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -157,7 +157,8 @@ class Server(Base):
     spawner = relationship("Spawner", back_populates="server", uselist=False)
 
     def __repr__(self):
-        return f"<Server({self.ip}:{self.port})>"
+        ip = f"[{self.ip}]" if ":" in self.ip else self.ip
+        return f"<Server({ip}:{self.port})>"
 
 
 # lots of things have roles

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -46,7 +46,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.types import LargeBinary, Text, TypeDecorator
 from tornado.log import app_log
 
-from .utils import compare_token, hash_token, new_token, random_port, utcnow
+from .utils import compare_token, fmt_ip_url, hash_token, new_token, random_port, utcnow
 
 # top-level variable for easier mocking in tests
 utcnow = partial(utcnow, with_tz=False)
@@ -157,8 +157,7 @@ class Server(Base):
     spawner = relationship("Spawner", back_populates="server", uselist=False)
 
     def __repr__(self):
-        ip = f"[{self.ip}]" if ":" in self.ip else self.ip
-        return f"<Server({ip}:{self.port})>"
+        return f"<Server({fmt_ip_url(self.ip)}:{self.port})>"
 
 
 # lots of things have roles

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -436,7 +436,10 @@ class Service(LoggingConfigurable):
             # since they are always local subprocesses
             hub = copy.deepcopy(self.hub)
             hub.connect_url = ''
-            hub.connect_ip = '127.0.0.1'
+            if self.hub.ip and ":" in self.hub.ip:
+                hub.connect_ip = "::1"
+            else:
+                hub.connect_ip = "127.0.0.1"
 
         self.spawner = _ServiceSpawner(
             cmd=self.command,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -480,6 +480,10 @@ class Spawner(LoggingConfigurable):
         Subclasses which launch remotely or in containers
         should override the default to '0.0.0.0'.
 
+        .. versionchanged:: 5.3
+            An empty string '' means all interfaces (IPv4 and IPv6). Prior to this
+            the behaviour of '' was not defined.
+
         .. versionchanged:: 2.0
             Default changed to '127.0.0.1', from unspecified.
         """,

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -470,6 +470,10 @@ class Spawner(LoggingConfigurable):
         The IP address (or hostname) the single-user server should listen on.
 
         Usually either '127.0.0.1' (default) or '0.0.0.0'.
+        On IPv6 only networks use '::1' or '::'.
+
+        If the spawned singleuser server is running JupyterHub 5.3.0 later
+        You can set this to the empty string '' to indicate both IPv4 and IPv6.
 
         The JupyterHub proxy implementation should be able to send packets to this interface.
 
@@ -477,10 +481,7 @@ class Spawner(LoggingConfigurable):
         should override the default to '0.0.0.0'.
 
         .. versionchanged:: 2.0
-            Default changed to '127.0.0.1', from ''.
-            In most cases, this does not result in a change in behavior,
-            as '' was interpreted as 'unspecified',
-            which used the subprocesses' own default, itself usually '127.0.0.1'.
+            Default changed to '127.0.0.1', from unspecified.
         """,
     ).tag(config=True)
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -48,6 +48,7 @@ from .traitlets import ByteSpecification, Callable, Command
 from .utils import (
     AnyTimeoutError,
     exponential_backoff,
+    fmt_ip_url,
     maybe_future,
     random_port,
     recursive_update,
@@ -1107,8 +1108,7 @@ class Spawner(LoggingConfigurable):
             base_url = '/'
 
         proto = 'https' if self.internal_ssl else 'http'
-        ip = f"[{self.ip}]" if ":" in self.ip else self.ip
-        bind_url = f"{proto}://{ip}:{self.port}{base_url}"
+        bind_url = f"{proto}://{fmt_ip_url(self.ip)}:{self.port}{base_url}"
         env["JUPYTERHUB_SERVICE_URL"] = bind_url
 
         # the public URLs of this server and the Hub

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -1093,7 +1093,8 @@ class Spawner(LoggingConfigurable):
             base_url = '/'
 
         proto = 'https' if self.internal_ssl else 'http'
-        bind_url = f"{proto}://{self.ip}:{self.port}{base_url}"
+        ip = f"[{self.ip}]" if ":" in self.ip else self.ip
+        bind_url = f"{proto}://{ip}:{self.port}{base_url}"
         env["JUPYTERHUB_SERVICE_URL"] = bind_url
 
         # the public URLs of this server and the Hub

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -483,6 +483,20 @@ class Spawner(LoggingConfigurable):
         """,
     ).tag(config=True)
 
+    @validate("ip")
+    def _strip_ipv6(self, proposal):
+        """
+        Currently (JupyterHub 5.2.1) it's necessary to use [] when specifying an
+        [ipv6] due to the IP being concatenated with the port when forming URLs
+        without [].
+
+        To avoid breaking existing workarounds strip [].
+        """
+        v = proposal["value"]
+        if v.startswith("[") and v.endswith("]"):
+            v = v[1:-1]
+        return v
+
     port = Integer(
         0,
         help="""

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -492,7 +492,7 @@ class Spawner(LoggingConfigurable):
     @validate("ip")
     def _strip_ipv6(self, proposal):
         """
-        Currently (JupyterHub 5.2.1) it's necessary to use [] when specifying an
+        Prior to 5.3.0 it was necessary to use [] when specifying an
         [ipv6] due to the IP being concatenated with the port when forming URLs
         without [].
 
@@ -500,6 +500,7 @@ class Spawner(LoggingConfigurable):
         """
         v = proposal["value"]
         if v.startswith("[") and v.endswith("]"):
+            self.log.warning("Removing '[' ']' from Spawner.ip %s", self.ip)
             v = v[1:-1]
         return v
 

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -108,8 +108,10 @@ def can_connect(ip, port):
 
     Return True if we can connect, False otherwise.
     """
-    if ip in {'', '0.0.0.0', '::'}:
+    if ip in {'', '0.0.0.0'}:
         ip = '127.0.0.1'
+    elif ip == "::":
+        ip = "::1"
     try:
         socket.create_connection((ip, port)).close()
     except OSError as e:
@@ -267,8 +269,10 @@ async def exponential_backoff(
 
 async def wait_for_server(ip, port, timeout=10):
     """Wait for any server to show up at ip:port."""
-    if ip in {'', '0.0.0.0', '::'}:
+    if ip in {'', '0.0.0.0'}:
         ip = '127.0.0.1'
+    elif ip == "::":
+        ip = "::1"
     display_ip = f"[{ip}]" if ":" in ip else ip
     app_log.debug("Waiting %ss for server at %s:%s", timeout, display_ip, port)
     tic = time.perf_counter()

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -273,7 +273,7 @@ async def wait_for_server(ip, port, timeout=10):
         ip = '127.0.0.1'
     elif ip == "::":
         ip = "::1"
-    display_ip = f"[{ip}]" if ":" in ip else ip
+    display_ip = fmt_ip_url(ip)
     app_log.debug("Waiting %ss for server at %s:%s", timeout, display_ip, port)
     tic = time.perf_counter()
     await exponential_backoff(
@@ -967,3 +967,13 @@ def recursive_update(target, new):
 
         else:
             target[k] = v
+
+
+def fmt_ip_url(ip):
+    """
+    Format an IP for use in URLs. IPv6 is wrapped with [], everything else is
+    unchanged
+    """
+    if ":" in ip:
+        return f"[{ip}]"
+    return ip

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -269,15 +269,16 @@ async def wait_for_server(ip, port, timeout=10):
     """Wait for any server to show up at ip:port."""
     if ip in {'', '0.0.0.0', '::'}:
         ip = '127.0.0.1'
-    app_log.debug("Waiting %ss for server at %s:%s", timeout, ip, port)
+    display_ip = f"[{ip}]" if ":" in ip else ip
+    app_log.debug("Waiting %ss for server at %s:%s", timeout, display_ip, port)
     tic = time.perf_counter()
     await exponential_backoff(
         lambda: can_connect(ip, port),
-        f"Server at {ip}:{port} didn't respond in {timeout} seconds",
+        f"Server at {display_ip}:{port} didn't respond in {timeout} seconds",
         timeout=timeout,
     )
     toc = time.perf_counter()
-    app_log.debug("Server at %s:%s responded in %.2fs", ip, port, toc - tic)
+    app_log.debug("Server at %s:%s responded in %.2fs", display_ip, port, toc - tic)
 
 
 async def wait_for_http_server(url, timeout=10, ssl_context=None):


### PR DESCRIPTION
Consistently handle IPv6 addresses the same way across JupyterHub:
- Bare IPv6 used for configuration should not be wrapped by `[` `]`
- IPv6 displayed in logs or messages should always be wrapped by `[` `]`