### PR TITLE
don't install unused browsers for playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Ensure browsers are installed for playwright
         if: matrix.browser
-        run: python -m playwright install --with-deps
+        run: python -m playwright install --with-deps firefox
 
       - name: Run pytest
         run: |


### PR DESCRIPTION
tests use firefox, only install firefox on ci

installing all the unused browsers takes an unnecessary amount of time