### PR TITLE
Change event-schemas version to string

### DIFF
--- a/jupyterhub/event-schemas/server-actions/v1.yaml
+++ b/jupyterhub/event-schemas/server-actions/v1.yaml
@@ -1,5 +1,5 @@
 "$id": https://schema.jupyter.org/jupyterhub/events/server-action
-version: 1
+version: "1"
 title: JupyterHub server events
 description: |
   Record actions on user servers made via JupyterHub.


### PR DESCRIPTION
jupyter-events expects the version to be a string- warnings are visible when running some pytests:
`2025-02-03T17:46:16.4745728Z   /opt/hostedtoolcache/Python/3.12.8/x64/lib/python3.12/site-packages/jupyter_events/schema.py:68: JupyterEventsVersionWarning: The `version` property of an event schema must be a string. It has been type coerced, but in a future version of this library, it will fail to validate. Please update schema: https://schema.jupyter.org/jupyterhub/events/server-action`

This was changed in https://github.com/jupyter/jupyter_events/pull/104

Is it safe to make this change in the minor/patch release of JupyterHub?