### PR TITLE
add apply_user_options hook

### DIFF
--- a/docs/source/reference/api/spawner.md
+++ b/docs/source/reference/api/spawner.md
@@ -10,7 +10,7 @@
 
 ```{eval-rst}
 .. autoconfigurable:: Spawner
-   :members: options_from_form, poll, start, stop, get_args, get_env, get_state, template_namespace, format_string, create_certs, move_certs
+   :members: options_from_form, user_options, poll, start, stop, get_args, get_env, get_state, template_namespace, format_string, create_certs, move_certs
 ```
 
 ### {class}`LocalProcessSpawner`

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -199,17 +199,17 @@ formdata = {
 When `formdata` arrives, it is passed through [](#Spawner.options_from_form):
 
 ```python
-spawner.user_options = [await] spawner.options_from_form(formdata[, spawner=spawner])
+spawner.user_options = spawner.options_from_form(formdata, spawner=spawner)
 ```
 
 to create `spawner.user_options`.
 
 [](#Spawner.options_from_form) is a configurable function to turn the HTTP form data into the correct structure for [](#Spawner.user_options).
-`options_from_form` must return a dictionary, and is meant to interpret the lists-of-strings a web form produces into the correct types.
+`options_from_form` must return a dictionary, _may_ be async, and is meant to interpret the lists-of-strings a web form produces into the correct types.
 For example, the `options_from_form` for the above form might look like:
 
 ```python
-def options_from_form(formdata):
+def options_from_form(formdata, spawner=None):
     options = {}
     options['integer'] = int(formdata['integer'][0]) # single integer value
     options['checkbox'] = formdata['checkbox'] == ['on']

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -2,7 +2,7 @@
 
 # Spawners
 
-A [Spawner][] starts each single-user notebook server.
+A [Spawner](#Spawner) starts each single-user notebook server.
 The Spawner represents an abstract interface to a process,
 and a custom Spawner needs to be able to take three actions:
 
@@ -37,7 +37,7 @@ Some examples include:
 
 ### Spawner.start
 
-`Spawner.start` should start a single-user server for a single user.
+[](#Spawner.start) should start a single-user server for a single user.
 Information about the user can be retrieved from `self.user`,
 an object encapsulating the user's name, authentication, and server info.
 
@@ -68,11 +68,11 @@ async def start(self):
 When `Spawner.start` returns, the single-user server process should actually be running,
 not just requested. JupyterHub can handle `Spawner.start` being very slow
 (such as PBS-style batch queues, or instantiating whole AWS instances)
-via relaxing the `Spawner.start_timeout` config value.
+via relaxing the [](#Spawner.start_timeout) config value.
 
 #### Note on IPs and ports
 
-`Spawner.ip` and `Spawner.port` attributes set the _bind_ URL,
+[](#Spawner.ip) and [](#Spawner.port) attributes set the _bind_ URL,
 which the single-user server should listen on
 (passed to the single-user process via the `JUPYTERHUB_SERVICE_URL` environment variable).
 The _return_ value is the IP and port (or full URL) the Hub should _connect to_.
@@ -124,7 +124,7 @@ If both attributes are not present, the Exception will be shown to the user as u
 
 ### Spawner.poll
 
-`Spawner.poll` checks if the spawner is still running.
+[](#Spawner.poll) checks if the spawner is still running.
 It should return `None` if it is still running,
 and an integer exit status, otherwise.
 
@@ -133,7 +133,7 @@ to check if the local process is still running. On Windows, it uses `psutil.pid_
 
 ### Spawner.stop
 
-`Spawner.stop` should stop the process. It must be a tornado coroutine, which should return when the process has finished exiting.
+[](#Spawner.stop) should stop the process. It must be a tornado coroutine, which should return when the process has finished exiting.
 
 ## Spawner state
 
@@ -168,15 +168,14 @@ def clear_state(self):
 
 ## Spawner options form
 
-(new in 0.4)
-
 Some deployments may want to offer options to users to influence how their servers are started.
-This may include cluster-based deployments, where users specify what resources should be available,
-or docker-based deployments where users can select from a list of base images.
+This may include cluster-based deployments, where users specify what memory or cpu resources should be available,
+or container-based deployments where users can select from a list of base images,
+or more complex configurations where users select a "profile" representing a bundle of settings to be applied together.
 
-This feature is enabled by setting `Spawner.options_form`, which is an HTML form snippet
+This feature is enabled by setting [](#Spawner.options_form), which is an HTML form snippet
 inserted unmodified into the spawn form.
-If the `Spawner.options_form` is defined, when a user tries to start their server, they will be directed to a form page, like this:
+If the `Spawner.options_form` is defined, when a user tries to start their server they will be directed to a form page, like this:
 
 ![spawn-form](/images/spawn-form.png)
 
@@ -186,28 +185,40 @@ See [this example](https://github.com/jupyterhub/jupyterhub/blob/HEAD/examples/s
 
 ### `Spawner.options_from_form`
 
-Options from this form will always be a dictionary of lists of strings, e.g.:
+Inputs from an HTML form always arrive as a dictionary of lists of strings, e.g.:
 
 ```python
-{
+formdata = {
   'integer': ['5'],
+  'checkbox': ['on'],
   'text': ['some text'],
   'select': ['a', 'b'],
 }
 ```
 
-When `formdata` arrives, it is passed through `Spawner.options_from_form(formdata)`,
-which is a method to turn the form data into the correct structure.
-This method must return a dictionary, and is meant to interpret the lists-of-strings into the correct types. For example, the `options_from_form` for the above form would look like:
+When `formdata` arrives, it is passed through [](#Spawner.options_from_form):
 
 ```python
-def options_from_form(self, formdata):
+spawner.user_options = [await] spawner.options_from_form(formdata[, spawner=spawner])
+```
+
+to create `spawner.user_options`.
+
+[](#Spawner.options_from_form) is a configurable function to turn the HTTP form data into the correct structure for [](#Spawner.user_options).
+`options_from_form` must return a dictionary, and is meant to interpret the lists-of-strings a web form produces into the correct types.
+For example, the `options_from_form` for the above form might look like:
+
+```python
+def options_from_form(formdata):
     options = {}
     options['integer'] = int(formdata['integer'][0]) # single integer value
+    options['checkbox'] = formdata['checkbox'] == ['on']
     options['text'] = formdata['text'][0] # single string value
     options['select'] = formdata['select'] # list already correct
     options['notinform'] = 'extra info' # not in the form at all
     return options
+
+c.Spawner.options_from_form = options_from_form
 ```
 
 which would return:
@@ -215,15 +226,114 @@ which would return:
 ```python
 {
   'integer': 5,
+  'checkbox': True,
   'text': 'some text',
   'select': ['a', 'b'],
   'notinform': 'extra info',
 }
 ```
 
-When `Spawner.start` is called, this dictionary is accessible as `self.user_options`.
+### Applying user options
 
-[spawner]: https://github.com/jupyterhub/jupyterhub/blob/HEAD/jupyterhub/spawner.py
+The base Spawner class doesn't do anything with `user_options`, that is also up to your deployment and/or chosen Spawner.
+This is because exposing any options to users has security implications,
+so it is part of your Spawner and/or deployment configuration to expose the options you trust your users to set.
+
+[](#Spawner.apply_user_options) is the hook for taking `user_options` and applying whatever configuration it may represent.
+
+```python
+def apply_user_options(spawner, user_options):
+    if "image" in user_options and isinstance(user_options["image"], str):
+        spawner.image = user_options["image"]
+
+c.Spawner.apply_user_options = apply_user_options
+```
+
+:::{versionadded} 5.3
+JupyterHub 5.3 introduces [](#Spawner.apply_user_options) configuration.
+Previously, [](#Spawner.user_options) could only be consumed during [](#Spawner.start),
+at which point `user_options` is available to the Spawner instance as `self.user_options`.
+This approach requires subclassing, so it was not possible to apply new `user_options` via configuration.
+In JupyterHub 5.3, it is possible to fully expose user options,
+and for some simple cases, fully with _declarative_ configuration.
+:::
+
+### Declarative configuration for user options
+
+While [](#Spawner.options_from_form) and [](#Spawner.apply_user_options) are callables by nature,
+some simple cases can be represented by declarative configuration,
+which is most conveniently expressed in e.g. the yaml of the JupyterHub helm chart.
+The cases currently handled are:
+
+```python
+c.Spawner.options_form = """
+<input name="image_input" type="text" value="quay.io/jupyterhub/singleuser:5.2"/>
+<input name="debug_checkbox" type="checkbox" />
+"""
+c.Spawner.options_from_form = "simple"
+c.Spawner.apply_user_options = {"image_input": "image", "debug_checkbox": "debug"}
+```
+
+The `simple` options_from_form does the very simplest interpretation of an html form,
+casting the lists of strings to single strings by getting the first item when there is only one.
+The only non-string handling it has is casting the checkbox value of `on` to True.
+
+So it turns this formdata:
+
+```python
+{
+  "image_input": ["my_image"],
+  "debug_checkbox": ["on"],
+}
+```
+
+into this `.user_options`
+
+```python
+{
+  "image_input": "my_image",
+  "debug_checkbox": True
+}
+```
+
+When `apply_user_options` is a dictionary, any input in `user_options` is looked up in this dictionary,
+and assigned to the corresponding Spawner attribute.
+Strings are passed through traitlets' `from_string` logic (what is used for setting values on the command-line),
+which means you can set numbers and things this way as well,
+even though `options_from_form` leaves these as strings.
+
+So in the above configuration, we have exposed `Spawner.debug` and `Spawner.image` without needing to write any functions.
+In jupyterhub helm chart yaml, this would look like:
+
+```yaml
+hub:
+  config:
+    KubeSpawner:
+      options_form: |
+        <input name="image_input" type="text" value="quay.io/jupyterhub/singleuser:5.2"/>
+        <input name="debug_checkbox" type="checkbox" />
+      options_from_form: simple
+      apply_user_options:
+        image_input: image
+        debug_checkbox: debug
+```
+
+### Setting `user_options` directly via the REST API
+
+In addition to going through the options form, `user_options` may be set directly, via the REST API.
+The body of a POST request to spawn a server may be a JSON dictionary,
+which will be used to set `user_options` directly.
+When used this way, neither `options_form` nor `options_from_form` are involved,
+`user_options` is set directly, and only `apply_user_options` is called.
+
+```
+POST /hub/api/users/servers/:name
+{
+  "option": 5,
+  "bool": True,
+  "string": "value"
+}
+```
 
 ## Writing a custom spawner
 

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -240,6 +240,7 @@ This is because the users can specify arbitrary option dictionary by using the A
 so it is part of your Spawner and/or deployment configuration to expose the options you trust your users to set.
 
 [](#Spawner.apply_user_options) is the hook for taking `user_options` and applying whatever configuration it may represent.
+It is critical that `apply_user_options` validates all input, since these are provided by the user.
 
 ```python
 def apply_user_options(spawner, user_options):
@@ -274,7 +275,7 @@ c.Spawner.options_from_form = "simple"
 c.Spawner.apply_user_options = {"image_input": "image", "debug_checkbox": "debug"}
 ```
 
-The `simple` options_from_form does the very simplest interpretation of an html form,
+`options_from_form = "simple"` uses a built-in method to do the very simplest interpretation of an html form,
 casting the lists of strings to single strings by getting the first item when there is only one.
 The only extra processing it performs is casting the checkbox value of `on` to True.
 
@@ -287,7 +288,7 @@ So it turns this formdata:
 }
 ```
 
-into this `.user_options`
+into this `user_options`
 
 ```python
 {
@@ -303,7 +304,7 @@ which means you can set numbers and things this way as well,
 even though `options_from_form` leaves these as strings.
 
 So in the above configuration, we have exposed `Spawner.debug` and `Spawner.image` without needing to write any functions.
-In jupyterhub helm chart yaml, this would look like:
+In the JupyterHub helm chart YAML, this would look like:
 
 ```yaml
 hub:

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -236,7 +236,7 @@ which would return:
 ### Applying user options
 
 The base Spawner class doesn't do anything with `user_options`, that is also up to your deployment and/or chosen Spawner.
-This is because exposing any options to users has security implications,
+This is because the users can specify arbitrary option dictionary by using the API,
 so it is part of your Spawner and/or deployment configuration to expose the options you trust your users to set.
 
 [](#Spawner.apply_user_options) is the hook for taking `user_options` and applying whatever configuration it may represent.
@@ -276,7 +276,7 @@ c.Spawner.apply_user_options = {"image_input": "image", "debug_checkbox": "debug
 
 The `simple` options_from_form does the very simplest interpretation of an html form,
 casting the lists of strings to single strings by getting the first item when there is only one.
-The only non-string handling it has is casting the checkbox value of `on` to True.
+The only extra processing it performs is casting the checkbox value of `on` to True.
 
 So it turns this formdata:
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -745,7 +745,7 @@ class Spawner(LoggingConfigurable):
 
             Default: do nothing
 
-            Typically a callalble which takes `(spawner: Spawner, user_options: dict)`,
+            Typically a callable which takes `(spawner: Spawner, user_options: dict)`,
             but for simple cases this can be a dict mapping user option fields to Spawner attribute names,
             e.g.::
 
@@ -759,7 +759,9 @@ class Spawner(LoggingConfigurable):
                 and may be set directly via the REST API,
                 no assumptions should be made on its structure or contents.
                 An empty dict should always be supported.
-                Make sure to validate any inputs before applying them!
+                Make sure to validate any inputs before applying them,
+                either in this callable, or in whatever is consuming the value
+                if this is a dict.
         
             .. versionadded:: 5.3
         

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -793,7 +793,11 @@ class Spawner(LoggingConfigurable):
             # should we catch less?
             # likely user errors are ValueError, TraitError, TypeError
             self.log.exception("Exception applying user_options for %s", self._log_name)
-            raise web.HTTPError(400, f"Invalid user options: {e}")
+            if isinstance(e, web.HTTPError):
+                # passthrough hook's HTTPError, so it can display a custom message
+                raise
+            else:
+                raise web.HTTPError(400, "Invalid user options")
 
     def _apply_user_options_dict(self, user_options):
         """if apply_user_options is a dict

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -762,7 +762,8 @@ class Spawner(LoggingConfigurable):
         
             .. versionadded:: 5.3
         
-                Prior to 5.3, applying user options must be done in `Spawner.start()`.
+                Prior to 5.3, applying user options must be done in `Spawner.start()`
+                or `Spawner.pre_spawn_hook()`.
             """,
     )
 
@@ -819,6 +820,19 @@ class Spawner(LoggingConfigurable):
 
         These user options are usually provided by the `options_form` displayed to the user when they start
         their server.
+        If specified via an `options_form`, form data is passed through `options_from_form` before storing
+        in `user_options`.
+        `user_options` may also be passed as the JSON body to a spawn request via the REST API,
+        in which case it is stored directly, unmodifed.
+        
+        `user_options` has no effect on its own, it must be handled by the Spawner in `spawner.start`,
+        or via deployment configuration in `apply_user_options` or `pre_spawn_hook`.
+        
+        .. seealso::
+        
+            - :attr:`options_form`
+            - :attr:`options_from_form`
+            - :attr:`apply_user_options`
         """
     )
 

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -585,7 +585,7 @@ async def test_spawner_options_from_form_with_spawner(db):
         assert result[key] == value
 
 
-def test_apply_user_options_dict(db):
+async def test_apply_user_options_dict(db):
     apply_user_options = {
         # from_string doesn't work,
         # but string assignment does
@@ -614,7 +614,7 @@ def test_apply_user_options_dict(db):
         # traitlets added `from_string` after requiring Python 3.9
         user_options["start_timeout"] = int(user_options["start_timeout"])
     spawner = new_spawner(db, apply_user_options=apply_user_options)
-    spawner._run_apply_user_options(user_options)
+    await spawner._run_apply_user_options(user_options)
     assert spawner.mem_limit == 1 << 30
     assert spawner.notebook_dir == "/tmp"
     assert spawner.term_timeout == 1

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -524,14 +524,53 @@ async def test_spawner_oauth_roles_bad(app, user):
 
 async def test_spawner_options_from_form(db):
     def options_from_form(form_data):
-        return form_data
+        options = {}
+        for key, value in form_data.items():
+            options[key] = value[0]
+        options["default"] = "added"
+        return options
 
     spawner = new_spawner(db, options_from_form=options_from_form)
     form_data = {"key": ["value"]}
     result = spawner.run_options_from_form(form_data)
-    for key, value in form_data.items():
-        assert key in result
-        assert result[key] == value
+    assert result == {
+        "key": "value",
+        "default": "added",
+    }
+
+
+@pytest.mark.parametrize(
+    "options_from_form, expected",
+    [
+        pytest.param(None, "unchanged", id="default"),
+        pytest.param("passthrough", "unchanged", id="passthrough"),
+        pytest.param(
+            "simple",
+            {
+                "single": "value",
+                "multiple": ["a", "b"],
+                "checkbox": True,
+                "number": "1",
+            },
+            id="simple",
+        ),
+    ],
+)
+async def test_predefined_options_from_form(db, options_from_form, expected):
+    kwargs = {}
+    if options_from_form:
+        kwargs["options_from_form"] = options_from_form
+    spawner = new_spawner(db, **kwargs)
+    form_data = {
+        "single": ["value"],
+        "multiple": ["a", "b"],
+        "checkbox": ["on"],
+        "number": ["1"],
+    }
+    if expected == "unchanged":
+        expected = form_data
+    result = spawner.run_options_from_form(form_data)
+    assert result == expected
 
 
 async def test_spawner_options_from_form_with_spawner(db):
@@ -544,6 +583,41 @@ async def test_spawner_options_from_form_with_spawner(db):
     for key, value in form_data.items():
         assert key in result
         assert result[key] == value
+
+
+def test_apply_user_options_dict(db):
+    apply_user_options = {
+        # from_string doesn't work,
+        # but string assignment does
+        "mem": "mem_limit",
+        "notebook_dir": "notebook_dir",
+        "term_timeout": "term_timeout",
+        "start_timeout": "start_timeout",
+        "environment": "environment",
+        "unsupported": "unsupported",
+    }
+    user_options = {
+        "mem": "1G",
+        "notebook_dir": "/tmp",
+        "term_timeout": 1,
+        "start_timeout": "10",
+        "environment": {
+            "key": "value",
+        },
+        # shouldn't set these values:
+        # unsupported, but declared;
+        "unsupported": 5,
+        # undeclared, but available
+        "cpu_limit": "1m",
+    }
+    spawner = new_spawner(db, apply_user_options=apply_user_options)
+    spawner._run_apply_user_options(user_options)
+    assert spawner.mem_limit == 1 << 30
+    assert spawner.notebook_dir == "/tmp"
+    assert spawner.term_timeout == 1
+    assert spawner.environment == {"key": "value"}
+    assert not hasattr(spawner, "unsupported")
+    assert spawner.cpu_limit is None
 
 
 def test_spawner_server(db):

--- a/jupyterhub/tests/test_spawner.py
+++ b/jupyterhub/tests/test_spawner.py
@@ -610,6 +610,9 @@ def test_apply_user_options_dict(db):
         # undeclared, but available
         "cpu_limit": "1m",
     }
+    if sys.version_info < (3, 9):
+        # traitlets added `from_string` after requiring Python 3.9
+        user_options["start_timeout"] = int(user_options["start_timeout"])
     spawner = new_spawner(db, apply_user_options=apply_user_options)
     spawner._run_apply_user_options(user_options)
     assert spawner.mem_limit == 1 << 30

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -862,6 +862,11 @@ class User:
             db.commit()
 
         spawner.user_options = options
+        # apply user options
+        r = spawner._run_apply_user_options(spawner.user_options)
+        if inspect.isawaitable(r):
+            await r
+
         # we are starting a new server, make sure it doesn't restore state
         spawner.clear_state()
 


### PR DESCRIPTION
cover more cases with config without need to subclass, and even some simple cases without needing Python functions in config.

New config:

- `Spawner.apply_user_options` - callable or dict of `{option: spawner_attribute}`
- `Spawner.options_from_form` has singleton string values `"passthrough"` (default, unchanged), and `"simple"` for the most common case of turning length-one lists into scalars.

closes #4977