### PR TITLE
rm outdated claim that "copy shareable link" does not work in JupyterHub

### DIFF
--- a/docs/source/reference/urls.md
+++ b/docs/source/reference/urls.md
@@ -183,13 +183,6 @@ will send user `hortense` to `/user/hortense/notebooks/Index.ipynb`
 This will not work in general,
 unless you grant those users access to your server.
 
-**Contributions welcome:** The JupyterLab "shareable link" should share this link
-when run with JupyterHub, but it does not.
-See [jupyterlab-hub](https://github.com/jupyterhub/jupyterlab-hub)
-where this should probably be done and
-[this issue in JupyterLab](https://github.com/jupyterlab/jupyterlab/issues/5388)
-that is intended to make it possible.
-
 ## Spawning
 
 ### `/hub/spawn[/:username[/:servername]]`


### PR DESCRIPTION
This has been working for several years.

Ref:
* https://github.com/jupyterlab/jupyterlab/issues/5388#event-1902114640
* https://jupyterhub.readthedocs.io/en/stable/faq/faq.html#:~:text=can%20use%20JupyterLab%E2%80%99s%20%E2%80%9C-,copy%20shareable%20link,-%E2%80%9D%20in%20the%20context