### PR TITLE
make sure custom error messages are shown on regular error pages

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1487,6 +1487,7 @@ class BaseHandler(RequestHandler):
         """render custom error pages"""
         exc_info = kwargs.get('exc_info')
         message = ''
+        message_html = ''
         exception = None
         status_message = responses.get(status_code, 'Unknown HTTP Error')
         if exc_info:
@@ -1496,11 +1497,16 @@ class BaseHandler(RequestHandler):
                 message = exception.log_message % exception.args
             except Exception:
                 pass
+            # allow custom html messages
+            message_html = getattr(exception, "jupyterhub_html_message", "")
 
             # construct the custom reason, if defined
             reason = getattr(exception, 'reason', '')
             if reason:
                 message = reasons.get(reason, reason)
+
+            # get special jupyterhub_message, if defined
+            message = getattr(exception, "jupyterhub_message", message)
 
         if exception and isinstance(exception, SQLAlchemyError):
             self.log.warning("Rolling back session due to database error %s", exception)
@@ -1511,6 +1517,7 @@ class BaseHandler(RequestHandler):
             status_code=status_code,
             status_message=status_message,
             message=message,
+            message_html=message_html,
             extra_error_html=getattr(self, 'extra_error_html', ''),
             exception=exception,
         )

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -375,7 +375,10 @@ class SpawnPendingHandler(BaseHandler):
             spawn_url = url_path_join(
                 self.hub.base_url, "spawn", user.escaped_name, escaped_server_name
             )
-            self.set_status(500)
+            status_code = 500
+            if isinstance(exc, web.HTTPError):
+                status_code = exc.status_code
+            self.set_status(status_code)
             html = await self.render_template(
                 "not_running.html",
                 user=user,

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1421,32 +1421,3 @@ async def test_spawn_fails_custom_message(app, user, kind, speed):
             assert "unhandle me" not in error.text
         else:
             raise ValueError(f"unexpected {kind=}")
-
-
-#
-# async def test_spawn_fails_custom_message_slow(app, user, no_patience):
-#     # test the response when spawn has previously failed
-#     # (i.e. slow spawn, so progress is rendered)
-#     # this renders the not_running.html with the original spawn error
-#     with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": hook_fail_slow}):
-#         cookies = await app.login_user(user.name)
-#         assert user.spawner.pre_spawn_hook is hook_fail_slow
-#         r = await get_page("spawn", app, cookies=cookies)
-#         assert r.ok
-#         # wait for ready signal before checking next redirect
-#         while user.spawner.active:
-#             await asyncio.sleep(0.1)
-#         app.log.info(f"pending {user.spawner.active=}, {user.spawner._spawn_future=}")
-#         # this should fetch the not-running page
-#         app.log.info("getting again")
-#         r = await get_page(f"spawn-pending/{user.escaped_name}", app, cookies=cookies)
-#         assert r.status_code == 418
-#         page = BeautifulSoup(r.content, features="html5lib")
-#         body = page.find(class_="container")
-#         assert "Spawn failed" in body.text
-#         assert "<🫖>" in body.text
-#         assert "🕸️🫖" in body.text
-#         # check escaping properly
-#         error_html = str(body)
-#         assert "&lt;🫖&gt;" in error_html
-#         assert "<b>🕸️🫖</b>" in error_html

--- a/share/jupyterhub/templates/error.html
+++ b/share/jupyterhub/templates/error.html
@@ -7,8 +7,11 @@
       <h1>{{ status_code }} : {{ status_message }}</h1>
     {% endblock h1_error %}
     {% block error_detail %}
-      {% if message %}<p>{{ message }}</p>{% endif %}
-      {% if message_html %}<p>{{ message_html | safe }}</p>{% endif %}
+      {% if message_html %}
+        <p>{{ message_html | safe }}</p>
+      {% elif message %}
+        <p>{{ message }}</p>
+      {% endif %}
       {% if extra_error_html %}<p>{{ extra_error_html | safe }}</p>{% endif %}
     {% endblock error_detail %}
   </div>


### PR DESCRIPTION
not just the `not_running` page, which is only served for slow spawns and/or past launches. Considering this a bug because this behavior is [documented](https://jupyterhub.readthedocs.io/en/stable/reference/spawners.html#exception-handling), but the correct behavior only occurs if the error happens after `slow_spawn_timeout`. This is also related to #5011 where the custom error would not be displayed when there's a race between slow spawn return and `spawner.poll()` indicating a failed start.

closes #2291

cc @kellyrowland 