### PR TITLE
improve xsrf errors on login

### DIFF
--- a/jupyterhub/_xsrf_utils.py
+++ b/jupyterhub/_xsrf_utils.py
@@ -106,9 +106,12 @@ def _get_xsrf_token_cookie(handler):
     return (None, None)
 
 
-def _set_xsrf_cookie(handler, xsrf_id, *, cookie_path="", authenticated=None):
+def _set_xsrf_cookie(
+    handler, xsrf_id, *, cookie_path="", authenticated=None, xsrf_token=None
+):
     """Set xsrf token cookie"""
-    xsrf_token = _create_signed_value_urlsafe(handler, "_xsrf", xsrf_id)
+    if xsrf_token is None:
+        xsrf_token = _create_signed_value_urlsafe(handler, "_xsrf", xsrf_id)
     xsrf_cookie_kwargs = {}
     xsrf_cookie_kwargs.update(handler.settings.get('xsrf_cookie_kwargs', {}))
     xsrf_cookie_kwargs.setdefault("path", cookie_path)
@@ -130,6 +133,7 @@ def _set_xsrf_cookie(handler, xsrf_id, *, cookie_path="", authenticated=None):
         xsrf_cookie_kwargs,
     )
     handler.set_cookie("_xsrf", xsrf_token, **xsrf_cookie_kwargs)
+    return xsrf_token
 
 
 def get_xsrf_token(handler, cookie_path=""):
@@ -175,7 +179,9 @@ def get_xsrf_token(handler, cookie_path=""):
             )
 
     if _set_cookie:
-        _set_xsrf_cookie(handler, xsrf_id, cookie_path=cookie_path)
+        _set_xsrf_cookie(
+            handler, xsrf_id, cookie_path=cookie_path, xsrf_token=xsrf_token
+        )
     handler._xsrf_token = xsrf_token
     return xsrf_token
 

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -9,6 +9,7 @@ from tornado import web
 from tornado.escape import url_escape
 from tornado.httputil import url_concat
 
+from .._xsrf_utils import _set_xsrf_cookie
 from ..utils import maybe_future
 from .base import BaseHandler
 
@@ -94,7 +95,37 @@ class LogoutHandler(BaseHandler):
 class LoginHandler(BaseHandler):
     """Render the login page."""
 
-    def _render(self, login_error=None, username=None):
+    def render_template(self, name, **ns):
+        # intercept error page rendering for form submissions
+        if (
+            name == "error.html"
+            and self.request.method.lower() == "post"
+            and self.request.headers.get("Sec-Fetch-Mode", "navigate") == "navigate"
+        ):
+            # regular login form submission
+            # render login form with error message
+            ns["login_error"] = ns.get("message") or ns.get("status_message", "")
+            ns["username"] = self.get_argument("username", strip=True, default="")
+            return self._render(**ns)
+        else:
+            return super().render_template(name, **ns)
+
+    def check_xsrf_cookie(self):
+        try:
+            return super().check_xsrf_cookie()
+        except web.HTTPError as e:
+            # rewrite xsrf error on login form for nicer message
+            # suggest retry, which is likely to succeed
+            # log the original error so admins can debug
+            self.log.error("XSRF error on login form: %s", e)
+            if self.request.headers.get("Sec-Fetch-Mode", "navigate") == "navigate":
+                raise web.HTTPError(
+                    e.status_code, "Login form invalid or expired. Try again."
+                )
+            else:
+                raise
+
+    def _render(self, login_error=None, username=None, **kwargs):
         context = {
             "next": url_escape(self.get_argument('next', default='')),
             "username": username,
@@ -116,6 +147,7 @@ class LoginHandler(BaseHandler):
             'login.html',
             **context,
             custom_html=custom_html,
+            **kwargs,
         )
 
     async def get(self):
@@ -147,6 +179,14 @@ class LoginHandler(BaseHandler):
                     self.redirect(auto_login_url)
                 return
             username = self.get_argument('username', default='')
+            # always set a fresh xsrf cookie when the login page is rendered
+            # ensures we are as far from expiration as possible
+            xsrf_token = self.xsrf_token
+            if self.request.headers.get("Sec-Fetch-Mode", "navigate") == "navigate":
+                _set_xsrf_cookie(
+                    self, self._xsrf_token_id, cookie_path=self.hub.base_url
+                )
+            # to restart the timer
             self.finish(await self._render(username=username))
 
     async def post(self):
@@ -169,6 +209,7 @@ class LoginHandler(BaseHandler):
             self._jupyterhub_user = user
             self.redirect(self.get_next_url(user))
         else:
+            self.set_status(403)
             html = await self._render(
                 login_error='Invalid username or password', username=data['username']
             )

--- a/jupyterhub/handlers/login.py
+++ b/jupyterhub/handlers/login.py
@@ -179,14 +179,18 @@ class LoginHandler(BaseHandler):
                     self.redirect(auto_login_url)
                 return
             username = self.get_argument('username', default='')
+
             # always set a fresh xsrf cookie when the login page is rendered
             # ensures we are as far from expiration as possible
+            # to restart the timer
             xsrf_token = self.xsrf_token
             if self.request.headers.get("Sec-Fetch-Mode", "navigate") == "navigate":
                 _set_xsrf_cookie(
-                    self, self._xsrf_token_id, cookie_path=self.hub.base_url
+                    self,
+                    self._xsrf_token_id,
+                    cookie_path=self.hub.base_url,
+                    xsrf_token=xsrf_token,
                 )
-            # to restart the timer
             self.finish(await self._render(username=username))
 
     async def post(self):

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -1414,15 +1414,31 @@ async def test_login_xsrf_initial_cookies(app, browser, case, username):
     # after visiting page, cookies get re-established
     await browser.goto(login_url)
     cookies = await browser.context.cookies()
+    cookies = sorted(cookies, key=lambda cookie: len(cookie['path'] or ''))
     print(cookies)
-    cookie = cookies[0]
+    cookie = cookies[-1]
     assert cookie['name'] == '_xsrf'
     assert cookie["path"] == app.hub.base_url
+    # make sure cookie matches form input
+    xsrf_input = browser.locator('//input[@name="_xsrf"]')
+    await expect(xsrf_input).to_have_value(cookie["value"])
 
-    # next page visit, cookies don't change
+    # every visit to login page resets the xsrf cookie
+    # value will only change if timestamp advances
+    await asyncio.sleep(1.5)
     await browser.goto(login_url)
     cookies_2 = await browser.context.cookies()
-    assert cookies == cookies_2
+    cookies_2 = sorted(cookies_2, key=lambda cookie: len(cookie['path'] or ''))
+    print(cookies_2)
+    new_cookie = cookies_2[-1]
+    # xsrf cookie reset
+    assert new_cookie['name'] == "_xsrf"
+    assert new_cookie != cookie
+    assert new_cookie["expires"] > cookie["expires"]
+    # make sure cookie matches form input
+    xsrf_input = browser.locator('//input[@name="_xsrf"]')
+    await expect(xsrf_input).to_have_value(new_cookie["value"])
+
     # login is successful
     await login(browser, username, username)
 

--- a/jupyterhub/tests/test_singleuser.py
+++ b/jupyterhub/tests/test_singleuser.py
@@ -103,7 +103,7 @@ async def test_singleuser_auth(
     assert r.status_code == 200
 
     # logout
-    r = await s.get(url_path_join(url, 'logout'))
+    r = await s.get(url_path_join(url, 'logout'), allow_redirects=False)
     assert len(r.cookies) == 0
 
     # accessing another user's server hits the oauth confirmation page

--- a/share/jupyterhub/templates/login.html
+++ b/share/jupyterhub/templates/login.html
@@ -45,7 +45,7 @@
                        autocomplete="username"
                        class="form-control"
                        name="username"
-                       val="{{ username }}"
+                       value="{{ username }}"
                        autofocus="autofocus"
                        {% endblock username_input_attrs %} />
               {% endblock username_input %}


### PR DESCRIPTION
- show login form for trying again, with an error message, just like a password failure
- nicer, but more vague "try again" error for expired xsrf (original error still logged)
   because users logging in don't need to know or understand xsrf stuff
- set fresh xsrf cookie when login page loads, to maximize time until expiration

What failed XSRF on login looks like before:

<img width="697" alt="Screenshot 2025-03-21 at 17 35 43" src="https://github.com/user-attachments/assets/e5fae2bc-8c44-4225-853a-9997ad330d06" />

and after:

<img width="390" alt="Screenshot 2025-03-21 at 17 34 27" src="https://github.com/user-attachments/assets/4b49bde7-6617-4613-9d3d-9430ed056269" />

