### PR TITLE
try to fix flaky spawn_pending browser test

### DIFF
--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -291,7 +291,8 @@ async def test_spawn_pending_progress(
             "Spawning server...",
             f"Server ready at {app.base_url}user/{urlname}/",
         ]
-        while not user.spawner.ready:
+        logs_list = []
+        while not user.spawner.ready and len(logs_list) < len(expected_messages):
             logs_list = [
                 await log.text_content()
                 for log in await browser.locator("div.progress-log-event").all()

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,9 @@ asyncio_default_fixture_loop_scope = module
 # jupyter_server plugin is incompatible with notebook imports
 addopts = -p no:jupyter_server -m 'not browser' --color yes --durations 10 --verbose
 
+log_format = %(asctime)s %(levelname)s %(filename)s:%(lineno)s %(message)s
+log_date_format = %H:%M:%S
+
 python_files = test_*.py
 markers =
     gen_test: marks an async tornado test


### PR DESCRIPTION
stop checking for events after the expected event has arrived

I think failures like [this one](https://github.com/jupyterhub/jupyterhub/actions/runs/14034430314/job/39289086132?pr=5016#step:11:171) might be caused if navigation happens in the middle, so we try to read the progress events after navigating away from the progress page.