### PR TITLE
url_path_join: handle empty trailing components

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1692,7 +1692,11 @@ class JupyterHub(Application):
         """add a url prefix to handlers"""
         for i, tup in enumerate(handlers):
             lis = list(tup)
-            lis[0] = url_path_join(prefix, tup[0])
+            if tup[0]:
+                lis[0] = url_path_join(prefix, tup[0])
+            else:
+                # the '' route should match /prefix not /prefix/
+                lis[0] = prefix.rstrip("/")
             handlers[i] = tuple(lis)
         return handlers
 

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -101,6 +101,23 @@ async def test_tornado_coroutines():
 
 
 @pytest.mark.parametrize(
+    "pieces, expected",
+    [
+        (("/"), "/"),
+        (("/", "/"), "/"),
+        (("/base", ""), "/base"),
+        (("/base/", ""), "/base/"),
+        (("/base", "abc", "def"), "/base/abc/def"),
+        (("/base/", "/abc/", "/def/"), "/base/abc/def/"),
+        ((""), ""),
+        (("abc", "def"), "abc/def"),
+    ],
+)
+def test_url_path_join(pieces, expected):
+    assert utils.url_path_join(*pieces) == expected
+
+
+@pytest.mark.parametrize(
     "forwarded, x_scheme, x_forwarded_proto, expected",
     [
         ("", "", "", "_attr_"),

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -109,7 +109,13 @@ async def test_tornado_coroutines():
         (("/base/", ""), "/base/"),
         (("/base", "abc", "def"), "/base/abc/def"),
         (("/base/", "/abc/", "/def/"), "/base/abc/def/"),
+        (("/base", "", "/", ""), "/base/"),
         ((""), ""),
+        (("", ""), ""),
+        (("", "part", ""), "part"),
+        (("", "/part"), "part"),
+        (("", "part", "", "after"), "part/after"),
+        (("", "part", "", "after/", "", ""), "part/after/"),
         (("abc", "def"), "abc/def"),
     ],
 )

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -786,7 +786,7 @@ class User:
         if handler:
             await self.refresh_auth(handler)
 
-        base_url = url_path_join(self.base_url, url_escape_path(server_name)) + '/'
+        base_url = url_path_join(self.base_url, url_escape_path(server_name), "/")
 
         orm_server = orm.Server(base_url=base_url)
         db.add(orm_server)
@@ -877,8 +877,7 @@ class User:
                 api_token,
                 url_path_join(self.url, url_escape_path(server_name), 'oauth_callback'),
                 allowed_scopes=allowed_scopes,
-                description="Server at %s"
-                % (url_path_join(self.base_url, server_name) + '/'),
+                description=f"Server at {url_path_join(self.base_url, server_name, '/')}",
             )
             spawner.orm_spawner.oauth_client = oauth_client
         db.commit()

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -466,9 +466,15 @@ def url_path_join(*pieces):
 
     Use to prevent double slash when joining subpath. This will leave the
     initial and final / in place.
+    Empty trailing items are ignored.
 
-    Copied from `notebook.utils.url_path_join`.
+    Based on `notebook.utils.url_path_join`.
     """
+    pieces = list(pieces)
+    while pieces and not pieces[-1]:
+        del pieces[-1]
+    if not pieces:
+        return ""
     initial = pieces[0].startswith('/')
     final = pieces[-1].endswith('/')
     stripped = [s.strip('/') for s in pieces]


### PR DESCRIPTION
This ensures that `url_path_join("/x/", "")` returns `/x/` not `/x`

https://discourse.jupyter.org/t/health-check-of-managed-service-returns-404/34142 reports that the JupyterHub service check uses `/services/name` instead of `/services/name/`. This is because `Server.wait_up` has an extra parameter that defaults to `""`
https://github.com/jupyterhub/jupyterhub/blob/742de1311e2671c2f5ea1187c508e60d299a9f63/jupyterhub/objects.py#L168-L176
which results in the trailing `/` being stripped by `url_path_join`

closes #5034 