### PR TITLE
server checks: don't delete trailing `/`

### DIFF
--- a/jupyterhub/objects.py
+++ b/jupyterhub/objects.py
@@ -172,11 +172,11 @@ class Server(HasTraits):
                 self.keyfile, self.certfile, cafile=self.cafile
             )
 
-            return wait_for_http_server(
-                url_path_join(self.url, extra_path),
-                timeout=timeout,
-                ssl_context=ssl_context,
-            )
+            if extra_path:
+                url = url_path_join(self.url, extra_path)
+            else:
+                url = self.url
+            return wait_for_http_server(url, timeout=timeout, ssl_context=ssl_context)
         else:
             return wait_for_server(
                 self._connect_ip, self._connect_port, timeout=timeout


### PR DESCRIPTION
`extra_path=""` was added in https://github.com/jupyterhub/jupyterhub/pull/4567 , by adding this new check we restore the original behaviour of keeping the trailing `/`. Reported in https://discourse.jupyter.org/t/health-check-of-managed-service-returns-404/34142
(see also https://github.com/jupyterhub/jupyterhub/pull/5033 for an explanation of why the trailing `/` was deleted)