### PR TITLE
skip js build on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,10 +8,9 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    nodejs: "20"
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:

--- a/setup.py
+++ b/setup.py
@@ -172,10 +172,6 @@ class JSX(BaseCommand):
     js_target = pjoin(static, 'js', 'admin-react.js')
 
     def should_run(self):
-        if os.getenv('READTHEDOCS'):
-            # yarn not available on RTD
-            return False
-
         if not os.path.exists(self.js_target):
             return True
 
@@ -213,6 +209,10 @@ class JSX(BaseCommand):
 
 
 def js_css_first(cls, strict=True):
+    if os.getenv('READTHEDOCS'):
+        # don't need to build frontend for the docs
+        return cls
+
     class Command(cls):
         def run(self):
             try:


### PR DESCRIPTION
don't need the frontend to build the docs. Saves time and resources on RTD.

previously only skipped jsx because yarn was unavailable, but we don't use yarn anymore.

Updates RTD build env to Python 3.13 on 24.04