### PR TITLE
Update events/server_action schema id

### DIFF
--- a/docs/source/reference/event-logging.md
+++ b/docs/source/reference/event-logging.md
@@ -38,7 +38,7 @@ JupyterHub 5.0 changes from the deprecated jupyter-telemetry to jupyter-events.
 The main changes are:
 
 - `EventLog` configuration is now called `EventLogger`
-- The `hub.jupyter.org/server-action` schema is now called `https://schema.jupyter.org/jupyterhub/events/server-action`
+- The `hub.jupyter.org/server-action` schema is now called `https://schema.jupyter.org/jupyterhub/events/server_action`
   :::
 
 [json schemas]: https://json-schema.org/

--- a/jupyterhub/event-schemas/server-actions/v1.yaml
+++ b/jupyterhub/event-schemas/server-actions/v1.yaml
@@ -1,4 +1,4 @@
-"$id": https://schema.jupyter.org/jupyterhub/events/server-action
+"$id": https://schema.jupyter.org/jupyterhub/events/server_action
 version: 1
 title: JupyterHub server events
 description: |
@@ -32,7 +32,7 @@ properties:
 
       This is a required field.
 
-      Possibl Values:
+      Possible Values:
 
       1. start
          A user's server was successfully started


### PR DESCRIPTION
I've updated the schema id to snake case, which seems to be the convention and opened a PR to contribute the schema to jupyter/schema: https://github.com/jupyter/schema/pull/7.

Related to #5019 