### PR TITLE
Add instruction on how to select dummy authenticator

### DIFF
--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -42,6 +42,7 @@ password unless a global password has been set. Once set, any username will
 still be accepted but the correct password will need to be provided.
 
 To use, specify
+
 ```python
 c.JupyterHub.authenticator_class = "dummy"
 ```

--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -41,6 +41,11 @@ When testing, it may be helpful to use the
 password unless a global password has been set. Once set, any username will
 still be accepted but the correct password will need to be provided.
 
+To use, specify
+```python
+c.JupyterHub.authenticator_class = "dummy"
+```
+
 :::{versionadded} 5.0
 The DummyAuthenticator's default `allow_all` is True,
 unlike most other Authenticators.


### PR DESCRIPTION
When working with JupyterHub I noticed there was not a clear instruction on how to quickly set DummyAuthenticator (or any other authenticator for that matter) in the config.
Adding it here, so it's easier to find right away in docs