### PR TITLE
Fix broken link to `idleness` section in capacity-planning.md

### DIFF
--- a/docs/source/explanation/capacity-planning.md
+++ b/docs/source/explanation/capacity-planning.md
@@ -208,7 +208,7 @@ mybinder.org node CPU usage is low with 50-150 users sharing just 8 cores
 
 ### Concurrent users and culling idle servers
 
-Related to [][idleness], all of these resource consumptions and limits are calculated based on **concurrently active users**,
+Related to [](idleness), all of these resource consumptions and limits are calculated based on **concurrently active users**,
 not total users.
 You might have 10,000 users of your JupyterHub deployment, but only 100 of them running at any given time.
 That 100 is the main number you need to use for your capacity planning.


### PR DESCRIPTION
The [Current link on document](https://jupyterhub.readthedocs.io/en/latest/explanation/capacity-planning.html#concurrent-users-and-culling-idle-servers) to the idleness section is broken. This PR updates it to point to the correct section.

![截圖 2025-04-12 15 56 46](https://github.com/user-attachments/assets/2cd92f58-b098-4e2c-93b4-d96be00f38eb)
