### PR TITLE
Fix outdated GitHub Wiki links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Visit `http://localhost:8000` in your browser, and sign in with your system user
 
 _Note_: To allow multiple users to sign in to the server, you will need to
 run the `jupyterhub` command as a _privileged user_, such as root.
-The [Run JupyterHub without root privileges using sudo](https://jupyterhub.readthedocs.io/en/latest/howto/configuration/config-sudo.html)
+The [documentation](https://jupyterhub.readthedocs.io/en/latest/howto/configuration/config-sudo.html)
 describes how to run the server as a _less privileged user_, which requires
 more configuration of the system.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Visit `http://localhost:8000` in your browser, and sign in with your system user
 
 _Note_: To allow multiple users to sign in to the server, you will need to
 run the `jupyterhub` command as a _privileged user_, such as root.
-The [wiki](https://github.com/jupyterhub/jupyterhub/wiki/Using-sudo-to-run-JupyterHub-without-root-privileges)
+The [Run JupyterHub without root privileges using sudo](https://jupyterhub.readthedocs.io/en/latest/howto/configuration/config-sudo.html)
 describes how to run the server as a _less privileged user_, which requires
 more configuration of the system.
 

--- a/docs/source/explanation/concepts.md
+++ b/docs/source/explanation/concepts.md
@@ -88,7 +88,7 @@ The following authenticators are included with JupyterHub:
   of a ssh server, but providing a web-browser based way to access the
   machine.
 
-There are [plenty of others to choose from](https://github.com/jupyterhub/jupyterhub/wiki/Authenticators).
+There are [plenty of others to choose from](authenticators-reference).
 You can connect to almost any other existing service to manage your
 users. You either use all users from this other service (e.g. your
 company), or enable only the allowed users (e.g. your group's

--- a/docs/source/howto/configuration/config-sudo.md
+++ b/docs/source/howto/configuration/config-sudo.md
@@ -125,7 +125,7 @@ the shadow password database.
 **Note:** On [Fedora based distributions](https://fedoraproject.org/wiki/List_of_Fedora_remixes) there is no clear way to configure
 the PAM database to allow sufficient access for authenticating with the target user's password
 from JupyterHub. As a workaround we recommend use an
-[alternative authentication method](https://github.com/jupyterhub/jupyterhub/wiki/Authenticators).
+[alternative authentication method](authenticators-reference).
 
 ```bash
 $ ls -l /etc/shadow

--- a/docs/source/tutorial/quickstart.md
+++ b/docs/source/tutorial/quickstart.md
@@ -90,6 +90,6 @@ To **allow multiple users to sign in** to the Hub server, you must start
 sudo jupyterhub
 ```
 
-[Run JupyterHub without root privileges using sudo](https://jupyterhub.readthedocs.io/en/latest/howto/configuration/config-sudo.html)
+[](howto:config:no-sudo)
 describes how to run the server as a _less privileged user_. This requires
 additional configuration of the system.

--- a/docs/source/tutorial/quickstart.md
+++ b/docs/source/tutorial/quickstart.md
@@ -90,6 +90,6 @@ To **allow multiple users to sign in** to the Hub server, you must start
 sudo jupyterhub
 ```
 
-The [wiki](https://github.com/jupyterhub/jupyterhub/wiki/Using-sudo-to-run-JupyterHub-without-root-privileges)
+[Run JupyterHub without root privileges using sudo](https://jupyterhub.readthedocs.io/en/latest/howto/configuration/config-sudo.html)
 describes how to run the server as a _less privileged user_. This requires
 additional configuration of the system.


### PR DESCRIPTION
Fixes #4758. I believe the original wiki link should now redirect to the current documentation on [Run JupyterHub without root privileges using sudo](https://jupyterhub.readthedocs.io/en/latest/howto/configuration/config-sudo.html). Please feel free to correct me if I'm mistaken!