### PR TITLE
set default permissions on workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -29,6 +29,9 @@ on:
       - "**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   # UTF-8 content may be interpreted as ascii and causes errors without this.
   LANG: C.UTF-8


### PR DESCRIPTION
already set on others. No actual change because we have this set in config. Static analysis like zizmor or CodeQL flags it.