### PR TITLE
Fix incorrect login username in service-fastapi README.md

### DIFF
--- a/examples/service-fastapi/README.md
+++ b/examples/service-fastapi/README.md
@@ -60,7 +60,7 @@ sudo docker build . -t service-fastapi
 sudo docker run -it -p 8000:8000 service-fastapi
 ```
 
-2. Visit http://127.0.0.1:8000/services/fastapi/docs. When going through the OAuth flow or getting a token from the control panel, you can log in with `testuser` / `passwd`.
+2. Visit http://127.0.0.1:8000/services/fastapi/docs. When going through the OAuth flow or getting a token from the control panel, you can log in with 'test-user' and any password.
 
 # PUBLIC_HOST
 


### PR DESCRIPTION
The [service-fastapi](https://github.com/jupyterhub/jupyterhub/tree/main/examples/service-fastapi#try-it-out-in-docker) example in the README currently instructs users to log in with the username `testuser`, which fails in practice.

This PR updates the README to use the correct username `test-user`, which allows successful login with any password.