### PR TITLE
Fix link in changelog

### DIFF
--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -31,7 +31,7 @@ Contributors to major version bumps in JupyterHub include:
 - A new [SharedPasswordAuthenticator](#SharedPasswordAuthenticator)
 
 We have also changed how we build the `jupyterhub` container images.
-Images are now built from [](https://github.com/jupyterhub/jupyterhub-container-images) instead of the JupyterHub repo.
+Images are now built from [jupyterhub-container-images](https://github.com/jupyterhub/jupyterhub-container-images) instead of the JupyterHub repo.
 The main user-facing implication of this is that image for a given JupyterHub version will be rebuilt,
 which has the following consequences:
 


### PR DESCRIPTION
Without this the sentence looks incomplete:

|Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/c3178d9a-96b4-4eaf-994e-04106b0b1269) | ![image](https://github.com/user-attachments/assets/2c0c8e93-4c4c-47ab-90dd-7706c63c8dd8) |
