### PR TITLE
Update docs to point to `/hub/user-redirect/` instead of `/user-redirect/`

### DIFF
--- a/docs/source/reference/urls.md
+++ b/docs/source/reference/urls.md
@@ -169,14 +169,14 @@ _Version changed: 1.0_
 JupyterHub version 0.9 failed these API requests with status `404`,
 but version 1.0 uses 503.
 
-## `/user-redirect/...`
+## `/hub/user-redirect/...`
 
-The `/user-redirect/...` URL is for sharing a URL that will redirect a user
+The `/hub/user-redirect/...` URL is for sharing a URL that will redirect a user
 to a path on their own default server.
 This is useful when different users have the same file at the same URL on their servers,
 and you want a single link to give to any user that will open that file on their server.
 
-e.g. a link to `/user-redirect/notebooks/Index.ipynb`
+e.g. a link to `/hub/user-redirect/notebooks/Index.ipynb`
 will send user `hortense` to `/user/hortense/notebooks/Index.ipynb`
 
 **DO NOT** share links to your own server with other users.


### PR DESCRIPTION
In the docs, we point people to `/user-redirect` for user-agnostic URL construction:
https://github.com/jupyterhub/jupyterhub/blob/bc21e99e7efccd12840239cdc9419a577ee17c47/docs/source/reference/urls.md?plain=1#L172

However, the handler for this URL is properly defined under `/hub/user-redirect/`, and it looks as though the `/user-redirect/` is 302 redirected to the `/hub/user-redirect/` endpoint.

My interpretation is that we should be encouraging `/hub/user-redirect/` over the redirecting alias.