### PR TITLE
update security.md, security doc to point to GitHub vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # Reporting a Vulnerability
 
 If you believe you’ve found a security vulnerability in a Jupyter
-project, please report it to security@ipython.org. If you prefer to
-encrypt your security reports, you can use [this PGP public key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/1d303a645f2505a8fd283826fafc9908/ipython_security.asc).
+project, please report it!
+See the [security documentation](https://jupyterhub.readthedocs.org/en/latest/contributing/security.html) for how.

--- a/docs/source/contributing/security.md
+++ b/docs/source/contributing/security.md
@@ -5,7 +5,11 @@
 If you find a security vulnerability in Jupyter or JupyterHub,
 whether it is a failure of the security model described in [Security Overview](explanation:security)
 or a failure in implementation,
-please report it to <mailto:security@ipython.org>.
+please report it!
 
+Please use GitHub's "Report a Vulnerability" button under Security > Advisories on the appropriate repo,
+e.g. [report here for JupyterHub](https://github.com/jupyterhub/jupyterhub/security/advisories).
+
+You may also send an email to <mailto:security@ipython.org>, but the GitHub reporting system is preferred.
 If you prefer to encrypt your security reports,
 you can use {download}`this PGP public key </ipython_security.asc>`.


### PR DESCRIPTION
removes redundant info from security.md which had some broken links, instead pointing to actual docs.