### PR TITLE
Fix internal ssl: do not disable hostname verification by default

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -170,7 +170,8 @@ def make_ssl_context(
     ssl_context.load_default_certs()
 
     ssl_context.load_cert_chain(certfile, keyfile)
-    ssl_context.check_hostname = check_hostname
+    if check_hostname is not None:
+        ssl_context.check_hostname = check_hostname
     return ssl_context
 
 


### PR DESCRIPTION
I think there is a little error in the `make_ssl_context` utils function that, just before returning, sets in the returned `ssl_context` the `check_hostname` passed as argument to the function. However, this argument has a default of `None`, so when calling the `make_ssl_context` function without explicitly passing `check_hostname` (as is done in the rest of the codebase) it effectively disables the hostname verification in the `ssl_context`, which I believe it is not the intended behavior.

If I am wrong and it really is the intended behavior just igonore and close the PR :sweat_smile: 

