### PR TITLE
Switch to rbubley/mirrors-prettier, downgrade prettier to last proper release v3.6.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,8 @@ repos:
           - jupyter
 
   # Autoformat: markdown, yaml, javascript (see the file .prettierignore)
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
     hooks:
       - id: prettier
         exclude: .*/templates/.*|docs/source/_static/rest-api.yml|docs/source/rbac/scope-table.md

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ for administration of the Hub and its users.
 - A Linux/Unix based system
 - [Python](https://www.python.org/downloads/) 3.8 or greater
 - [nodejs/npm](https://www.npmjs.com/)
-
   - If you are using **`conda`**, the nodejs and npm dependencies will be installed for
     you by conda.
 

--- a/docs/source/_static/rest-api.yml
+++ b/docs/source/_static/rest-api.yml
@@ -62,18 +62,19 @@ paths:
                     properties:
                       class:
                         type: string
-                        description: The Python class currently active for JupyterHub
-                          Authentication
+                        description: The Python class currently active for 
+                          JupyterHub Authentication
                       version:
                         type: string
-                        description: The version of the currently active Authenticator
+                        description: The version of the currently active 
+                          Authenticator
                   spawner:
                     type: object
                     properties:
                       class:
                         type: string
-                        description: The Python class currently active for spawning
-                          single-user notebook servers
+                        description: The Python class currently active for 
+                          spawning single-user notebook servers
                       version:
                         type: string
                         description: The version of the currently active Spawner
@@ -256,8 +257,8 @@ paths:
       parameters:
         - $ref: "#/components/parameters/userName"
       requestBody:
-        description: Updated user info. At least one key to be updated (name or admin)
-          is required.
+        description: Updated user info. At least one key to be updated (name or 
+          admin) is required.
         content:
           application/json:
             schema:
@@ -265,12 +266,12 @@ paths:
               properties:
                 name:
                   type: string
-                  description: the new name (optional, if another key is updated i.e.
-                    admin)
+                  description: the new name (optional, if another key is updated
+                    i.e. admin)
                 admin:
                   type: boolean
-                  description: update admin (optional, if another key is updated i.e.
-                    name)
+                  description: update admin (optional, if another key is updated
+                    i.e. name)
         required: true
       responses:
         200:
@@ -286,8 +287,8 @@ paths:
     post:
       operationId: post-user-activity
       summary: Notify Hub of activity for a given user
-      description: Notify the Hub of activity by the user, e.g. accessing a service
-        or (more likely) actively using a server.
+      description: Notify the Hub of activity by the user, e.g. accessing a 
+        service or (more likely) actively using a server.
       parameters:
         - $ref: "#/components/parameters/userName"
       requestBody:
@@ -366,8 +367,8 @@ paths:
           description: The user's notebook server has started
           content: {}
         202:
-          description: The user's notebook server has not yet started, but has been
-            requested
+          description: The user's notebook server has not yet started, but has 
+            been requested
           content: {}
       security:
         - oauth2:
@@ -380,8 +381,8 @@ paths:
         - $ref: "#/components/parameters/userName"
       responses:
         202:
-          description: The user's notebook server has not yet stopped as it is taking
-            a while to stop
+          description: The user's notebook server has not yet stopped as it is 
+            taking a while to stop
           content: {}
         204:
           description: The user's notebook server has stopped
@@ -412,8 +413,8 @@ paths:
           description: The user's notebook named-server has started
           content: {}
         202:
-          description: The user's notebook named-server has not yet started, but has
-            been requested
+          description: The user's notebook named-server has not yet started, but
+            has been requested
           content: {}
       security:
         - oauth2:
@@ -448,8 +449,8 @@ paths:
         required: false
       responses:
         202:
-          description: The user's notebook named-server has not yet stopped as it
-            is taking a while to stop
+          description: The user's notebook named-server has not yet stopped as 
+            it is taking a while to stop
           content: {}
         204:
           description: The user's notebook named-server has stopped
@@ -462,8 +463,8 @@ paths:
     get:
       operationId: get-user-shared
       summary: List servers shared with user
-      description: Returns list of Shares granting the user access to servers owned
-        by others (new in 5.0)
+      description: Returns list of Shares granting the user access to servers 
+        owned by others (new in 5.0)
       parameters:
         - $ref: "#/components/parameters/userName"
 
@@ -576,11 +577,13 @@ paths:
                 expires_in:
                   type: number
                   example: 3600
-                  description: lifetime (in seconds) after which the requested token
-                    will expire. Omit, or specify null or 0 for no expiration.
+                  description: lifetime (in seconds) after which the requested 
+                    token will expire. Omit, or specify null or 0 for no 
+                    expiration.
                 note:
                   type: string
-                  description: A note attached to the token for future bookkeeping
+                  description: A note attached to the token for future 
+                    bookkeeping
                 roles:
                   type: array
                   description: |
@@ -758,7 +761,8 @@ paths:
         - $ref: "#/components/parameters/sharedServerName"
       responses:
         200:
-          description: The permissions granted to members of `group` on `owner/server`
+          description: The permissions granted to members of `group` on 
+            `owner/server`
           content:
             application/json:
               schema:
@@ -1173,7 +1177,8 @@ paths:
                         description: |
                           The full URL for accepting the code,
                           if JupyterHub.public_url configuration is defined.
-                        example: https://hub.example.org/hub/accept-share?code=abc123
+                        example: 
+                          https://hub.example.org/hub/accept-share?code=abc123
       security:
         - oauth2:
             - shares
@@ -1250,8 +1255,8 @@ paths:
     get:
       operationId: get-proxy
       summary: Get the proxy's routing table
-      description: A convenience alias for getting the routing table directly from
-        the proxy
+      description: A convenience alias for getting the routing table directly 
+        from the proxy
       parameters:
         - $ref: "#/components/parameters/paginationOffset"
         - $ref: "#/components/parameters/paginationLimit"
@@ -1262,8 +1267,8 @@ paths:
             application/json:
               schema:
                 type: object
-                description: configurable-http-proxy routing table (see configurable-http-proxy
-                  docs for details)
+                description: configurable-http-proxy routing table (see 
+                  configurable-http-proxy docs for details)
       security:
         - oauth2:
             - proxy
@@ -1282,8 +1287,8 @@ paths:
       summary: Notify the Hub about a new proxy
       description: Notifies the Hub of a new proxy to use.
       requestBody:
-        description: Any values that have changed for the new proxy. All keys are
-          optional.
+        description: Any values that have changed for the new proxy. All keys 
+          are optional.
         content:
           application/json:
             schema:
@@ -1374,8 +1379,8 @@ paths:
     get:
       operationId: get-auth-cookie
       summary: Identify a user from a cookie
-      description: Used by single-user notebook servers to hand off cookie authentication
-        to the Hub
+      description: Used by single-user notebook servers to hand off cookie 
+        authentication to the Hub
       parameters:
         - name: cookie_name
           in: path
@@ -1499,12 +1504,12 @@ paths:
               properties:
                 proxy:
                   type: boolean
-                  description: Whether the proxy should be shutdown as well (default
-                    from Hub config)
+                  description: Whether the proxy should be shutdown as well 
+                    (default from Hub config)
                 servers:
                   type: boolean
-                  description: Whether users' notebook servers should be shutdown
-                    as well (default from Hub config)
+                  description: Whether users' notebook servers should be 
+                    shutdown as well (default from Hub config)
         required: false
       responses:
         202:
@@ -1648,8 +1653,8 @@ components:
             type: string
         server:
           type: string
-          description: The user's notebook server's base URL, if running; null if
-            not.
+          description: The user's notebook server's base URL, if running; null 
+            if not.
         pending:
           type: string
           description: The currently pending action, if any
@@ -1680,8 +1685,8 @@ components:
       properties:
         name:
           type: string
-          description: The server's name. The user's default server has an empty name
-            ('')
+          description: The server's name. The user's default server has an empty
+            name ('')
         ready:
           type: boolean
           description: |
@@ -1743,14 +1748,14 @@ components:
         state:
           type: object
           properties: {}
-          description: Arbitrary internal state from this server's spawner. Only available
-            on the hub's users list or get-user-by-name method, and only with admin:users:server_state
-            scope. None otherwise.
+          description: Arbitrary internal state from this server's spawner. Only
+            available on the hub's users list or get-user-by-name method, and 
+            only with admin:users:server_state scope. None otherwise.
         user_options:
           type: object
           properties: {}
-          description: User specified options for the user's spawned instance of a
-            single-user server.
+          description: User specified options for the user's spawned instance of
+            a single-user server.
     RequestIdentity:
       description: |
         The model for the entity making the request.
@@ -1918,8 +1923,8 @@ components:
           items:
             type: string
         group:
-          description: the group being shared with (exactly one of 'user' or 'group'
-            will be non-null, the other will be null)
+          description: the group being shared with (exactly one of 'user' or 
+            'group' will be non-null, the other will be null)
           type:
             - object
             - "null"
@@ -1927,8 +1932,8 @@ components:
             name:
               type: string
         user:
-          description: the user being shared with (exactly one of 'user' or 'group'
-            will be non-null, the other will be null)
+          description: the user being shared with (exactly one of 'user' or 
+            'group' will be non-null, the other will be null)
           type:
             - object
             - "null"
@@ -1941,8 +1946,8 @@ components:
           format: date-time
 
     ShareCode:
-      description: A single sharing code. There is at most one of these objects per
-        (server, user) or (server, group) combination.
+      description: A single sharing code. There is at most one of these objects 
+        per (server, user) or (server, group) combination.
       type: object
       properties:
         server:
@@ -1977,37 +1982,41 @@ components:
       properties:
         id:
           type: string
-          description: The id of the API token. Used for modifying or deleting the
-            token.
+          description: The id of the API token. Used for modifying or deleting 
+            the token.
         user:
           type: string
-          description: The user that owns a token (undefined if owned by a service)
+          description: The user that owns a token (undefined if owned by a 
+            service)
         service:
           type: string
-          description: The service that owns the token (undefined of owned by a user)
+          description: The service that owns the token (undefined of owned by a 
+            user)
         roles:
           type: array
-          description: Deprecated in JupyterHub 3, always an empty list. Tokens have
-            'scopes' starting from JupyterHub 3.
+          description: Deprecated in JupyterHub 3, always an empty list. Tokens 
+            have 'scopes' starting from JupyterHub 3.
           items:
             type: string
         scopes:
           type: array
-          description: List of scopes this token has been assigned. New in JupyterHub
-            3. In JupyterHub 2.x, tokens were assigned 'roles' instead of scopes.
+          description: List of scopes this token has been assigned. New in 
+            JupyterHub 3. In JupyterHub 2.x, tokens were assigned 'roles' 
+            instead of scopes.
           items:
             type: string
         note:
           type: string
-          description: A note about the token, typically describing what it was created
-            for.
+          description: A note about the token, typically describing what it was 
+            created for.
         created:
           type: string
           description: Timestamp when this token was created
           format: date-time
         expires_at:
           type: string
-          description: Timestamp when this token expires. Null if there is no expiry.
+          description: Timestamp when this token expires. Null if there is no 
+            expiry.
           format: date-time
         last_activity:
           type: string
@@ -2030,41 +2039,45 @@ components:
       properties:
         token:
           type: string
-          description: The token itself. Only present in responses to requests for
-            a new token.
+          description: The token itself. Only present in responses to requests 
+            for a new token.
         id:
           type: string
-          description: The id of the API token. Used for modifying or deleting the
-            token.
+          description: The id of the API token. Used for modifying or deleting 
+            the token.
         user:
           type: string
-          description: The user that owns a token (undefined if owned by a service)
+          description: The user that owns a token (undefined if owned by a 
+            service)
         service:
           type: string
-          description: The service that owns the token (undefined of owned by a user)
+          description: The service that owns the token (undefined of owned by a 
+            user)
         roles:
           type: array
-          description: Deprecated in JupyterHub 3, always an empty list. Tokens have
-            'scopes' starting from JupyterHub 3.
+          description: Deprecated in JupyterHub 3, always an empty list. Tokens 
+            have 'scopes' starting from JupyterHub 3.
           items:
             type: string
         scopes:
           type: array
-          description: List of scopes this token has been assigned. New in JupyterHub
-            3. In JupyterHub 2.x, tokens were assigned 'roles' instead of scopes.
+          description: List of scopes this token has been assigned. New in 
+            JupyterHub 3. In JupyterHub 2.x, tokens were assigned 'roles' 
+            instead of scopes.
           items:
             type: string
         note:
           type: string
-          description: A note about the token, typically describing what it was created
-            for.
+          description: A note about the token, typically describing what it was 
+            created for.
         created:
           type: string
           description: Timestamp when this token was created
           format: date-time
         expires_at:
           type: string
-          description: Timestamp when this token expires. Null if there is no expiry.
+          description: Timestamp when this token expires. Null if there is no 
+            expiry.
           format: date-time
         last_activity:
           type: string
@@ -2094,22 +2107,23 @@ components:
           tokenUrl: /hub/api/oauth2/token
           scopes:
             (no_scope): Identify the owner of the requesting entity.
-            self: The user’s own resources _(metascope for users, resolves to (no_scope)
-              for services)_
-            inherit: Everything that the token-owning entity can access _(metascope
-              for tokens)_
-            admin-ui: Access the admin page. Permission to take actions via the admin
-              page granted separately.
-            admin:users: Read, modify, create, and delete users and their authentication
-              state, not including their servers or tokens. This is an extremely privileged
-              scope and should be considered tantamount to superuser.
+            self: The user’s own resources _(metascope for users, resolves to 
+              (no_scope) for services)_
+            inherit: Everything that the token-owning entity can access 
+              _(metascope for tokens)_
+            admin-ui: Access the admin page. Permission to take actions via the 
+              admin page granted separately.
+            admin:users: Read, modify, create, and delete users and their 
+              authentication state, not including their servers or tokens. This 
+              is an extremely privileged scope and should be considered 
+              tantamount to superuser.
             admin:auth_state: Read a user’s authentication state.
-            users: Read and write permissions to user models (excluding servers, tokens
-              and authentication state).
+            users: Read and write permissions to user models (excluding servers,
+              tokens and authentication state).
             delete:users: Delete users.
             list:users: List users, including at least their names.
-            read:users: Read user models (including the URL of the default server
-              if it is running).
+            read:users: Read user models (including the URL of the default 
+              server if it is running).
             read:users:name: Read names of users.
             read:users:groups: Read users’ group membership.
             read:users:activity: Read time of last user activity.
@@ -2118,24 +2132,25 @@ components:
             read:roles:services: Read service role assignments.
             read:roles:groups: Read group role assignments.
             users:activity: Update time of last user activity.
-            admin:servers: Read, start, stop, create and delete user servers and their
-              state.
+            admin:servers: Read, start, stop, create and delete user servers and
+              their state.
             admin:server_state: Read and write users’ server state.
             servers: Start and stop user servers.
-            read:servers: Read users’ names and their server models (excluding the
-              server state).
+            read:servers: Read users’ names and their server models (excluding 
+              the server state).
             delete:servers: Stop and delete users' servers.
             tokens: Read, write, create and delete user tokens.
             read:tokens: Read user tokens.
-            admin:groups: Read and write group information, create and delete groups.
+            admin:groups: Read and write group information, create and delete 
+              groups.
             groups: 'Read and write group information, including adding/removing any
               users to/from groups. Note: adding users to groups may affect permissions.'
             list:groups: List groups, including at least their names.
             read:groups: Read group models.
             read:groups:name: Read group names.
             delete:groups: Delete groups.
-            admin:services: Create, read, update, delete services, not including services
-              defined from config files.
+            admin:services: Create, read, update, delete services, not including
+              services defined from config files.
             list:services: List services, including at least their names.
             read:services: Read service models.
             read:services:name: Read service names.
@@ -2148,7 +2163,7 @@ components:
             read:groups:shares: Read servers shared with a group.
             read:shares: Read information about shared access to servers.
             shares: Manage access to shared servers.
-            proxy: Read information about the proxy’s routing table, sync the Hub
-              with the proxy and notify the Hub about a new proxy.
+            proxy: Read information about the proxy’s routing table, sync the 
+              Hub with the proxy and notify the Hub about a new proxy.
             shutdown: Shutdown the hub.
             read:metrics: Read prometheus metrics.

--- a/docs/source/explanation/websecurity.md
+++ b/docs/source/explanation/websecurity.md
@@ -186,7 +186,6 @@ For example:
 
 - `Content-Security-Policy` header must prohibit popups and iframes from the same origin.
   The following Content-Security-Policy rules are _insecure_ and readily enable users to access each others' servers:
-
   - `frame-ancestors: 'self'`
   - `frame-ancestors: '*'`
   - `sandbox allow-popups`

--- a/docs/source/rbac/tech-implementation.md
+++ b/docs/source/rbac/tech-implementation.md
@@ -84,7 +84,6 @@ The passed scopes are compared to the scopes required to access the API as follo
 - if the API scopes are present within the set of passed scopes, the access is granted and the API returns its "full" response
 
 - if that is not the case, another check is utilized to determine if subscopes of the required API scopes can be found in the passed scope set:
-
   - if found, the RBAC framework employs the {ref}`filtering <vertical-filtering-target>` procedures to refine the API response to access only resource attributes corresponding to the passed scopes. For example, providing a scope `read:users:activity!group=class-C` for the `GET /users` API will return a list of user models from group `class-C` containing only the `last_activity` attribute for each user model
 
   - if not found, the access to API is denied

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -17,11 +17,9 @@ Please submit pull requests to update information or to add new institutions or 
 - [BIDS - Berkeley Institute for Data Science](https://bids.berkeley.edu/)
 
 - [Data 8](http://data8.org/)
-
   - [GitHub organization](https://github.com/data-8)
 
 - [NERSC](https://www.nersc.gov/)
-
   - [Press release on Jupyter and Cori](https://www.nersc.gov/news-publications/nersc-news/nersc-center-news/2016/jupyter-notebooks-will-open-up-new-possibilities-on-nerscs-cori-supercomputer/)
   - [Moving and sharing data](https://www.nersc.gov/assets/Uploads/03-MovingAndSharingData-Cholia.pdf)
 
@@ -134,7 +132,6 @@ The [Educational Development and Technology](https://ethz.ch/en/the-eth-zurich/o
 ### University of California San Diego
 
 - San Diego Supercomputer Center - Andrea Zonca
-
   - [Deploy JupyterHub on a Supercomputer with SSH](https://zonca.github.io/2017/05/jupyterhub-hpc-batchspawner-ssh.html)
   - [Run Jupyterhub on a Supercomputer](https://zonca.github.io/2015/04/jupyterhub-hpc.html)
   - [Deploy JupyterHub on a VM for a Workshop](https://zonca.github.io/2016/04/jupyterhub-sdsc-cloud.html)

--- a/docs/source/tutorial/quickstart.md
+++ b/docs/source/tutorial/quickstart.md
@@ -11,7 +11,6 @@ Before installing JupyterHub, you will need:
   installing Python packages is helpful.
 - [Node.js {{node_min}}](https://www.npmjs.com/) or greater, along with npm. [Install Node.js/npm](https://docs.npmjs.com/getting-started/installing-node),
   using your operating system's package manager.
-
   - If you are using **`conda`**, the nodejs and npm dependencies will be installed for
     you by conda.
 


### PR DESCRIPTION
prettier on pre-commit.ci is showing inconsistent behaviour, for example in https://github.com/jupyterhub/jupyterhub/pull/5091 pre-commit.ci pushed changes that are unrelated to the original (first) commit. More problematically, running prettier via pre-commit locally vs pre-commit.ci may make different formatting changes. This switches to https://github.com/rbubley/mirrors-prettier, which is maintained, and uses the last proper prettier release instead of an 4.0.0 alpha release.

Same as https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3705