### PR TITLE
Fix hub activity log to use spawner.last_activity

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -1034,7 +1034,7 @@ class ActivityAPIHandler(APIHandler):
                         user.name,
                         server_name,
                         isoformat(last_activity),
-                        isoformat(user.last_activity),
+                        isoformat(spawner.last_activity),
                     )
 
         self.db.commit()


### PR DESCRIPTION
Update debug log to compare activity timestamps with spawner.last_activity instead of user.last_activity.