### PR TITLE
Avoid double `//` in `test_proxy_service`

### DIFF
--- a/jupyterhub/tests/test_services.py
+++ b/jupyterhub/tests/test_services.py
@@ -65,7 +65,9 @@ async def test_proxy_service(app, mockservice_url):
     service = mockservice_url
     name = service.name
     await app.proxy.get_all_routes()
-    url = public_url(app, service) + '/foo'
+    url = public_url(app, service)
+    assert url.endswith("/")
+    url += "foo"
     r = await async_requests.get(url, allow_redirects=False)
     path = f'/services/{name}/foo'
     r.raise_for_status()


### PR DESCRIPTION
`test_services::test_proxy_service` is failing in some cases because a request is being made to `/@/space%20word/services/test-service-NN//foo` (note the double `//`) and EchoHandler is returning that URL unchanged, instead of `/@/space%20word/services/test-service-NN/foo`