### PR TITLE
allow 6 items in header drop-down

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -262,6 +262,7 @@ html_static_path = ["_static"]
 
 html_theme = "jupyterhub_sphinx_theme"
 html_theme_options = {
+    "header_links_before_dropdown": 6,
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
we only have 6 items, so don't put one item under More:

<img width="663" height="152" alt="Screenshot 2025-08-05 at 21 14 28" src="https://github.com/user-attachments/assets/2848c60c-83cf-4121-ac2d-9db3171f6d29" />

closes #5114

I'll open an issue on pydata-sphinx-theme to see if this can be done automatically.