### PR TITLE
JupyterCon banner and jupyter colors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -231,7 +231,6 @@ def setup(app):
     app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")
 
 
-
 # -- Read The Docs -----------------------------------------------------------
 #
 # Since RTD runs sphinx-build directly without running "make html", we run the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -228,6 +228,8 @@ def setup(app):
     app.add_directive("jupyterhub-generate-config", ConfigDirective)
     app.add_directive("jupyterhub-help-all", HelpAllDirective)
     app.add_directive("jupyterhub-rest-api-links", RestAPILinksDirective)
+    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")
+
 
 
 # -- Read The Docs -----------------------------------------------------------
@@ -262,6 +264,7 @@ html_static_path = ["_static"]
 
 html_theme = "jupyterhub_sphinx_theme"
 html_theme_options = {
+    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
     "header_links_before_dropdown": 6,
     "icon_links": [
         {


### PR DESCRIPTION
This PR does a couple of things:

- Adds an announcement banner for JupyterCon
- Links a CSS file from the Jupyter documentation that we can use for jupyter colors in our docs

