### PR TITLE
don't revert asynchttp class when setting up internal ssl

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1989,7 +1989,10 @@ class JupyterHub(Application):
                 self.internal_ssl_cert,
                 cafile=self.internal_ssl_ca,
             )
-            AsyncHTTPClient.configure(None, defaults={"ssl_options": ssl_context})
+            AsyncHTTPClient.configure(
+                AsyncHTTPClient.configured_class(),
+                defaults={"ssl_options": ssl_context},
+            )
 
     def init_db(self):
         """Create the database connection"""

--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -330,7 +330,9 @@ class JupyterHubSingleUser(ExtensionApp):
             self.hub_auth.certfile,
             cafile=self.hub_auth.client_ca,
         )
-        AsyncHTTPClient.configure(None, defaults={"ssl_options": ssl_context})
+        AsyncHTTPClient.configure(
+            AsyncHTTPClient.configured_class(), defaults={"ssl_options": ssl_context}
+        )
         return AsyncHTTPClient()
 
     async def check_hub_version(self):

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -406,7 +406,9 @@ class SingleUserNotebookAppMixin(Configurable):
         ssl_context = make_ssl_context(
             self.keyfile, self.certfile, cafile=self.client_ca
         )
-        AsyncHTTPClient.configure(None, defaults={"ssl_options": ssl_context})
+        AsyncHTTPClient.configure(
+            AsyncHTTPClient.configured_class(), defaults={"ssl_options": ssl_context}
+        )
         return AsyncHTTPClient()
 
     async def check_hub_version(self):


### PR DESCRIPTION
None reverts to the default class, it doesn't not preserve the current value

closes #5158 