### PR TITLE
unpin pytest-asyncio

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -3887,6 +3887,10 @@ class JupyterHub(Application):
             tasks = [t for t in asyncio.all_tasks()]
             for t in tasks:
                 self.log.debug("Task status: %s", t)
+        self._stop_event_loop()
+
+    def _stop_event_loop(self):
+        """In a method to allow tests to not do this"""
         asyncio.get_event_loop().stop()
 
     def stop(self):

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -102,7 +102,7 @@ def ssl_tmpdir(tmpdir_factory):
 
 
 @fixture(scope='module')
-async def app(request, io_loop, ssl_tmpdir):
+async def app(request, ssl_tmpdir):
     """Mock a jupyterhub app for testing"""
     mocked_app = None
     ssl_enabled = getattr(
@@ -170,39 +170,23 @@ async def io_loop(request):
     The main reason to depend on this fixture is to ensure your cleanup
     happens before the io_loop is closed.
     """
+    warn(
+        "jupyterhub's io_loop fixture is deprecated. Use async fixtures to get the event loop.",
+        DeprecationWarning,
+    )
     io_loop = AsyncIOMainLoop()
     event_loop = asyncio.get_running_loop()
     assert asyncio.get_event_loop() is event_loop
     assert io_loop.asyncio_loop is event_loop
-
-    def _close():
-        # cleanup everything
-        try:
-            event_loop.run_until_complete(event_loop.shutdown_asyncgens())
-        except (asyncio.CancelledError, RuntimeError):
-            pass
-        io_loop.close(all_fds=True)
-
-        # workaround pytest-asyncio trying to cleanup after loop is closed
-        # problem introduced in pytest-asyncio 0.25.2
-        def noop(*args, **kwargs):
-            warn("Loop used after close...", RuntimeWarning, stacklevel=2)
-            return
-
-        event_loop.run_until_complete = noop
-
-    request.addfinalizer(_close)
     return io_loop
 
 
 @fixture(autouse=True)
-async def cleanup_after(request, io_loop):
+async def cleanup_after(request):
     """function-scoped fixture to shutdown user servers
 
     allows cleanup of servers between tests
     without having to launch a whole new app
-
-    depends on io_loop to ensure it runs before things are closed.
     """
 
     try:

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -382,6 +382,10 @@ class MockHub(JupyterHub):
         super().stop()
         self.db_file.close()
 
+    def _stop_event_loop(self):
+        # leave it to pytest-asyncio to stop the loop
+        pass
+
     async def login_user(self, name):
         """Login a user by name, returning her cookies."""
         base_url = public_url(self)

--- a/jupyterhub/tests/test_utils.py
+++ b/jupyterhub/tests/test_utils.py
@@ -29,11 +29,12 @@ async def yield_n(n, delay=0.01):
         yield i
 
 
-def schedule_future(io_loop, *, delay, result=None):
+def schedule_future(*, delay, result=None):
     """Construct a Future that will resolve after a delay"""
     f = asyncio.Future()
+
     if delay:
-        io_loop.call_later(delay, lambda: f.set_result(result))
+        asyncio.get_running_loop().call_later(delay, lambda: f.set_result(result))
     else:
         f.set_result(result)
     return f
@@ -48,8 +49,8 @@ def schedule_future(io_loop, *, delay, result=None):
         (0.5, 10, 0.2, [0, 1]),
     ],
 )
-async def test_iterate_until(io_loop, deadline, n, delay, expected):
-    f = schedule_future(io_loop, delay=deadline)
+async def test_iterate_until(deadline, n, delay, expected):
+    f = schedule_future(delay=deadline)
 
     yielded = []
     async with aclosing(iterate_until(f, yield_n(n, delay=delay))) as items:
@@ -58,8 +59,8 @@ async def test_iterate_until(io_loop, deadline, n, delay, expected):
     assert yielded == expected
 
 
-async def test_iterate_until_ready_after_deadline(io_loop):
-    f = schedule_future(io_loop, delay=0)
+async def test_iterate_until_ready_after_deadline():
+    f = schedule_future(delay=0)
 
     async def gen():
         for i in range(5):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
   # the test test_nbclassic_control_panel.
   "nbclassic",
   "pytest>=3.3",
-  "pytest-asyncio>=0.17,!=0.23.*,<1.0.0",
+  "pytest-asyncio>=0.17,!=0.23.*",
   "pytest-cov",
   "pytest-rerunfailures",
   "requests-mock",


### PR DESCRIPTION
let's see what breaks; hopefully #5095 was just a bug upstream that's been fixed in the meantime

reverts #5094 closes #5095