### PR TITLE
fix sr-only -> visually hidden

### DIFF
--- a/share/jupyterhub/templates/home.html
+++ b/share/jupyterhub/templates/home.html
@@ -4,7 +4,7 @@
 {% endif %}
 {% block main %}
   <div class="container">
-    <h1 class="sr-only">JupyterHub home page</h1>
+    <h1 class="visually-hidden">JupyterHub home page</h1>
     <div class="row">
       <div class="text-center">
         {% if default_server.active %}<a id="stop" role="button" class="btn btn-lg btn-danger">Stop My Server</a>{% endif %}

--- a/share/jupyterhub/templates/spawn_pending.html
+++ b/share/jupyterhub/templates/spawn_pending.html
@@ -14,7 +14,7 @@
                aria-valuenow="0"
                aria-valuemin="0"
                aria-valuemax="100">
-            <span class="sr-only"><span id="sr-progress">0%</span> Complete</span>
+            <span class="visually-hidden"><span id="sr-progress">0%</span> Complete</span>
           </div>
         </div>
         <p id="progress-message"></p>

--- a/share/jupyterhub/templates/token.html
+++ b/share/jupyterhub/templates/token.html
@@ -1,7 +1,7 @@
 {% extends "page.html" %}
 {% block main %}
   <div class="container">
-    <h1 class="sr-only">Manage JupyterHub Tokens</h1>
+    <h1 class="visually-hidden">Manage JupyterHub Tokens</h1>
     <div class="row justify-content-center">
       <form id="request-token-form" class="col-lg-6">
         <div class="form-group">


### PR DESCRIPTION
removed in bootstrap 5, but we accidentially had it from fontawesome 6 as well, which is also gone now

closes #5168 