### PR TITLE
Update JupyterCon 2025 announcement links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -263,7 +263,7 @@ html_static_path = ["_static"]
 
 html_theme = "jupyterhub_sphinx_theme"
 html_theme_options = {
-    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
+    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/\">REGISTER NOW</a>",
     "header_links_before_dropdown": 6,
     "icon_links": [
         {


### PR DESCRIPTION
- Mirrors https://github.com/jupyter/jupyter.github.io/pull/824
- Follow-up to https://github.com/jupyterhub/jupyterhub/pull/5142