### PR TITLE
avoid setting ssl config when there isn't any

### DIFF
--- a/jupyterhub/singleuser/extension.py
+++ b/jupyterhub/singleuser/extension.py
@@ -325,14 +325,18 @@ class JupyterHubSingleUser(ExtensionApp):
     @default('hub_http_client')
     def _default_client(self):
         # can't use ssl_options in case of pycurl
+        defaults = dict(validate_cert=True)
+        # don't set falsy empty strings,
+        # which tornado interprets as paths
+        if self.hub_auth.client_ca:
+            defaults["ca_certs"] = self.hub_auth.client_ca
+        if self.hub_auth.keyfile:
+            defaults["client_key"] = self.hub_auth.keyfile
+        if self.hub_auth.certfile:
+            defaults["client_cert"] = self.hub_auth.certfile
         AsyncHTTPClient.configure(
             AsyncHTTPClient.configured_class(),
-            defaults=dict(
-                ca_certs=self.hub_auth.client_ca,
-                client_key=self.hub_auth.keyfile,
-                client_cert=self.hub_auth.certfile,
-                validate_cert=True,
-            ),
+            defaults=defaults,
         )
         return AsyncHTTPClient()
 

--- a/jupyterhub/singleuser/mixins.py
+++ b/jupyterhub/singleuser/mixins.py
@@ -403,14 +403,18 @@ class SingleUserNotebookAppMixin(Configurable):
     @default('hub_http_client')
     def _default_client(self):
         # can't use ssl_options in case of pycurl
+        defaults = dict(validate_cert=True)
+        # don't set falsy empty strings,
+        # which tornado interprets as paths
+        if self.client_ca:
+            defaults["ca_certs"] = self.client_ca
+        if self.keyfile:
+            defaults["client_key"] = self.keyfile
+        if self.certfile:
+            defaults["client_cert"] = self.certfile
         AsyncHTTPClient.configure(
             AsyncHTTPClient.configured_class(),
-            defaults=dict(
-                ca_certs=self.client_ca,
-                client_key=self.keyfile,
-                client_cert=self.certfile,
-                validate_cert=True,
-            ),
+            defaults=defaults,
         )
         return AsyncHTTPClient()
 


### PR DESCRIPTION
rather than setting our falsy values, which aren't treated as undefined, they are treated as the path `''`

we could set None, but even better to leave undefined

regression in 5.4.1

closes #5179 