### PR TITLE
docs - update jupyterhub repo links to main branch

### DIFF
--- a/docs/source/reference/authenticators.md
+++ b/docs/source/reference/authenticators.md
@@ -32,7 +32,7 @@ popular services:
 - MediaWiki
 - OpenShift
 
-A [generic implementation](https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/generic.py), which you can use for OAuth authentication with any provider, is also available.
+A [generic implementation](https://github.com/jupyterhub/oauthenticator/blob/main/oauthenticator/generic.py), which you can use for OAuth authentication with any provider, is also available.
 
 ## The Dummy Authenticator
 

--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -399,10 +399,10 @@ done via the HubAuth constructor, direct assignment to a HubAuth object, or via 
 `JUPYTERHUB_API_TOKEN` environment variable. A number of the examples in the
 root of the jupyterhub git repository set the `JUPYTERHUB_API_TOKEN` variable
 so consider having a look at those for further reading
-([cull-idle](https://github.com/jupyterhub/jupyterhub/tree/master/examples/cull-idle),
-[external-oauth](https://github.com/jupyterhub/jupyterhub/tree/master/examples/external-oauth),
-[service-notebook](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-notebook)
-and [service-whoami](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-whoami))
+([cull-idle](https://github.com/jupyterhub/jupyterhub/tree/main/examples/cull-idle),
+[external-oauth](https://github.com/jupyterhub/jupyterhub/tree/main/examples/external-oauth),
+[service-notebook](https://github.com/jupyterhub/jupyterhub/tree/main/examples/service-notebook)
+and [service-whoami](https://github.com/jupyterhub/jupyterhub/tree/main/examples/service-whoami))
 
 Most of the logic for authentication implementation is found in the
 {meth}`.HubAuth.user_for_token` methods,


### PR DESCRIPTION
this updates a handful of links to the jupyterhub github repo to use the (current) `main` branch.