### PR TITLE
Remove JupyterCon 2025 announcement banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -263,7 +263,6 @@ html_static_path = ["_static"]
 
 html_theme = "jupyterhub_sphinx_theme"
 html_theme_options = {
-    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/\">REGISTER NOW</a>",
     "header_links_before_dropdown": 6,
     "icon_links": [
         {


### PR DESCRIPTION
This removes the JupyterCon 2025 promotional announcement banner from the documentation configuration.

Reverts announcement from PR #5142
See jupyter-governance/ec-team-compass#146

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by @jasongrout

This doesn't revert the "stable" branch of the docs that @minrk mentions [here](https://github.com/jupyterhub/jupyterhub/pull/5142#issuecomment-3372766522), it just reverts the actual announcement text.