### PR TITLE
add configurable service.timeout

### DIFF
--- a/jupyterhub/alembic/versions/be8ecf03ddac_service_timeout.py
+++ b/jupyterhub/alembic/versions/be8ecf03ddac_service_timeout.py
@@ -1,0 +1,29 @@
+"""empty message
+
+Revision ID: be8ecf03ddac
+Revises: 4621fec11365
+Create Date: 2025-11-24 16:12:05.681152
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "be8ecf03ddac"
+down_revision = "4621fec11365"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "services",
+        sa.Column(
+            "timeout", sa.Integer(), default=30, server_default="30", nullable=False
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("services", "timeout")

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -2961,7 +2961,9 @@ class JupyterHub(Application):
                 # no URL to check, nothing to do
                 continue
             try:
-                await Server.from_orm(service.orm.server).wait_up(timeout=1, http=True)
+                await Server.from_orm(service.orm.server).wait_up(
+                    timeout=service.timeout, http=True
+                )
             except AnyTimeoutError:
                 self.log.warning(
                     "Cannot connect to %s service %s at %s",
@@ -3636,25 +3638,45 @@ class JupyterHub(Application):
             self.log.info("Adding external service %s", msg)
 
         if service.url:
-            tries = 10 if service.managed else 1
-            for i in range(tries):
-                try:
-                    await Server.from_orm(service.orm.server).wait_up(
-                        http=True, timeout=1, ssl_context=ssl_context
-                    )
-                except AnyTimeoutError:
-                    if service.managed:
+            server = Server.from_orm(service.orm.server)
+            wait_up_task = asyncio.create_task(
+                server.wait_up(
+                    http=True, timeout=service.timeout, ssl_context=ssl_context
+                )
+            )
+            futures = []
+            if service.managed:
+
+                async def wait_for_stop():
+                    """Return with status when managed service exits"""
+                    while True:
                         status = await service.spawner.poll()
-                        if status is not None:
-                            self.log.critical(
-                                "Service %s exited with status %s",
-                                service_name,
-                                status,
-                            )
-                            return False
-                else:
-                    return True
-            else:
+                        if status is None:
+                            await asyncio.sleep(1)
+                        else:
+                            return status
+
+                wait_for_stop_task = asyncio.create_task(wait_for_stop())
+                futures.append(wait_for_stop_task)
+
+            done, pending = await asyncio.wait(
+                futures, return_when=asyncio.FIRST_EXCEPTION
+            )
+            # cancel pending
+            [f.cancel() for f in pending if not f.done()]
+            if service.managed and wait_for_stop_task in done:
+                # service process exited while we were waiting to connect
+                status = await wait_for_stop_task
+                self.log.critical(
+                    "Service %s exited with status %s",
+                    service_name,
+                    status,
+                )
+                return False
+
+            try:
+                await wait_up_task
+            except AnyTimeoutError:
                 if service.managed:
                     self.log.critical(
                         "Cannot connect to %s service %s",

--- a/jupyterhub/orm.py
+++ b/jupyterhub/orm.py
@@ -490,6 +490,8 @@ class Service(Base):
 
     user = Column(Unicode(255), nullable=True)
 
+    timeout = Column(Integer, default=30, nullable=False)
+
     from_config = Column(Boolean, default=True)
 
     api_tokens = relationship(

--- a/jupyterhub/services/service.py
+++ b/jupyterhub/services/service.py
@@ -52,6 +52,7 @@ from traitlets import (
     Dict,
     HasTraits,
     Instance,
+    Integer,
     List,
     Set,
     Unicode,
@@ -247,6 +248,15 @@ class Service(LoggingConfigurable):
 
     display = Bool(
         True, help="""Whether to list the service on the JupyterHub UI"""
+    ).tag(input=True)
+
+    timeout = Integer(
+        30,
+        help="""
+        Timeout (in seconds) to wait for the service to become available.
+
+        .. versionadded:: 6.0
+        """,
     ).tag(input=True)
 
     oauth_no_confirm = Bool(


### PR DESCRIPTION
and simplify concurrent wait up & wait for exit for managed services by using concurrent tasks instead of a for loop with short timeouts

closes #5138