### PR TITLE
changelog for 5.4.3

### DIFF
--- a/docs/source/reference/changelog.md
+++ b/docs/source/reference/changelog.md
@@ -22,7 +22,7 @@ Contributors to major version bumps in JupyterHub include:
 
 ## 5.4
 
-### 5.4.3 - 2025-12-11
+### 5.4.3 - 2025-12-12
 
 ([full changelog](https://github.com/jupyterhub/jupyterhub/compare/5.4.2...5.4.3))
 


### PR DESCRIPTION
I want to get one more release out fixing a couple more 5.4 regressions:

- #5236
- #5191

I've also backported some recent docs improvements so they show up in our default `stable` docs.