### PR TITLE
browser test_spawn_pending_progress : fix server ready expectation

### DIFF
--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -291,7 +291,7 @@ async def test_spawn_pending_progress(
             f"Server ready at {user.server_url()}",
         ]
         logs_list = []
-        while not user.spawner.ready and len(logs_list) < len(expected_messages):
+        while not user.spawner.ready and len(logs_list) <= len(expected_messages):
             logs_list = [
                 await log.text_content()
                 for log in await browser.locator("div.progress-log-event").all()


### PR DESCRIPTION
so it gets the right url when subdomains are used

fixes flaky test_spawn_pending_progress with subdomains enabled