### PR TITLE
Fix command to check Node.js version in setup.md

### DIFF
--- a/docs/source/contributing/setup.md
+++ b/docs/source/contributing/setup.md
@@ -81,7 +81,7 @@ a more detailed discussion.
    This should return a version number greater than or equal to {{python_min}}.
 
    ```bash
-   npm -v
+   node -v
    ```
 
    This should return a version number greater than or equal to {{node_min}}.


### PR DESCRIPTION
the command mentioned previously (`npm -v`) only returns the version of npm instead of node.js. As the most recent version of npm is 11.7.0 and node.js > v12 is required, some people might wonder about not beeing able to fulfill this version-requirement.