### PR TITLE
docs: update JSX README and remove outdated place command

### DIFF
--- a/jsx/README.md
+++ b/jsx/README.md
@@ -11,7 +11,9 @@ admin dashboard codebase.
 - `npm run hot`: Bundles the application and runs a mock (serverless) version on port 8000
 - `npm run lint`: Lints JSX with ESLint
 - `npm run lint --fix`: Lints and fixes errors JSX with ESLint / formats with Prettier
-- `npm run place`: Copies the transpiled React bundle to share/jupyterhub/static/js/admin-react.js for use.
+- `npm run build:watch`: Automatically rebuild the admin page during development.
+- `npm run test`: Runs the test suite.
+- `npm run snap`: Updates snapshot tests.
 
 ### Good To Know
 


### PR DESCRIPTION
This Pr addresses the documentation part of issue #5263. The jsx/README.md was outdated and contained a command that is no longer in use. 

Changes made: 
 Removed the outdated npm run place command as it has been replaced by direct building of the react site.

Added descriptions for the following missing commands to improve developer experience:
* npm run build:watch: For automatically rebuilding the admin page during development.

* npm run test: To run the test suite.

* npm run snap: To update snapshot tests.
*
Note on npm audit: I have focused on the documentation updates for this PR. I am happy to address the npm aduit fix as well if needed, once my local environment setup is fully verified.