### PR TITLE
increase timeout waiting for stop server button

### DIFF
--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -1347,7 +1347,9 @@ async def test_start_stop_server_on_admin_page(
 
     # click on Start button
     await click_start_server(browser, user1.name)
-    await expect(browser.get_by_role("button", name="Stop Server")).to_have_count(1)
+    await expect(browser.get_by_role("button", name="Stop Server")).to_have_count(
+        1, timeout=30_000
+    )
     await expect(browser.get_by_role("button", name="Start Server")).to_have_count(
         len(users_list) - 1
     )


### PR DESCRIPTION
another flaky test

this takes some time, because the server needs to finish handling the spawn request

