### PR TITLE
add zizmor to pre-commit, address lint

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,8 @@ updates:
           - "actions/*"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: /
     groups:
@@ -29,6 +31,8 @@ updates:
           - patch
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: /jsx
     groups:
@@ -64,3 +68,5 @@ updates:
           - major
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
-          node-version: "20"
+          node-version: "24"
           package-manager-cache: false
 
       - name: install build requirements

--- a/.github/workflows/support-bot.yml
+++ b/.github/workflows/support-bot.yml
@@ -12,7 +12,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/support-requests@v4
+      - uses: dessant/support-requests@47d5ea12f6c9e4a081637de9626b7319b415a3bf # v4
         with:
           github-token: ${{ github.token }}
           support-label: "support"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -39,11 +39,13 @@ env:
 
 jobs:
   validate-rest-api-definition:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22"
           cache: npm
@@ -55,13 +57,14 @@ jobs:
   test-docs:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # make rediraffecheckdiff requires git history to compare current
           # commit with the main branch and previous releases.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
           cache: pip
@@ -99,22 +102,24 @@ jobs:
       - name: check redirects for this PR
         if: github.event_name == 'pull_request'
         run: |
-          cd docs
-          export REDIRAFFE_BRANCH=origin/${{ github.base_ref }}
           make rediraffecheckdiff
+        env:
+          REDIRAFFE_BRANCH: origin/${{ github.base_ref }}
+        working-directory: docs
 
       # this should check currently published 'stable' links for redirects
       - name: check redirects since last release
         if: github.repository == 'jupyterhub/jupyterhub'
         run: |
-          cd docs
           export REDIRAFFE_BRANCH=$(git describe --tags --abbrev=0)
           make rediraffecheckdiff
+        working-directory: docs
 
       # longer-term redirect check (fixed version) for older links
       - name: check redirects since 3.0.0
         if: github.repository == 'jupyterhub/jupyterhub'
         run: |
-          cd docs
-          export REDIRAFFE_BRANCH=3.0.0
           make rediraffecheckdiff
+        env:
+          REDIRAFFE_BRANCH: "3.0.0"
+        working-directory: docs

--- a/.github/workflows/test-jsx.yml
+++ b/.github/workflows/test-jsx.yml
@@ -32,10 +32,12 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          node-version: "20"
+          persist-credentials: false
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
 
       - name: install jsx
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,23 +144,23 @@ jobs:
           if [ "${{ matrix.jupyverse }}" != "" ]; then
               echo "JUPYTERHUB_SINGLEUSER_APP=jupyverse" >> $GITHUB_ENV
           fi
-      - uses: actions/checkout@v6
-      # NOTE: actions/setup-node@v6 make use of a cache within the GitHub base
-      #       environment and setup in a fraction of a second.
-      - name: Install Node
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          node-version: "20"
+          persist-credentials: false
+
+      - name: Install Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+
       - name: Install Javascript dependencies
         run: |
           npm install
           npm install -g configurable-http-proxy yarn
           npm list
 
-      # NOTE: actions/setup-python@v6 make use of a cache within the GitHub base
-      #       environment and setup in a fraction of a second.
       - name: Install Python ${{ matrix.python }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
           cache: pip
@@ -265,4 +265,4 @@ jobs:
         run: |
           pytest -k "${{ matrix.subset }}" --maxfail=2 --cov=jupyterhub jupyterhub/tests
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,14 @@ repos:
         files: ".*templates/.*.html"
         types_or: ["html"]
 
+  # github actions security checks
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.23.1
+    hooks:
+      - id: zizmor
+        args:
+          - --fix
+
   # Autoformat and linting, misc. details
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,0 +1,12 @@
+rules:
+  cache-poisoning:
+    # only care about cache poisoning in release workflow
+    ignore:
+      - test.yml
+      - test-docs.yml
+      - test-jsx.yml
+  unpinned-uses:
+    config:
+      policies:
+        jupyterhub/*: ref-pin
+        manics/*: ref-pin


### PR DESCRIPTION
I think @manics has maybe used this the most and might have advice

It's probably most important to run this on release workflow (we try to avoid credentials in most workflows), but the per-file configuration is lacking.

For example, I'd be okay with ignoring the artipacked rule everywhere but release, and allowing ref-pin everywhere but release as well. But the configuration doesn't seem to have the appropriate granularity to run with a different policies per workflow.

What I'd really like is a policy like:

- be super strict on release.yml
- be more lax in test workflows **BUT** keep ensuring that they have no credentials to leak (i.e. enforce `contents:read`)

which is basically what we had, but not enforced. I'm not sure there's an easy way to get this, though.