### PR TITLE
Fix red color of failed progress bar

### DIFF
--- a/share/jupyterhub/templates/spawn_pending.html
+++ b/share/jupyterhub/templates/spawn_pending.html
@@ -123,7 +123,7 @@
         if (evt.failed) {
           evtSource.close();
           // turn progress bar red
-          progressBar.addClass('progress-bar-danger');
+          progressBar.addClass('bg-danger');
           // open event log for debugging
           $('#progress-details').prop('open', true);
         }


### PR DESCRIPTION
Due to the [Bootstrap update](https://jupyterhub.readthedocs.io/en/5.2.1/howto/upgrading-v5.html#bootstrap-5) in JupyterHub `5.x`, the class name of the red progress bar changed from `progress-bar-danger` to `bg-danger`.

I didn't find a changelog but the docs of the versions [v3.4](https://getbootstrap.com/docs/3.4/components/#progress-alternatives) and [v5.3](https://getbootstrap.com/docs/5.3/components/progress/#backgrounds) reflect this change. 