### PR TITLE
Prevent treating a role as 'stale' if defined in load_managed_roles

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1589,7 +1589,8 @@ class JupyterHub(Application):
     handlers = List()
 
     config_role_names = List(
-        [], help = "Cached list of authenticator-managed roles loaded by load_managed_roles on startup"
+        [],
+        help="Cached list of authenticator-managed roles loaded by load_managed_roles on startup",
     )
 
     _log_formatter_cls = CoroutineLogFormatter

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1588,6 +1588,10 @@ class JupyterHub(Application):
 
     handlers = List()
 
+    config_role_names = List(
+        [], help = "Cached list of authenticator-managed roles loaded by load_managed_roles on startup"
+    )
+
     _log_formatter_cls = CoroutineLogFormatter
     http_server = None
     proxy_process = None
@@ -2342,10 +2346,9 @@ class JupyterHub(Application):
             for role in managed_roles:
                 role['managed_by_auth'] = True
             roles_to_load.extend(managed_roles)
-
         self.log.debug('Loading roles into database')
         default_roles = roles.get_default_roles()
-        config_role_names = [r['name'] for r in roles_to_load]
+        self.config_role_names = [r['name'] for r in roles_to_load]
 
         default_roles_dict = {role["name"]: role for role in default_roles}
         init_roles = []
@@ -2364,7 +2367,7 @@ class JupyterHub(Application):
                 role_spec = merged_role_spec
 
             # Check for duplicates
-            if config_role_names.count(role_name) > 1:
+            if self.config_role_names.count(role_name) > 1:
                 raise ValueError(
                     f"Role {role_name} multiply defined. Please check the `load_roles` configuration"
                 )
@@ -3299,6 +3302,7 @@ class JupyterHub(Application):
             eventlog=self.eventlog,
             app=self,
             xsrf_cookies=True,
+            config_role_names=self.config_role_names,
         )
         # allow configured settings to have priority
         settings.update(self.tornado_settings)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -948,7 +948,7 @@ class BaseHandler(RequestHandler):
         if self.authenticator.manage_roles:
             auth_roles = authenticated.get("roles")
             if auth_roles is not None:
-                await user.sync_roles(auth_roles)
+                user.sync_roles(auth_roles)
         # always set auth_state and commit,
         # because there could be key-rotation or clearing of previous values
         # going on.

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -948,7 +948,7 @@ class BaseHandler(RequestHandler):
         if self.authenticator.manage_roles:
             auth_roles = authenticated.get("roles")
             if auth_roles is not None:
-                user.sync_roles(auth_roles)
+                await user.sync_roles(auth_roles)
         # always set auth_state and commit,
         # because there could be key-rotation or clearing of previous values
         # going on.

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -392,7 +392,9 @@ class User:
             .all()
         )
         # prevent deletion of role scopes that are explicitly defined in auth.load_managed_roles()
-        predef_managed_roles = [r.get('name') for r in await self.authenticator.load_managed_roles() or []]
+        predef_managed_roles = [
+            r.get('name') for r in await self.authenticator.load_managed_roles() or []
+        ]
 
         for stripped_role in managed_stripped_roles:
             if (

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -392,7 +392,7 @@ class User:
             .all()
         )
         # prevent deletion of role scopes that are explicitly defined in auth.load_managed_roles()
-        predef_managed_roles = [r.get('name') for r in await self.authenticator.load_managed_roles()]
+        predef_managed_roles = [r.get('name') for r in await self.authenticator.load_managed_roles() or []]
 
         for stripped_role in managed_stripped_roles:
             if (

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -301,7 +301,7 @@ class User:
             self.orm_user.groups = []
         self.db.commit()
 
-    async def sync_roles(self, auth_roles):
+    def sync_roles(self, auth_roles):
         """Synchronize roles with database"""
         auth_roles_by_name = {role['name']: role for role in auth_roles}
 
@@ -391,17 +391,13 @@ class User:
             )
             .all()
         )
-        # prevent deletion of role scopes that are explicitly defined in auth.load_managed_roles()
-        predef_managed_roles = [
-            r.get('name') for r in await self.authenticator.load_managed_roles() or []
-        ]
 
         for stripped_role in managed_stripped_roles:
             if (
                 not stripped_role.users
                 and not stripped_role.services
                 and not stripped_role.groups
-                and not stripped_role.name in predef_managed_roles
+                and not stripped_role.name in self.settings.get('config_role_names')
             ):
                 self.db.delete(stripped_role)
 

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -301,7 +301,7 @@ class User:
             self.orm_user.groups = []
         self.db.commit()
 
-    def sync_roles(self, auth_roles):
+    async def sync_roles(self, auth_roles):
         """Synchronize roles with database"""
         auth_roles_by_name = {role['name']: role for role in auth_roles}
 
@@ -391,11 +391,15 @@ class User:
             )
             .all()
         )
+        # prevent deletion of role scopes that are explicitly defined in auth.load_managed_roles()
+        predef_managed_roles = [r.get('name') for r in await self.authenticator.load_managed_roles()]
+
         for stripped_role in managed_stripped_roles:
             if (
                 not stripped_role.users
                 and not stripped_role.services
                 and not stripped_role.groups
+                and not stripped_role.name in predef_managed_roles
             ):
                 self.db.delete(stripped_role)
 


### PR DESCRIPTION
This PR is an attempt to address https://github.com/jupyterhub/jupyterhub/issues/5306.

Currently, if a role is removed from a user by `user.sync_roles`, and the role has no other remaining members, then the role and its scopes are deleted from the Hub database. This happens even if the role's scopes are defined in the authenticator's `load_managed_roles`, which can lead to a situation where the Hub needs to be rebooted to restore the role's scopes.

With this commit, if the role is defined in `auth.load_managed_roles`, it will not be considered as 'stale' when being removed from a user (by the same logic as the handling of 'stale' authenticator-managed roles in `app.init_role_creation`), and so its scopes are preserved.

The slight side effect is that the "sync_roles" function has to be redefined as async to be able to call the  `load_managed_roles` coroutine, and so the call in `handlers/base.py` also becomes an `await` - I couldn't find a clean way to avoid this redefinition, but the change seems minimal since it's only called in this one place.