### PR TITLE
Add browser test for named servers with forms

### DIFF
--- a/jupyterhub/tests/browser/conftest.py
+++ b/jupyterhub/tests/browser/conftest.py
@@ -23,7 +23,9 @@ async def browser():
 def user_special_chars(app):
     """Fixture for creating a temporary user with special characters in the name"""
     user = add_user(app.db, app, name=new_username("testuser<'&\">"))
-    yield namedtuple('UserSpecialChars', ['user', 'urlname'])(
+    yield namedtuple('UserSpecialChars', ['user', 'urlname', 'urlname_alt'])(
         user,
         user.name.replace("<'&\">", "%3C%27%26%22%3E"),
+        # Sometimes the URL only has partial escaping
+        user.name.replace("<'&\">", "%3C'&%22%3E"),
     )

--- a/jupyterhub/tests/browser/conftest.py
+++ b/jupyterhub/tests/browser/conftest.py
@@ -23,7 +23,7 @@ async def browser():
 def user_special_chars(app):
     """Fixture for creating a temporary user with special characters in the name"""
     user = add_user(app.db, app, name=new_username("testuser<'&\">"))
-    yield namedtuple('UserSpecialChars', ['user', 'urlname', 'urlname_alt'])(
+    yield namedtuple('UserSpecialChars', ['user', 'urlname', 'urlname_js'])(
         user,
         user.name.replace("<'&\">", "%3C%27%26%22%3E"),
         # Sometimes the URL only has partial escaping

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -364,7 +364,7 @@ async def test_spawn_named_server_with_form(
 
     user = user_special_chars.user
     urlname = user_special_chars.urlname
-    urlname_alt = user_special_chars.urlname_alt
+    urlname_js = user_special_chars.urlname_js
     entered_display_name = " <  🐧  > "
     expected_encoded_display_name = "%20%3C%20%20%F0%9F%90%A7%20%20%3E"
     expected_server_name = " <  🐧  >"
@@ -376,7 +376,7 @@ async def test_spawn_named_server_with_form(
     await browser.get_by_role("button", name="Add New Server").click()
 
     await browser.wait_for_url(
-        f"**/hub/spawn/{urlname_alt}/{expected_encoded_display_name}"
+        f"**/hub/spawn/{urlname_js}/{expected_encoded_display_name}"
     )
 
     await browser.get_by_role("textbox", name="energy").fill(entered_form_input)

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -366,9 +366,8 @@ async def test_spawn_named_server_with_form(
     urlname = user_special_chars.urlname
     urlname_alt = user_special_chars.urlname_alt
     entered_display_name = " <  🐧  > "
-    expected_display_name = "< 🐧 >"
-    expected_encoded_display_name = "%3C%20%F0%9F%90%A7%20%3E"
-    expected_server_name = "x-dc14c4a4"
+    expected_encoded_display_name = "%20%3C%20%20%F0%9F%90%A7%20%20%3E"
+    expected_server_name = " <  🐧  >"
 
     entered_form_input = "😇 <&!&> 😇"
 
@@ -377,13 +376,13 @@ async def test_spawn_named_server_with_form(
     await browser.get_by_role("button", name="Add New Server").click()
 
     await browser.wait_for_url(
-        f"**/hub/spawn/{urlname_alt}/{expected_server_name}?display_name={expected_encoded_display_name}"
+        f"**/hub/spawn/{urlname_alt}/{expected_encoded_display_name}"
     )
 
     await browser.get_by_role("textbox", name="energy").fill(entered_form_input)
     await browser.get_by_role("button", name="Start").click()
 
-    await browser.wait_for_url(f"**/user/{urlname}/{expected_server_name}/")
+    await browser.wait_for_url(f"**/user/{urlname}/{expected_encoded_display_name}/")
 
     user_server_env_url = url_path_join(
         public_url(app, user), expected_server_name, "/env"

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -353,6 +353,46 @@ async def test_spawn_pending_server_ready(app, browser, user_special_chars):
     await expect(stop_start_btns.nth(1)).to_have_id("start")
 
 
+async def test_spawn_named_server_with_form(
+    app,
+    browser,
+    user_special_chars,
+    form_spawn,
+    named_servers,  # noqa: F811
+):
+    """verify that a new named server with special characters is slugified and launched with custom form inputs"""
+
+    user = user_special_chars.user
+    urlname = user_special_chars.urlname
+    urlname_alt = user_special_chars.urlname_alt
+    entered_display_name = " <  🐧  > "
+    expected_display_name = "< 🐧 >"
+    expected_encoded_display_name = "%3C%20%F0%9F%90%A7%20%3E"
+    expected_server_name = "x-dc14c4a4"
+
+    entered_form_input = "😇 <&!&> 😇"
+
+    await login_home(browser, app, user.name)
+    await browser.get_by_role("textbox", name="server name").fill(entered_display_name)
+    await browser.get_by_role("button", name="Add New Server").click()
+
+    await browser.wait_for_url(
+        f"**/hub/spawn/{urlname_alt}/{expected_server_name}?display_name={expected_encoded_display_name}"
+    )
+
+    await browser.get_by_role("textbox", name="energy").fill(entered_form_input)
+    await browser.get_by_role("button", name="Start").click()
+
+    await browser.wait_for_url(f"**/user/{urlname}/{expected_server_name}/")
+
+    user_server_env_url = url_path_join(
+        public_url(app, user), expected_server_name, "/env"
+    )
+    response = await browser.goto(user_server_env_url)
+    env = await response.json()
+    assert env["ENERGY"] == entered_form_input
+
+
 # HOME PAGE
 
 

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -499,6 +499,13 @@ def slow_bad_spawn(app):
 
 
 @fixture
+def form_spawn(app):
+    """Fixture enabling FormSpawner"""
+    with mock.patch.dict(app.tornado_settings, {'spawner_class': mocking.FormSpawner}):
+        yield
+
+
+@fixture
 def create_temp_role(app):
     """Generate a temporary role with certain scopes.
     Convenience function that provides setup, database handling and teardown"""

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -38,7 +38,7 @@ from urllib.parse import urlparse
 from pamela import PAMError
 from sqlalchemy import event
 from tornado.httputil import url_concat
-from traitlets import Bool, Dict, default
+from traitlets import Bool, Dict, Unicode, default
 
 from .. import metrics, orm, roles
 from ..app import JupyterHub
@@ -153,10 +153,28 @@ class SlowBadSpawner(MockSpawner):
         raise RuntimeError("I don't work!")
 
 
+class CustomInputSpawner(SlowSpawner):
+    """A spawner that can be used to test custom form inputs by requesting /env"""
+
+    form_input = Unicode()
+
+    def get_env(self):
+        env = super().get_env()
+        env["FORM_INPUT"] = self.form_input
+        return env
+
+
 class FormSpawner(MockSpawner):
     """A spawner that has an options form defined"""
 
-    options_form = "IMAFORM"
+    energy = Unicode(help="field that is set as an environment variable for testing")
+
+    # Only one of the form fields is used in browser UI tests
+    options_form = """
+        <input aria-label="energy" name="energy" type="text" value=""/>
+    """
+
+    apply_user_options = {"energy": "energy"}
 
     def options_from_form(self, form_data):
         options = {'notspecified': 5}
@@ -170,6 +188,11 @@ class FormSpawner(MockSpawner):
         if 'illegal_argument' in form_data:
             raise ValueError("You are not allowed to specify 'illegal_argument'")
         return options
+
+    def get_env(self):
+        env = super().get_env()
+        env["ENERGY"] = self.energy
+        return env
 
 
 class FalsyCallableFormSpawner(FormSpawner):


### PR DESCRIPTION
Whilst working on https://github.com/jupyterhub/jupyterhub/pull/5192 I discovered we don't have a full test for named servers with forms.

There's a discrepancy in how the username `testuser<'&\">` is escaped, it's different for `/hub/spawn/` (`'&` is not escaped) and `/user/`
- `/hub/spawn/testuser%3C'&%22%3E/{expected_encoded_display_name}`, uses default javascript escaping https://github.com/jupyterhub/jupyterhub/blob/f8188bedd678c17b0342bfc48705eecfeadccd83/share/jupyterhub/static/js/home.js#L51
- `/user/testuser%3C%27%26%22%3E/{expected_encoded_display_name}/`
