### PR TITLE
Revert "ci: temporary pin-down cryptography"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
             # make sure our `>=` pins really do express our minimum supported versions
             pip install -r ci/oldest-dependencies/requirements.old -e .
           else
-            pip install --pre -e ".[test]" "pycurl; python_version >= '3.10'" 'cryptography<47'
+            pip install --pre -e ".[test]" "pycurl; python_version >= '3.10'"
           fi
 
           if [ "${{ matrix.main_dependencies }}" != "" ]; then


### PR DESCRIPTION
Reverts jupyterhub/jupyterhub#5351 unpins cryptography

certipy 0.2.3 fixed the issue, should work fine, now