### PR TITLE
browser tests: increase default expect timeout to 30s

### DIFF
--- a/jupyterhub/tests/browser/conftest.py
+++ b/jupyterhub/tests/browser/conftest.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 import pytest
-from playwright.async_api import async_playwright
+from playwright.async_api import async_playwright, expect
 
 from ..conftest import add_user, new_username
 
@@ -12,7 +12,10 @@ async def browser():
     async with async_playwright() as playwright:
         browser = await playwright.firefox.launch(headless=True)
         context = await browser.new_context()
+        # context sets default timeout for a lot of things, but not expect
         context.set_default_timeout(30_000)
+        # default timeout for expect
+        expect.set_options(timeout=30_000)
         page = await context.new_page()
         yield page
         await context.clear_cookies()

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -596,6 +596,11 @@ async def test_token_form_expires_in(
         await open_token_page(app, browser, user_special_chars.user)
     # check the list of tokens duration
     dropdown = browser.locator('#token-expiration-seconds')
+    # wait for options to load
+    options = await expect(dropdown.locator('option')).to_have_count(
+        len(expected_options)
+    )
+
     options = await dropdown.locator('option').all()
     actual_values = [
         (await option.text_content(), await option.get_attribute('value'))

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -1386,9 +1386,7 @@ async def test_start_stop_server_on_admin_page(
 
     # click on Start button
     await click_start_server(browser, user1.name)
-    await expect(browser.get_by_role("button", name="Stop Server")).to_have_count(
-        1, timeout=30_000
-    )
+    await expect(browser.get_by_role("button", name="Stop Server")).to_have_count(1)
     await expect(browser.get_by_role("button", name="Start Server")).to_have_count(
         len(users_list) - 1
     )

--- a/jupyterhub/tests/browser/test_browser.py
+++ b/jupyterhub/tests/browser/test_browser.py
@@ -729,25 +729,26 @@ async def test_request_token_expiration(
     )
     assert last_used_text == "Never"
 
-    expires_at_text = (
-        await api_token_table_area.locator("tr.token-row")
-        .get_by_role("cell")
-        .nth(4)
-        .text_content()
+    # flaky: moment rendering is async
+    expires_at_cell = (
+        api_token_table_area.locator("tr.token-row").get_by_role("cell").nth(4)
     )
 
     if token_opt == "Never":
         assert orm_token.expires_at is None
-        assert expires_at_text == "Never"
+        expires_at_text = "Never"
     elif token_opt == "1 Hour":
-        assert expires_at_text == "in an hour"
+        expires_at_text = "in an hour"
     elif token_opt == "1 Day":
-        assert expires_at_text == "in a day"
+        expires_at_text = "in a day"
     elif token_opt == "1 Week":
-        assert expires_at_text == "in 7 days"
+        expires_at_text = "in 7 days"
     elif token_opt == "server_up":
         assert orm_token.expires_at is None
-        assert expires_at_text == "Never"
+        expires_at_text = "Never"
+
+    await expect(expires_at_cell).to_have_text(expires_at_text)
+
     # verify that the button for revoke is presented
     revoke_btn = (
         api_token_table_area.locator("tr.token-row").get_by_role("button").nth(0)


### PR DESCRIPTION
I believe the 5s timeout is causing flaky tests because everything is super slow on CI, so bump it to 30s. I _thought_ we were already doing this, because `set_default_timeout` [says](https://playwright.dev/python/docs/api/class-browsercontext#browser-context-set-default-timeout) it affects "all the methods accepting [timeout](https://playwright.dev/python/docs/api/class-browsercontext#browser-context-set-default-timeout-option-timeout) option," but that apparently doesn't include `expect`.

also update a test reliant on async `moment` rendering to use expect rather than a one-time retrieval of text content, which I saw fail when I was testing this.

I think this might close #5361 and possibly a few other browser tests that seem to have become flaky, but shouldn't replace #5362, which is also an improvement.