### PR TITLE
Re-use Browser instance across tests

### DIFF
--- a/jupyterhub/tests/browser/conftest.py
+++ b/jupyterhub/tests/browser/conftest.py
@@ -11,24 +11,6 @@ async def _browser():
     # browser_type in ["chromium", "firefox", "webkit"]
     async with async_playwright() as playwright:
         browser = await playwright.firefox.launch(headless=True)
-<<<<<<< HEAD
-        context = await browser.new_context()
-        # context sets default timeout for a lot of things, but not expect
-        context.set_default_timeout(30_000)
-        # default timeout for expect
-        expect.set_options(timeout=30_000)
-        page = await context.new_page()
-        yield page
-        await context.clear_cookies()
-        await browser.close()
-||||||| parent of a24e5300 (Split browser into 2 logical entities)
-        context = await browser.new_context()
-        context.set_default_timeout(30_000)
-        page = await context.new_page()
-        yield page
-        await context.clear_cookies()
-        await browser.close()
-=======
         yield browser
 
 
@@ -42,20 +24,7 @@ async def browser(_browser):
     page = await context.new_page()
     yield page
     await context.clear_cookies()
-<<<<<<< HEAD
-<<<<<<< HEAD
     await context.close()
->>>>>>> a24e5300 (Split browser into 2 logical entities)
-||||||| parent of f1f82b3c (increase default expect timeout to 30s)
-    await context.close()
-=======
-    await browser.close()
->>>>>>> f1f82b3c (increase default expect timeout to 30s)
-||||||| parent of f4747d64 (update close)
-    await browser.close()
-=======
-    await context.close()
->>>>>>> f4747d64 (update close)
 
 
 @pytest.fixture

--- a/jupyterhub/tests/browser/conftest.py
+++ b/jupyterhub/tests/browser/conftest.py
@@ -6,11 +6,12 @@ from playwright.async_api import async_playwright, expect
 from ..conftest import add_user, new_username
 
 
-@pytest.fixture()
-async def browser():
+@pytest.fixture(scope="module")
+async def _browser():
     # browser_type in ["chromium", "firefox", "webkit"]
     async with async_playwright() as playwright:
         browser = await playwright.firefox.launch(headless=True)
+<<<<<<< HEAD
         context = await browser.new_context()
         # context sets default timeout for a lot of things, but not expect
         context.set_default_timeout(30_000)
@@ -20,6 +21,41 @@ async def browser():
         yield page
         await context.clear_cookies()
         await browser.close()
+||||||| parent of a24e5300 (Split browser into 2 logical entities)
+        context = await browser.new_context()
+        context.set_default_timeout(30_000)
+        page = await context.new_page()
+        yield page
+        await context.clear_cookies()
+        await browser.close()
+=======
+        yield browser
+
+
+@pytest.fixture
+async def browser(_browser):
+    context = await _browser.new_context()
+    # context sets default timeout for a lot of things, but not expect
+    context.set_default_timeout(30_000)
+    # default timeout for expect
+    expect.set_options(timeout=30_000)
+    page = await context.new_page()
+    yield page
+    await context.clear_cookies()
+<<<<<<< HEAD
+<<<<<<< HEAD
+    await context.close()
+>>>>>>> a24e5300 (Split browser into 2 logical entities)
+||||||| parent of f1f82b3c (increase default expect timeout to 30s)
+    await context.close()
+=======
+    await browser.close()
+>>>>>>> f1f82b3c (increase default expect timeout to 30s)
+||||||| parent of f4747d64 (update close)
+    await browser.close()
+=======
+    await context.close()
+>>>>>>> f4747d64 (update close)
 
 
 @pytest.fixture

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@
 
 # automatically run coroutine tests with asyncio
 asyncio_mode = auto
-# use module-level loop scope (requires pytest-asyncio 0.24)
+# set to module scope for asyncio
 asyncio_default_fixture_loop_scope = module
 
 # jupyter_server plugin is incompatible with notebook imports


### PR DESCRIPTION
Draft test as a followup for playwright async fixture docs in #5363 