### PR TITLE
require jupyter-events >= 0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic>=1.4
 certipy>=0.1.2
 idna
 jinja2>=2.11.0
-jupyter_events
+jupyter_events>=0.11.0
 oauthlib>=3.0
 packaging
 pamela>=1.1.0; sys_platform != 'win32'


### PR DESCRIPTION
this is required for the change in version type from int to string.

Running with 0.10 leads to [validation errors expecting an integer](https://github.com/jupyterhub/roadmap/issues/12#issuecomment-4380745904).

cc @bl-aire 