### PR TITLE
ensure jupyterhub session id is set for cookie-authenticated requests

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -270,20 +270,25 @@ class BaseHandler(RequestHandler):
         """
         # cases:
         # 1. logged in, session id (session_id:user_id)
-        # 2. logged in, no session id (anonymous_id:user_id)
+        # 2. logged in, no session id (shouldn't happen!) sets new session id, same as 1.
         # 3. not logged in, session id (session_id:anonymous_id)
         # 4. no cookies at all, use single anonymous value (:anonymous_id)
         session_id = self.get_session_cookie()
         if self.current_user:
             if isinstance(self.current_user, User):
                 user_id = self.current_user.cookie_id
+                if not session_id:
+                    # this shouldn't happen if cookie-authenticated
+                    self.log.warning(
+                        "session id not set for %s, setting a new one",
+                        self.current_user.name,
+                    )
+                    self.set_session_cookie()
+                    session_id = self._session_id
             else:
                 # this shouldn't happen, but may if e.g. a Service attempts to fetch a page,
                 # which usually won't work, but this method should not be what raises
-                user_id = ""
-            if not session_id:
-                # no session id, use non-portable anonymous id
-                session_id = _anonymous_xsrf_id(self)
+                user_id = session_id = ""
         else:
             # not logged in yet, use non-portable anonymous id
             user_id = _anonymous_xsrf_id(self)
@@ -490,6 +495,7 @@ class BaseHandler(RequestHandler):
             # have cookie, but it's not valid. Clear it and start over.
             clear()
             return
+
         # update user activity
         if self._record_activity(user):
             self.db.commit()
@@ -503,7 +509,12 @@ class BaseHandler(RequestHandler):
 
     def get_current_user_cookie(self):
         """get_current_user from a cookie token"""
-        return self._user_for_cookie(self.hub.cookie_name)
+        user = self._user_for_cookie(self.hub.cookie_name)
+        if user and not self.get_session_cookie():
+            # make sure session cookie is set for cookie-authenticated requests
+            self.log.debug("Setting new session id for %s", user.name)
+            self.set_session_cookie()
+        return user
 
     async def get_current_user(self):
         """get current username"""
@@ -692,6 +703,8 @@ class BaseHandler(RequestHandler):
 
         Returns None if no session id is stored
         """
+        if hasattr(self, "_session_id"):
+            return self._session_id
         return self.get_cookie(SESSION_COOKIE_NAME, None)
 
     def set_session_cookie(self):

--- a/jupyterhub/tests/test_pages.py
+++ b/jupyterhub/tests/test_pages.py
@@ -1472,3 +1472,36 @@ async def test_spawn_fails_custom_message(app, user, kind, speed):
             assert "unhandle me" not in error.text
         else:
             raise ValueError(f"unexpected {kind=}")
+
+
+async def test_session_id(app):
+    # `cookies` is our request cookies
+    # `r.cookies` is the _new_ cookies set by any given response
+    cookies = await app.login_user('ursula')
+    # session id set on login
+    assert 'jupyterhub-session-id' in cookies
+    # cookie-authenticated request for any page without a session id
+    # sets a new session id cookie
+    cookies.pop("jupyterhub-session-id")
+    r = await async_requests.get(ujoin(public_url(app), "hub/token"), cookies=cookies)
+    assert r.ok
+    # requesting token page sets new session id and xsrf token
+    assert "_xsrf" in r.cookies
+    assert "jupyterhub-session-id" in r.cookies
+    for cookie in r.cookies:
+        cookies.pop(cookie.name, None)
+        cookies[cookie.name] = cookie.value
+
+    # second request for same page doesn't set any new cookies
+    r = await async_requests.get(ujoin(public_url(app), "hub/token"), cookies=cookies)
+    assert r.ok
+    assert not r.cookies
+
+    # POST a token with the cookies
+    r = await async_requests.post(
+        ujoin(public_url(app), f"hub/api/users/ursula/tokens?_xsrf={cookies['_xsrf']}"),
+        cookies=cookies,
+    )
+    assert r.ok
+    # request shouldn't set any new cookies
+    assert not r.cookies


### PR DESCRIPTION
if not set, session id cookie will be set on any cookie-authenticated request

#5385 was primarily caused by the xsrf behavior when no session-id is set. This ensures that any cookie-authenticated request will re-set the session-id cookie, rather than setting it only on login, which has other benefits for token revocation, etc.

It also prevents the use of the anonymous IP-sensitive value in the event of the session id not being set (which shouldn't happen anyway, but is possible if you mess with cookies in between page request and). This means you _will_ get an xsrf mismatch if you clear or change the session id between the page request and the form submission. This was already the case before, though, if session id was set on one request _or_ the other.

closes #5385 