### PR TITLE
docs: clarify upgrade-db subcommand vs --upgrade-db flag

### DIFF
--- a/docs/source/explanation/database.md
+++ b/docs/source/explanation/database.md
@@ -131,6 +131,13 @@ In general, you select your database backend with [](JupyterHub.db_url), and can
 - `jupyterhub upgrade-db` will execute a schema upgrade. You should backup your database before running this.
 - `jupyterhub downgrade-db` may be able to revert a schema upgrade on PostgreSQL and MySQL, but this is not guaranteed to work, and is not supported.
 
+JupyterHub exposes two related interfaces for running a schema upgrade. They are not the same:
+
+- The `jupyterhub upgrade-db` subcommand is a standalone action: it performs the schema upgrade and then exits without starting the Hub.
+- The `--upgrade-db` flag (passed to `jupyterhub`) starts the Hub normally and runs the schema upgrade during startup if one is needed.
+
+For most upgrades, prefer the `jupyterhub upgrade-db` subcommand so the migration runs as a discrete step that you can inspect before starting the Hub.
+
 ### SQLite
 
 The SQLite database should not be used on NFS. SQLite uses reader/writer locks

--- a/docs/source/howto/upgrading.md
+++ b/docs/source/howto/upgrading.md
@@ -107,6 +107,8 @@ jupyterhub upgrade-db
 This should find the location of your database, and run the necessary upgrades
 for it.
 
+The `jupyterhub upgrade-db` subcommand runs the schema upgrade and exits without starting the Hub. If you would rather have the upgrade run as part of starting the Hub, pass the `--upgrade-db` flag to `jupyterhub` instead, and the Hub will upgrade the schema during startup if one is needed.
+
 ### What happens if I delete my database?
 
 Losing the Hub database is often not a big deal. Information that


### PR DESCRIPTION
Fixes #2134.

In #2134, @Zsailer (member) said "I'll work on clarifying this distinction in docs as well." for the difference between `jupyterhub upgrade-db` (subcommand) and `jupyterhub --upgrade-db` (flag). The clarification was never added.

This adds a short note in two places where users already meet `upgrade-db`:

- `docs/source/explanation/database.md` — under "Upgrading the JupyterHub database", spell out that the subcommand exits after the schema upgrade while the flag runs the migration during Hub startup, and recommend the subcommand for most upgrades.
- `docs/source/howto/upgrading.md` — point out the flag as an alternative right after the existing `jupyterhub upgrade-db` step.

No code changes. Markdown only.
