### PR TITLE
fix dist artifact name in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: upload dists
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.repository.name }}-dist
+          name: ${{ github.event.repository.name }}-dist
           path: dist/
 
   pypi-publish:
@@ -93,7 +93,7 @@ jobs:
       - name: Get release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ github.repository.name }}-dist
+          name: ${{ github.event.repository.name }}-dist
           path: dist/
 
       - name: Publish to PyPI


### PR DESCRIPTION
it's github.event.repository.name, not github.repository.name. Did this ever work? Not sure, but I think so.