### PR TITLE
avoid logging traceback on HTTPError raised in spawn

### DIFF
--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -15,6 +15,7 @@ import pytest
 from dateutil.parser import parse as parse_date
 from pytest import fixture, mark
 from tornado.httputil import url_concat
+from tornado.web import HTTPError
 
 import jupyterhub
 
@@ -1248,6 +1249,33 @@ async def test_bad_spawn(app, bad_spawn):
     # check that we don't re-use spawners that failed
     spawner = user.spawners['']
     assert not getattr(spawner, 'reused', False)
+
+
+async def test_spawn_error_log(app, bad_spawn, caplog):
+    db = app.db
+    name = "castor"
+    user = add_user(db, app=app, name=name)
+
+    def pre_spawn_http(spawner):
+        raise HTTPError(418, "Teapot alert!")
+
+    def pre_spawn_unhandled(spawner):
+        raise ValueError("Not on my watch")
+
+    with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": pre_spawn_http}):
+        r = await api_request(app, 'users', name, 'server', method='post')
+    assert r.status_code == 418
+    assert "Traceback" not in caplog.text
+    assert r.json() == {"status": 418, "message": "Teapot alert!"}
+
+    with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": pre_spawn_unhandled}):
+        r = await api_request(app, 'users', name, 'server', method='post')
+    assert r.status_code == 500
+    assert r.json() == {"status": 500, "message": "error"}
+    # unhandled error logs a traceback
+    assert "Traceback" in caplog.text
+    # unhandled error logs a traceback
+    assert "Not on my watch" in caplog.text
 
 
 async def test_spawn_nosuch_user(app):

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -1002,6 +1002,12 @@ class User:
                 )
                 e.reason = 'timeout'
                 self.settings['statsd'].incr('spawner.failure.timeout')
+            elif isinstance(e, web.HTTPError):
+                # avoid logging noisy traceback on HTTPError,
+                # since this should be informative and will be relayed to the user
+                self.log.error(f"Error starting {self.name}'s server: {e}")
+                self.settings['statsd'].incr('spawner.failure.error')
+                e.reason = 'error'
             else:
                 self.log.exception(
                     f"Unhandled error starting {self.name}'s server: {e}"


### PR DESCRIPTION
HTTPErrors should be shown to users and logged more quietly. They are already relayed to users at the higher level, but the traceback part got logged here.

this is the simple bug part of #5357, only preventing tracebacks in the logs for HTTPError.

Being a simple bugfix means we can backport it for the next 5.x release.

The SpawnException can be done separately, since it won't be backported.