### PR TITLE
Fix some links that are permanently redirected in the linkcheck

### DIFF
--- a/docs/source/explanation/websecurity.md
+++ b/docs/source/explanation/websecurity.md
@@ -180,7 +180,7 @@ JupyterHub uses distinct xsrf tokens stored in cookies on each server path to at
 This has limitations because not all requests are protected by these XSRF tokens,
 and unless additional measures are taken, the XSRF tokens from other user prefixes may be retrieved.
 
-[Same-Origin Policy]: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
+[Same-Origin Policy]: https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Same-origin_policy
 
 For example:
 

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -176,7 +176,6 @@ Based on the Kubernetes deployment using [Z2JH](https://z2jh.jupyter.org/en/stab
 
 ### Google Cloud Platform
 
-- [Using Tensorflow and JupyterHub in Classrooms](https://cloud.google.com/solutions/using-tensorflow-jupyterhub-classrooms)
 - [using-tensorflow-and-jupyterhub blog post](https://opensource.googleblog.com/2016/10/using-tensorflow-and-jupyterhub.html)
 
 ### Everware

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -157,7 +157,7 @@ More than 10 general-purpose, and more than 20 course-specific environments are 
 
 ### bwJupyter for Teaching
 
-[bwJupyter](https://bwjupyter.de) is a collaboration between the [Karlsruhe Institute of Technology (KIT)](https://www.kit.edu/) and the [University of Stuttgart](https://www.uni-stuttgart.de/).
+[bwJupyter](https://www.bwjupyter.de) is a collaboration between the [Karlsruhe Institute of Technology (KIT)](https://www.kit.edu/) and the [University of Stuttgart](https://www.uni-stuttgart.de/).
 The project was funded by the Baden-Württemberg Ministry of Science, Research and Arts, and aims to provide a central JupyterHub for all universities in the state of Baden-Württemberg.
 In its first year of operation, over 7.700 active users from 40 universities were registered.
 


### PR DESCRIPTION
https://cloud.google.com/solutions/using-tensorflow-jupyterhub-classrooms is no longer relevant, the other links are straightforward