### PR TITLE
Fix upgrade-db crash in api_token_scopes data migration (#5427)

### DIFF
--- a/jupyterhub/alembic/versions/651f5419b74d_api_token_scopes.py
+++ b/jupyterhub/alembic/versions/651f5419b74d_api_token_scopes.py
@@ -31,7 +31,15 @@ def access_scopes(oauth_client: orm.OAuthClient, db: Session):
         return frozenset()
     spawner = oauth_client.spawner
     if spawner:
-        scopes.add(f"access:servers!server={spawner.user.name}/{spawner.name}")
+        # Avoid spawner.user.name: it lazy-loads the User ORM object, whose
+        # selectin relationships (User.roles, User.shared_with_me) reference
+        # columns/tables added in later schema versions (roles.managed_by_auth,
+        # shares) that do not exist yet at this migration step. Use raw SQL.
+        user_name = db.execute(
+            text("SELECT name FROM users WHERE id = :user_id"),
+            {"user_id": spawner.user_id},
+        ).scalar()
+        scopes.add(f"access:servers!server={user_name}/{spawner.name}")
     else:
         statement = "SELECT * FROM services WHERE oauth_client_id = :identifier"
         service = db.execute(
@@ -125,17 +133,19 @@ def upgrade():
             # oauth clients have allowed_roles, evaluate to allowed_scopes
             db = Session(bind=c)
             for oauth_client in db.query(orm.OAuthClient).options(
-                [
-                    selectinload(orm.OAuthClient.allowed_roles).defer(
-                        orm.Role.managed_by_auth
-                    ),
-                    # access_scopes() loads the orm.Spawner object, but the new
-                    # display_name column isn't added until a subsequent db upgrade
-                    # script runs, so we need to ignore the new column here
-                    selectinload(orm.OAuthClient.spawner).defer(
-                        orm.Spawner.display_name
-                    ),
-                ]
+                selectinload(orm.OAuthClient.allowed_roles).defer(
+                    orm.Role.managed_by_auth
+                ),
+                # access_scopes() loads the orm.Spawner object, but the new
+                # display_name column isn't added until a subsequent db upgrade
+                # script runs, so we need to ignore the new column here
+                selectinload(orm.OAuthClient.spawner).defer(
+                    orm.Spawner.display_name
+                ),
+                # block every other relationship load (e.g. Spawner.user ->
+                # User.roles / User.shared_with_me selectin) that would touch
+                # not-yet-existing schema — same guard as the api_tokens loop
+                raiseload("*"),
             ):
                 allowed_scopes = set(roles.roles_to_scopes(oauth_client.allowed_roles))
                 allowed_scopes.update(access_scopes(oauth_client, db))

--- a/jupyterhub/tests/populate_db.py
+++ b/jupyterhub/tests/populate_db.py
@@ -80,6 +80,21 @@ def populate_db(url):
         spawner.server = orm.Server()
         db.commit()
 
+        # per-server oauth client tied to a spawner
+        # regression coverage for jupyterhub/jupyterhub#5427: the api_token_scopes
+        # upgrade migration must resolve access_scopes() for a spawner's oauth
+        # client without lazy-loading future ORM relationships (User.roles,
+        # User.shared_with_me) that reference not-yet-existing schema.
+        # The spawner.oauth_client relationship was added in 2.0.
+        if jupyterhub.version_info >= (2,):
+            server_oauth_client = orm.OAuthClient(
+                identifier='jupyterhub-user-has-server'
+            )
+            db.add(server_oauth_client)
+            db.commit()
+            spawner.oauth_client = server_oauth_client
+            db.commit()
+
         # admin's spawner is not running
         spawner = orm.Spawner(name='', user=admin)
         db.add(spawner)


### PR DESCRIPTION
## Problem

Closes #5427.

Upgrading a **populated** database (e.g. 2.3.x → 5.x) crashes during alembic revision `651f5419b74d` (`api_token_scopes`) when an OAuth client has an associated spawner (i.e. a user who has started a server):

- `psycopg2.errors.UndefinedColumn: column roles.managed_by_auth does not exist`
- variant: `relation "shares" does not exist`

## Root cause

The `oauth_clients` data-migration loop calls `access_scopes(oauth_client, db)`, which accesses `spawner.user.name`. That lazy-loads the `User` ORM object, and `User` has `lazy="selectin"` relationships (`User.roles`, `User.shared_with_me`) that auto-fire on load. They select `roles.managed_by_auth` (added in 5.0) and the `shares` table (added in 5.x) — neither exists yet at this migration step.

Prior patches deferred individual columns (`Role.managed_by_auth`, `Spawner.display_name`) but never blocked the cascading `User` relationship loads.

## Fix

- **`access_scopes()`**: resolve the user name with raw SQL on `spawner.user_id` instead of the live ORM relationship, mirroring the existing services branch in the same function.
- **`oauth_clients` query loop**: pass loader options as `*args` (was incorrectly passed as a single list), defer `Spawner.display_name`, and add `raiseload("*")` so any remaining/future relationship load fails loudly instead of silently touching not-yet-existing schema — mirroring the safe `api_tokens` loop just above.
- **`tests/populate_db.py`**: tie a per-server OAuth client to the `has-server` spawner so `test_upgrade` actually exercises this path (regression coverage). Guarded on `version_info >= (2,)` since `Spawner.oauth_client` was added in 2.0.

## Verification

- `pytest jupyterhub/tests/test_db.py -k upgrade` — fails on the augmented `populate_db.py` before the fix, passes after, for all `hub_version` params.
- Reproduces the reported Postgres `UndefinedColumn` via `JUPYTERHUB_TEST_DB_URL`.

A matching PR targets the `5.x` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)