### PR TITLE
Remove/replace some broken links

### DIFF
--- a/docs/source/explanation/websecurity.md
+++ b/docs/source/explanation/websecurity.md
@@ -267,7 +267,4 @@ A handy website for testing your deployment is
 ## Vulnerability reporting
 
 If you believe you have found a security vulnerability in JupyterHub, or any
-Jupyter project, please report it to
-[security@ipython.org](mailto:security@ipython.org). If you prefer to encrypt
-your security reports, you can use [this PGP public
-key](https://jupyter.org/assets/ipython_security.asc).
+Jupyter project, please report it by following the guide on https://jupyter.org/security.

--- a/docs/source/reference/gallery-jhub-deployments.md
+++ b/docs/source/reference/gallery-jhub-deployments.md
@@ -64,7 +64,7 @@ easy to do with RStudio too.
 Within CERN, there are two noteworthy JupyterHub deployments in operation:
 
 - [SWAN](https://swan.web.cern.ch/swan/), which stands for Service for Web based Analysis, serves as an interactive data analysis platform primarily utilized at CERN.
-- [VRE](https://vre-hub.github.io/), which stands for Virtual Research Environment, is an analysis platform developed within the [EOSC Project](https://eoscfuture.eu/) to cater to the needs of scientific communities involved in European projects.
+- [VRE](https://vre-hub.github.io/) (Virtual Research Environment) is an analysis platform developed as part of [EOSC](https://eosc.eu/) to cater to the needs of scientific communities involved in European projects.
 
 ### Chameleon
 


### PR DESCRIPTION
Note this includes an change to the secvuln reporting section since we no longer have a GPG key https://github.com/jupyter/security/issues/121