### PR TITLE
Update README to reflect the minimum supported Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ for administration of the Hub and its users.
 ### Check prerequisites
 
 - A Linux/Unix based system
-- [Python](https://www.python.org/downloads/) 3.8 or greater
+- [Python](https://www.python.org/downloads/) 3.10 or greater
 - [nodejs/npm](https://www.npmjs.com/)
   - If you are using **`conda`**, the nodejs and npm dependencies will be installed for
     you by conda.


### PR DESCRIPTION
## Summary

Update the README installation prerequisites to match the project's current Python version requirement.

## Changes

- Updated the minimum supported Python version in `README.md` from **3.8** to **3.10**.

## Why

The README currently lists Python 3.8 or greater as a prerequisite, while `pyproject.toml` requires:

```toml
requires-python = ">=3.10"
```

This change keeps the documentation consistent with the project's package metadata and helps avoid confusion for users and contributors.