### PR TITLE
Invalid UTF-8 JSON request body returns HTTP 500 instead of HTTP 400

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -112,12 +112,12 @@ class APIHandler(BaseHandler):
         """Return the body of the request as JSON data."""
         if not self.request.body:
             return None
+        body = self.request.body.strip().decode("utf-8", "replace")
 
         try:
-            body = self.request.body.strip().decode('utf-8')
             model = json.loads(body)
         except Exception:
-            self.log.debug("Bad JSON bytes: %r", self.request.body)
+            self.log.debug("Bad JSON: %r", body)
             self.log.error("Couldn't parse JSON", exc_info=True)
             raise web.HTTPError(400, 'Invalid JSON in body of request')
         return model

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -112,11 +112,12 @@ class APIHandler(BaseHandler):
         """Return the body of the request as JSON data."""
         if not self.request.body:
             return None
-        body = self.request.body.strip().decode('utf-8')
+
         try:
+            body = self.request.body.strip().decode('utf-8')
             model = json.loads(body)
         except Exception:
-            self.log.debug("Bad JSON: %r", body)
+            self.log.debug("Bad JSON bytes: %r", self.request.body)
             self.log.error("Couldn't parse JSON", exc_info=True)
             raise web.HTTPError(400, 'Invalid JSON in body of request')
         return model

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -106,13 +106,6 @@ async def test_post_content_type(app, content_type, status):
 
 async def test_invalid_utf8_json_returns_400(app):
     """Sending invalid-UTF8 bytes with Content-Type: application/json should return 400."""
-    db = app.db
-    # ensure admin user exists
-    user = find_user(db, 'admin')
-    if user is None:
-        user = add_user(db, app, name='admin', admin=True)
-    cookies = await app.login_user('admin')
-
     # send invalid UTF-8 bytes as application/json
     r = await api_request(
         app,
@@ -120,7 +113,6 @@ async def test_invalid_utf8_json_returns_400(app):
         method='post',
         data=b'\xff\xfe',
         headers={'Content-Type': 'application/json'},
-        cookies=cookies,
     )
     assert r.status_code == 400
 

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -104,6 +104,27 @@ async def test_post_content_type(app, content_type, status):
     assert r.status_code == status
 
 
+async def test_invalid_utf8_json_returns_400(app):
+    """Sending invalid-UTF8 bytes with Content-Type: application/json should return 400."""
+    db = app.db
+    # ensure admin user exists
+    user = find_user(db, 'admin')
+    if user is None:
+        user = add_user(db, app, name='admin', admin=True)
+    cookies = await app.login_user('admin')
+
+    # send invalid UTF-8 bytes as application/json
+    r = await api_request(
+        app,
+        'users',
+        method='post',
+        data=b'\xff\xfe',
+        headers={'Content-Type': 'application/json'},
+        cookies=cookies,
+    )
+    assert r.status_code == 400
+
+
 @mark.parametrize("xsrf_in_url", [True, False, "invalid"])
 @mark.parametrize(
     "method, path",


### PR DESCRIPTION
Invalid UTF-8 request bodies with Content-Type: application/json currently raise a UnicodeDecodeError, resulting in an HTTP 500 response.

This change moves UTF-8 decoding into the existing error handling so malformed UTF-8 is treated as invalid JSON and returns HTTP 400 instead.

Testing

Added a regression test for invalid UTF-8 JSON requests.
Verified that the new test fails on the original implementation and passes with this change.
Ran jupyterhub/tests/test_api.py; all tests passed.