### PR TITLE
WIP: Introduce a hook to reinterpret an incoming request to /hub/spawn

### DIFF
--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -1772,6 +1772,27 @@ class JupyterHub(Application):
         """,
     ).tag(config=True)
 
+    spawn_intent_hook = Callable(
+        None,
+        allow_none=True,
+        help="""
+        Callable to reinterpret an incoming request to the /spawn page.
+
+        Receives 3 parameters:
+        1. user - the currently authenticated user
+        2. server_name - the route-derived server name ('' on the default
+           /hub/spawn page, the server name on /hub/spawn/:user/:server)
+        3. query - decoded GET query args (a dict of lists), with 'next' removed
+
+        It should return an optional dict with any of the keys:
+        - redirect_url - reinterpret the request and redirect here
+        - render_spawn_form - True to render the options form instead of
+          spawning directly from the query arguments
+
+        Return None or an empty dict to preserve current behavior.
+        """,
+    ).tag(config=True)
+
     use_legacy_stopped_server_status_code = Bool(
         False,
         help="""
@@ -3295,6 +3316,7 @@ class JupyterHub(Application):
             subdomain_host=self.subdomain_host,
             domain=self.domain,
             implicit_spawn_seconds=self.implicit_spawn_seconds,
+            spawn_intent_hook=self.spawn_intent_hook,
             allow_named_servers=self.allow_named_servers,
             default_server_name=self._default_server_name,
             named_server_limit_per_user=self.named_server_limit_per_user,

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -195,6 +195,16 @@ class SpawnHandler(BaseHandler):
             self.log.error(error_message)
             raise web.HTTPError(400, error_message)
 
+    async def run_spawn_intent_hook(self, user, server_name, query):
+        """Run the spawn_intent_hook if defined
+
+        Returns the hook's result dict (with optional 'redirect_url' and
+        'render_spawn_form' keys), or None if no hook is configured.
+        """
+        hook = self.settings.get('spawn_intent_hook')
+        if hook is not None:
+            return await maybe_future(hook(user, server_name, query))
+
     @needs_scope("servers")
     async def _get(self, user_name, server_name, display_name):
         for_user = user_name
@@ -204,6 +214,20 @@ class SpawnHandler(BaseHandler):
             user = self.find_user(for_user)
             if user is None:
                 raise web.HTTPError(404, f"No such user: {for_user}")
+
+        query = {
+            key: [b.decode('utf8') for b in byte_list]
+            for key, byte_list in self.request.query_arguments.items()
+        }
+        # 'next' is reserved argument for redirect after spawn
+        query.pop('next', None)
+
+        # a spawn_intent_hook may reinterpret the request: redirect it
+        # elsewhere, or render the options form instead of spawning directly
+        intent = await self.run_spawn_intent_hook(user, server_name, query)
+        if intent and intent.get('redirect_url'):
+            self.redirect(intent['redirect_url'])
+            return
 
         if server_name:
             await self._check_named_server_request(user, server_name, display_name)
@@ -241,19 +265,20 @@ class SpawnHandler(BaseHandler):
         await spawner.run_auth_state_hook(auth_state)
 
         # Try to start server directly when query arguments are passed.
-        query_options = {}
-        for key, byte_list in self.request.query_arguments.items():
-            query_options[key] = [bs.decode('utf8') for bs in byte_list]
-
-        # 'next' is reserved argument for redirect after spawn
-        query_options.pop('next', None)
+        query_options = dict(query)
 
         # display_name is reserved for jupyterhub
         query_options.pop('display_name', None)
 
+        spawn_now = len(query_options) > 0
+        # a spawn_intent_hook may ask to render the pre-filled options form
+        # instead of spawning directly from the query arguments
+        if intent and intent.get('render_spawn_form'):
+            spawn_now = False
+
         spawn_exc = None
 
-        if len(query_options) > 0:
+        if spawn_now:
             try:
                 self.log.debug(
                     "Triggering spawn with supplied query arguments for %s",


### PR DESCRIPTION
As we're discussing in https://github.com/jupyterhub/jupyterhub/issues/5459, we need a way to make sure we can render the spawn form on requests to /hub/spawn even when the default server is running.

This is a draft of one proposed approach where we introduce a new `spawn_intent_hook` that can decide whether to redirect the spawn request to an existing/new server or to render the spawn options form.

This gives the hook user the flexibility to decide whether:
- keep the current behavior and always redirect to the default server
- redirect to a running named server if it already exists
- or redirect to a new named server or some other custom behavior

For example, for the fancy-profiles use case, we can use a hook like this to make sure we can spawn a uniquely named named-server on every click of a permalink:

```
def spawn_intent_hook(user, server_name, query):
    """On GET /hub/spawn carrying the permalink payload, derive a unique named
    server and redirect to its spawn page (so each click gets its own server
    even when one is already running).
    """
    payload = query.get(PERMALINK_QUERY_PARAM)
    if not payload:
        return None
    if server_name:
        # already routed to the named server so we render the pre-filled form
        return {"render_spawn_form": True}
    name = new_unique_server_name(user, payload)
    target = url_path_join(
        user.settings.get("base_url", "/"), "hub", "spawn", user.escaped_name, name
    )
    return {"redirect_url": url_concat(target, {PERMALINK_QUERY_PARAM: payload[0]})}
 ```
 
 This also fixes https://github.com/jupyterhub/jupyterhub/issues/5101 as a side effect of us having more control over whether we render the form or spawn a server.