### PR TITLE
add JupyterHub.extra_user_scopes

### DIFF
--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -115,40 +115,88 @@ In case the role with a certain name already exists in the database, its definit
 
 Role definitions can include those of the "default" roles listed above (admin excluded),
 if the default scopes associated with those roles do not suit your deployment.
+
 For example, to specify what permissions the $JUPYTERHUB_API_TOKEN issued to all single-user servers
-has,
-define the `server` role.
+has, you may define the `server` role.
+However, starting with JupyterHub 4, it is recommended to use the {attr}`.Spawner.server_token_scopes` option for this instead.
 
 To restore the JupyterHub 1.x behavior of servers being able to do anything their owners can do,
 use the scope `inherit` (for 'inheriting' the owner's permissions):
 
 ```python
-c.JupyterHub.load_roles = [
- {
-   'name': 'server',
-   'scopes': ['inherit'],
- }
-]
+c.JupyterHub.server_token_scopes = {"inherit"}
 ```
 
 or, better yet, identify the specific [scopes][] you want server environments to have access to.
+If you choose to _restrict_ the server token, the one required scope for the server token `users:activity!user` will be added automatically.
 
-[scopes]: available-scopes-target
-
-If you don't want to get too detailed,
-one option is the `self` scope,
-which will have no effect on non-admin users,
-but will restrict the token issued to admin user servers to only have access to their own resources,
+If you don't want to get too detailed, one option is the `self` scope,
+which will restrict the token issued to admin user servers to only have access to their own resources,
 instead of being able to take actions on behalf of all other users.
 
 ```python
+c.JupyterHub.server_token_scopes = {"self"}
+```
+
+You can also override the default user role, to add _or remove_ permissions from all jupyterhub users by defining the `user` role.
+By default, the `user` role has only the `self` scope, allowing accessing and managing the user's own server:
+
+```python
 c.JupyterHub.load_roles = [
- {
-   'name': 'server',
-   'scopes': ['self'],
- }
+  {
+    "name": "user",
+    "scopes": [
+      "self",
+    ],
+  }
 ]
 ```
+
+If you override the user role, you can _restrict_ user permissions to less than this, e.g.
+
+```python
+c.JupyterHub.load_roles = [
+  {
+    "name": "user",
+    "scopes": [
+      "access:servers!user",
+      "users:activity!user",
+    ],
+  }
+]
+```
+
+which will allow users to access their own servers, but not start them (maybe you have some other mechanism you control for starting servers).
+
+If you want to _add_ to default user permissions, make sure to include the `self` scope, otherwise you might find yourself restricting users unintentionally.
+
+Starting with JupyterHub 6, there is now {attr}`.JupyterHub.extra_user_scopes` option,
+which only _adds_ to the default user scopes, so you don't need to override the default role with `load_roles` if expanding permissions is your goal.
+For example, to grant access to any JupyterHub service:
+
+```python
+c.JupyterHub.extra_user_scopes = {"access:services"}
+```
+
+which _adds_ the `access:services` scope to all users without overriding the default scopes in the `user` role.
+This is equivalent (in JupyterHub 6.0) to:
+
+```python
+c.JupyterHub.load_roles = [
+  {
+    "name": "user",
+    "scopes": [
+      "self",
+      "access:services",
+    ],
+  }
+]
+```
+
+but if a future JupyterHub release ever changes the default user role, the `extra_user_scopes` approach will continue to add `access:services` to the default, whatever the default may be,
+whereas the overridden `user` role will continue to have exactly the permissions defined in your configuration, no matter what the default changes to.
+
+[scopes]: available-scopes-target
 
 (removing-roles-target)=
 

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -196,6 +196,25 @@ c.JupyterHub.load_roles = [
 but if a future JupyterHub release ever changes the default user role, the `extra_user_scopes` approach will continue to add `access:services` to the default, whatever the default may be,
 whereas the overridden `user` role will continue to have exactly the permissions defined in your configuration, no matter what the default changes to.
 
+You cannot define scopes for the `user` role using `extra_user_scopes` and `load_roles` at the same time (there would be no reason to).
+If your config has both:
+
+```python
+c.JupyterHub.extra_user_scopes = {"access:services"}
+c.JupyterHub.load_roles = [
+  {
+    "name": "user",
+    "scopes": [
+      "self",
+      "access:servers!group=shared",
+    ],
+  }
+]
+```
+
+then `extra_user_scopes` will be ignored.
+If you are defining user scopes via `load_roles`, then that is the only list of scopes that will be considered.
+
 [scopes]: available-scopes-target
 
 (removing-roles-target)=

--- a/docs/source/rbac/roles.md
+++ b/docs/source/rbac/roles.md
@@ -116,7 +116,7 @@ In case the role with a certain name already exists in the database, its definit
 Role definitions can include those of the "default" roles listed above (admin excluded),
 if the default scopes associated with those roles do not suit your deployment.
 
-For example, to specify what permissions the $JUPYTERHUB_API_TOKEN issued to all single-user servers
+For example, to specify what permissions the `$JUPYTERHUB_API_TOKEN` issued to all single-user servers
 has, you may define the `server` role.
 However, starting with JupyterHub 4, it is recommended to use the {attr}`.Spawner.server_token_scopes` option for this instead.
 

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -353,6 +353,23 @@ class JupyterHub(Application):
         """,
     ).tag(config=True)
 
+    extra_user_scopes = Set(
+        Unicode(),
+        config=True,
+        help="""
+        Additional scopes to ADD to the default `user` role.
+        
+        Any scopes here will be **ADDED** to the `user` role, which affects all JupyterHub users.
+        Use this to grant all users additional permissions (e.g. `access:services`)
+        beyond what they have by default.
+
+        This option avoids the need to redefine the user role via `load_roles` in order to change default user permissions,
+        which can lead to removing scopes unintentionally.
+
+        .. versionadded:: 6.0
+        """,
+    )
+
     custom_scopes = Dict(
         key_trait=Unicode(),
         value_trait=Dict(
@@ -2363,6 +2380,10 @@ class JupyterHub(Application):
             roles_to_load.extend(managed_roles)
         self.log.debug('Loading roles into database')
         default_roles = roles.get_default_roles()
+        if self.extra_user_scopes:
+            for role in default_roles:
+                if role["name"] == "user":
+                    role["scopes"].extend(self.extra_user_scopes)
         self.config_role_names = [r['name'] for r in roles_to_load]
 
         default_roles_dict = {role["name"]: role for role in default_roles}
@@ -2373,6 +2394,16 @@ class JupyterHub(Application):
             self.log.debug("Loading role %s", role_name)
             if role_name in default_roles_dict:
                 self.log.debug("Overriding default role %s", role_name)
+                if role_name == "user" and "scopes" in role_spec:
+                    role_scopes = role_spec["scopes"]
+                    if self.extra_user_scopes:
+                        self.log.warning(
+                            f"user role overridden with scopes={role_scopes}, extra_user_scopes={self.extra_user_scopes} will be ignored."
+                        )
+                    if "self" not in role_scopes:
+                        self.log.warning(
+                            f"user role overridden with scopes={role_scopes}, which does not include 'self', users may lack necessary permissions. Consider setting `c.JupyterHub.extra_user_scopes` to add user permissions."
+                        )
                 # merge custom role spec with default role spec when overriding
                 # so the new role can be partially defined
                 default_role_spec = default_roles_dict.pop(role_name)

--- a/jupyterhub/tests/test_app.py
+++ b/jupyterhub/tests/test_app.py
@@ -17,6 +17,7 @@ import pytest
 import traitlets
 from traitlets.config import Config
 
+from jupyterhub.roles import get_default_roles
 from jupyterhub.scopes import get_scopes_for
 
 from .. import orm
@@ -503,6 +504,62 @@ async def test_user_creation(tmpdir, request):
         "in-group",
         "in-role",
     }
+
+
+@pytest.mark.db
+@pytest.mark.parametrize(
+    "extra_user_scopes, user_scopes, expected_warn",
+    [
+        pytest.param({"access:services"}, None, None, id="extra_user_scopes only"),
+        pytest.param(
+            None,
+            {"access:servers!user"},
+            "does not include 'self'",
+            id="user_role only",
+        ),
+        pytest.param(
+            {"access:services"},
+            {"access:servers!user"},
+            [
+                "will be ignored",
+                "extra_user_scopes={'",
+            ],
+            id="both set",
+        ),
+    ],
+)
+async def test_extra_user_scopes(caplog, extra_user_scopes, user_scopes, expected_warn):
+    roles = []
+    if user_scopes:
+        roles.append(
+            {
+                "name": "user",
+                "scopes": user_scopes,
+            }
+        )
+    cfg = Config()
+    cfg.JupyterHub.load_roles = roles
+    if extra_user_scopes:
+        cfg.JupyterHub.extra_user_scopes = extra_user_scopes
+
+    default_roles = {role['name']: role for role in get_default_roles()}
+    default_scopes = default_roles["user"]["scopes"]
+    hub = MockHub(config=cfg, log=logging.getLogger())
+    hub.init_db()
+    caplog.clear()
+    await hub.init_role_creation()
+    if user_scopes:
+        expected_scopes = user_scopes
+    else:
+        expected_scopes = set(default_scopes) | set(extra_user_scopes or [])
+    user_role = orm.Role.find(hub.db, "user")
+    assert set(user_role.scopes) == set(expected_scopes)
+    if expected_warn:
+        logged = "\n".join([f"{rec.levelname}:{rec.message}" for rec in caplog.records])
+        if not isinstance(expected_warn, list):
+            expected_warn = [expected_warn]
+        for message in expected_warn:
+            assert message in logged
 
 
 @pytest.mark.db


### PR DESCRIPTION
avoids need to redefine user role preserving default scopes to add permissions

closes #5446