### PR TITLE
add SpawnException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ node_modules
 dist
 docs/_build
 docs/build
-docs/source/reference/metrics.md
+docs/source/includes/metrics_table.md
 
 .ipynb_checkpoints
 .virtual_documents

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -40,8 +40,8 @@ html: metrics
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-metrics: source/reference/metrics.md
-source/reference/metrics.md:
+metrics: source/includes/metrics_table.md
+source/includes/metrics_table.md:
 	python3 generate-metrics.py
 
 

--- a/docs/generate-metrics.py
+++ b/docs/generate-metrics.py
@@ -27,18 +27,17 @@ class Generator:
         return table_rows
 
     def prometheus_metrics(self):
-        generated_directory = f"{HERE}/source/reference"
+        generated_directory = f"{HERE}/source/includes"
         if not os.path.exists(generated_directory):
             os.makedirs(generated_directory)
 
-        filename = f"{generated_directory}/metrics.md"
+        filename = f"{generated_directory}/metrics_table.md"
         table_name = ""
         headers = ["Type", "Name", "Description"]
         values = self._parse_metrics()
         writer = self.create_writer(table_name, headers, values)
 
         with open(filename, 'w') as f:
-            f.write("# List of Prometheus Metrics\n\n")
             f.write(writer.dumps())
             f.write("\n")
         print(f"Generated {filename}")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,10 @@ with pyproject_toml.open("rb") as f:
     pyproject = tomllib.load(f)
 
 
+exclude_patterns = [
+    "includes/*",
+]
+
 # -- MyST configuration ------------------------------------------------------
 # ref: https://myst-parser.readthedocs.io/en/latest/configuration.html
 #

--- a/docs/source/reference/api/spawner.md
+++ b/docs/source/reference/api/spawner.md
@@ -6,6 +6,12 @@
 .. automodule:: jupyterhub.spawner
 ```
 
+### {class}`SpawnException`
+
+```{eval-rst}
+.. autoclass:: SpawnException
+```
+
 ### {class}`Spawner`
 
 ```{eval-rst}

--- a/docs/source/reference/metrics.md
+++ b/docs/source/reference/metrics.md
@@ -6,4 +6,5 @@ and splits the previous `status=failure` into `status=error` for unhandled error
 ```
 
 ```{include} ../includes/metrics_table.md
+
 ```

--- a/docs/source/reference/metrics.md
+++ b/docs/source/reference/metrics.md
@@ -1,0 +1,9 @@
+# List of Prometheus Metrics
+
+```{versionchanged} 6.0
+`jupyterhub_server_spawn_duration_seconds` adds a `reason` label
+and splits the previous `status=failure` into `status=error` for unhandled errors and `status=failure` for rejected spawns, such as those which raise {class}`.SpawnException`.
+```
+
+```{include} ../includes/metrics_table.md
+```

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -139,7 +139,7 @@ Alternatively `.jupyterhub_message` is rendered as unformatted text.
 If both attributes are not present, an HTTPError's `message` is shown to the user.
 For other unhandled errors, a default "Internal Server Error" message will be given.
 
-raising an HTTPError and setting `.jupyterhub_message` and `.jupyterhub_html_message` will generally be equivalent to raising a SpawnException:
+Raising an HTTPError and setting `.jupyterhub_message` and `.jupyterhub_html_message` will generally be equivalent to raising a SpawnException:
 
 ```python
 from tornado.web import HTTPError

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -114,13 +114,47 @@ class MySpawner(Spawner):
 
 #### Exception handling
 
-When `Spawner.start` raises an Exception, a message can be passed on to the user via the exception using a `.jupyterhub_html_message` or `.jupyterhub_message` attribute.
+Spawn methods or hooks can raise a {class}`.SpawnException` for expected failures.
+SpawnException allows separately specifying:
 
-When the Exception has a `.jupyterhub_html_message` attribute, it will be rendered as HTML to the user.
+- `message` - the message to be shown to the user
+- `reason` - a label used in prometheus metrics to categorize spawn failures.
+  Should be short and have a limited number of unique values (such as 'timeout').
+- `message_html` - an HTML-formatted message, shown on HTML pages (e.g. the spawn error page).
+  Should have the same content as `message`, but may contain e.g. formatted links for follow-up.
+- `log_message` - a message used in logs (not shown to users)
 
+```{versionadded} 6.0
+SpawnException is new in JupyterHub 6.0.
+You can get much of this behavior prior to 6.0 by raising an {py:class}`~tornado.web.HTTPError`
+explicitly, rather than arbitrary unhandled errors.
+```
+
+When `Spawner.start` raises an {py:class}`~tornado.web.HTTPError`, a special message can be passed on to the user via the exception using a `.jupyterhub_html_message` and/or `.jupyterhub_message` attribute.
+If `.jupyterhub_message` is set, the default `message` will be logged, but not shown to the user.
+
+When the Exception has a `.jupyterhub_html_message` attribute, it will be rendered as HTML on user-facing pages.
 Alternatively `.jupyterhub_message` is rendered as unformatted text.
 
-If both attributes are not present, the Exception will be shown to the user as unformatted text.
+If both attributes are not present, an HTTPError's `message` is shown to the user.
+For other unhandled errors, a default "Internal Server Error" message will be given.
+
+raising an HTTPError and setting `.jupyterhub_message` and `.jupyterhub_html_message` will generally be equivalent to raising a SpawnException:
+
+```python
+from tornado.web import HTTPError
+e = web.HTTPError(400, "log message")
+e.jupyterhub_message = "user message"
+e.jupyterhub_html_message = "<b>user message!</b>"
+raise e
+```
+
+will behave the same as:
+
+```python
+from jupyterhub.spawner import SpawnException
+raise SpawnException("user message", reason="event", message_html="<b>user message!</b>", log_message="log_message", status_code=400)
+```
 
 ### Spawner.poll
 

--- a/docs/source/reference/spawners.md
+++ b/docs/source/reference/spawners.md
@@ -114,6 +114,12 @@ class MySpawner(Spawner):
 
 #### Exception handling
 
+```{versionadded} 6.0
+SpawnException is new in JupyterHub 6.0.
+You can get most of the same behavior prior to 6.0 by raising an {py:class}`~tornado.web.HTTPError`
+explicitly, rather than arbitrary unhandled errors.
+```
+
 Spawn methods or hooks can raise a {class}`.SpawnException` for expected failures.
 SpawnException allows separately specifying:
 
@@ -123,12 +129,6 @@ SpawnException allows separately specifying:
 - `message_html` - an HTML-formatted message, shown on HTML pages (e.g. the spawn error page).
   Should have the same content as `message`, but may contain e.g. formatted links for follow-up.
 - `log_message` - a message used in logs (not shown to users)
-
-```{versionadded} 6.0
-SpawnException is new in JupyterHub 6.0.
-You can get much of this behavior prior to 6.0 by raising an {py:class}`~tornado.web.HTTPError`
-explicitly, rather than arbitrary unhandled errors.
-```
 
 When `Spawner.start` raises an {py:class}`~tornado.web.HTTPError`, a special message can be passed on to the user via the exception using a `.jupyterhub_html_message` and/or `.jupyterhub_message` attribute.
 If `.jupyterhub_message` is set, the default `message` will be logged, but not shown to the user.

--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -14,6 +14,7 @@ from tornado import web
 from .. import orm
 from ..handlers import BaseHandler
 from ..scopes import get_scopes_for
+from ..spawner import SpawnException
 from ..utils import isoformat, url_escape_path, url_path_join
 
 PAGINATION_MEDIA_TYPE = "application/jupyterhub-pagination+json"
@@ -129,16 +130,17 @@ class APIHandler(BaseHandler):
         status_message = responses.get(status_code, 'Unknown Error')
         if exc_info:
             exception = exc_info[1]
-            # get the custom message, if defined
-            try:
-                message = exception.log_message % exception.args
-            except Exception:
-                pass
+            if isinstance(exception, SpawnException):
+                log_message = exception.log_message
+                message = exception.message
+                reason = exception.reason
+            elif isinstance(exception, web.HTTPError):
+                message = exception.get_message()
+                reason = exception.reason
+                status_message = reason or message
 
-            # construct the custom reason, if defined
-            reason = getattr(exception, 'reason', '')
-            if reason:
-                status_message = reason
+            # get special jupyterhub_message, if defined
+            message = getattr(exception, "jupyterhub_message", message)
 
         if exception and isinstance(exception, SQLAlchemyError):
             try:

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1071,7 +1071,7 @@ class BaseHandler(RequestHandler):
 
         if concurrent_spawn_limit and spawn_pending_count >= concurrent_spawn_limit:
             SERVER_SPAWN_DURATION_SECONDS.labels(
-                status=ServerSpawnStratus.failure,
+                status=ServerSpawnStatus.failure,
                 reason=ServerSpawnFailureReason.throttled,
             ).observe(time.perf_counter() - spawn_start_time)
             # Suggest number of seconds client should wait before retrying

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -43,11 +43,12 @@ from ..metrics import (
     LoginStatus,
     ProxyDeleteStatus,
     ServerPollStatus,
+    ServerSpawnFailureReason,
     ServerSpawnStatus,
     ServerStopStatus,
 )
 from ..objects import Server
-from ..spawner import LocalProcessSpawner
+from ..spawner import LocalProcessSpawner, SpawnException
 from ..user import User
 from ..utils import (
     AnyTimeoutError,
@@ -1049,7 +1050,8 @@ class BaseHandler(RequestHandler):
         if server_name in user.spawners and user.spawners[server_name].pending:
             pending = user.spawners[server_name].pending
             SERVER_SPAWN_DURATION_SECONDS.labels(
-                status=ServerSpawnStatus.already_pending
+                status=ServerSpawnStatus.failure,
+                reason=ServerSpawnFailureReason.already_pending,
             ).observe(time.perf_counter() - spawn_start_time)
             raise RuntimeError(f"{user_server_name} pending {pending}")
 
@@ -1069,7 +1071,8 @@ class BaseHandler(RequestHandler):
 
         if concurrent_spawn_limit and spawn_pending_count >= concurrent_spawn_limit:
             SERVER_SPAWN_DURATION_SECONDS.labels(
-                status=ServerSpawnStatus.throttled
+                status=ServerSpawnStratus.failure,
+                reason=ServerSpawnFailureReason.throttled,
             ).observe(time.perf_counter() - spawn_start_time)
             # Suggest number of seconds client should wait before retrying
             # This helps prevent thundering herd problems, where users simply
@@ -1105,7 +1108,8 @@ class BaseHandler(RequestHandler):
         if active_server_limit and active_count >= active_server_limit:
             self.log.info('%s servers active, no space available', active_count)
             SERVER_SPAWN_DURATION_SECONDS.labels(
-                status=ServerSpawnStatus.too_many_users
+                status=ServerSpawnStatus.failure,
+                reason=ServerSpawnFailureReason.too_many_users,
             ).observe(time.perf_counter() - spawn_start_time)
             raise web.HTTPError(
                 429, "Active user limit exceeded. Try again in a few minutes."
@@ -1146,7 +1150,8 @@ class BaseHandler(RequestHandler):
                 "User %s took %.3f seconds to start", user_server_name, toc - tic
             )
             SERVER_SPAWN_DURATION_SECONDS.labels(
-                status=ServerSpawnStatus.success
+                status=ServerSpawnStatus.success,
+                reason=ServerSpawnFailureReason.none,
             ).observe(time.perf_counter() - spawn_start_time)
             self.eventlog.emit(
                 schema_id='https://schema.jupyter.org/jupyterhub/events/server-action',
@@ -1203,11 +1208,29 @@ class BaseHandler(RequestHandler):
                 self.settings['failure_count'] = 0
                 return
             # spawn failed, increment count and abort if limit reached
+            e = f.exception()
+            if isinstance(e, SpawnException):
+                status = ServerSpawnStatus.failure
+                reason = e.reason
+            elif isinstance(e, web.HTTPError) and e.status_code < 500:
+                status = ServerSpawnStatus.failure
+                # use default value
+                reason = e.reason or ServerSpawnFailureReason.none
+            elif isinstance(e, web.HTTPError) and e.status_code >= 500:
+                status = ServerSpawnStatus.error
+                reason = e.reason or ServerSpawnFailureReason.none
+            else:
+                status = ServerSpawnStatus.error
+                reason = ServerSpawnFailureReason.none
+
             SERVER_SPAWN_DURATION_SECONDS.labels(
-                status=ServerSpawnStatus.failure
+                status=status,
+                reason=reason,
             ).observe(time.perf_counter() - spawn_start_time)
             self.settings.setdefault('failure_count', 0)
-            self.settings['failure_count'] += 1
+            if status == ServerSpawnStatus.error:
+                # increment on error only, not on handled rejections
+                self.settings['failure_count'] += 1
             failure_count = self.settings['failure_count']
             failure_limit = spawner.consecutive_failure_limit
             if failure_limit and 1 < failure_count < failure_limit:
@@ -1261,7 +1284,8 @@ class BaseHandler(RequestHandler):
 
             if status is not None:
                 SERVER_SPAWN_DURATION_SECONDS.labels(
-                    status=ServerSpawnStatus.failure
+                    status=ServerSpawnStatus.error,
+                    reason="exited",
                 ).observe(time.perf_counter() - spawn_start_time)
 
                 # if it stopped, give the original spawn future a second chance to raise
@@ -1527,20 +1551,25 @@ class BaseHandler(RequestHandler):
         message_html = ''
         exception = None
         status_message = responses.get(status_code, 'Unknown HTTP Error')
+        reason = ''
         if exc_info:
             exception = exc_info[1]
-            # get the custom message, if defined
-            try:
-                message = exception.log_message % exception.args
-            except Exception:
-                pass
+            if isinstance(exception, SpawnException):
+                log_message = exception.log_message
+                message = exception.message
+                message_html = exception.message_html
+                reason = exception.reason
+            elif isinstance(exception, web.HTTPError):
+                message = exception.get_message()
+                reason = exception.reason
+                status_message = reason or message
+
             # allow custom html messages
             message_html = getattr(exception, "jupyterhub_html_message", "")
 
             # construct the custom reason, if defined
-            reason = getattr(exception, 'reason', '')
             if reason:
-                message = reasons.get(reason, reason)
+                message = reasons.get(reason, message)
 
             # get special jupyterhub_message, if defined
             message = getattr(exception, "jupyterhub_message", message)

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -1565,7 +1565,7 @@ class BaseHandler(RequestHandler):
                 status_message = reason or message
 
             # allow custom html messages
-            message_html = getattr(exception, "jupyterhub_html_message", "")
+            message_html = getattr(exception, "jupyterhub_html_message", message_html)
 
             # construct the custom reason, if defined
             if reason:

--- a/jupyterhub/handlers/pages.py
+++ b/jupyterhub/handlers/pages.py
@@ -17,6 +17,7 @@ from .. import __version__, orm
 from ..metrics import SERVER_POLL_DURATION_SECONDS, ServerPollStatus
 from ..scopes import describe_raw_scopes, needs_scope
 from ..slugs import is_valid_display_name, is_valid_safe_slug, normalise_unicode
+from ..spawner import SpawnException
 from ..utils import (
     format_exception,
     maybe_future,
@@ -423,7 +424,11 @@ class SpawnHandler(BaseHandler):
         # otherwise it may cause a redirect loop
         if f.done() and f.exception():
             exc = f.exception()
-            self.log.exception(f"Error starting server {spawner._log_name}: {exc}")
+            if isinstance(exc, (web.HTTPError, SpawnException)):
+                log = self.log.error
+            else:
+                log = self.log.exception
+            log(f"Error starting server {spawner._log_name}: {exc}")
             if isinstance(exc, web.HTTPError):
                 # allow custom HTTPErrors to pass through
                 raise exc

--- a/jupyterhub/metrics.py
+++ b/jupyterhub/metrics.py
@@ -99,7 +99,7 @@ REQUEST_DURATION_SECONDS = Histogram(
 SERVER_SPAWN_DURATION_SECONDS = Histogram(
     'server_spawn_duration_seconds',
     'Time taken for server spawning operation',
-    ['status'],
+    ['status', 'reason'],
     # Use custom bucket sizes, since the default bucket ranges
     # are meant for quick running processes. Spawns can take a while!
     buckets=spawn_duration_buckets,
@@ -182,9 +182,23 @@ class ServerSpawnStatus(Enum):
 
     success = 'success'
     failure = 'failure'
-    already_pending = 'already-pending'
+    error = 'error'
+
+    def __str__(self):
+        return self.value
+
+
+class ServerSpawnFailureReason(Enum):
+    """Default values for enums
+
+    custom SpawnExceptions can also set arbitrary strings,
+    but these are the internal ones
+    """
+
+    none = ''
     throttled = 'throttled'
     too_many_users = 'too-many-users'
+    already_pending = 'already-pending'
 
     def __str__(self):
         return self.value
@@ -192,8 +206,13 @@ class ServerSpawnStatus(Enum):
 
 for s in ServerSpawnStatus:
     # Create empty metrics with the given status
-    SERVER_SPAWN_DURATION_SECONDS.labels(status=s)
+    SERVER_SPAWN_DURATION_SECONDS.labels(status=s, reason=ServerSpawnFailureReason.none)
 
+for reason in ServerSpawnFailureReason:
+    # Create empty metrics with the given failure reason
+    SERVER_SPAWN_DURATION_SECONDS.labels(
+        status=ServerSpawnStatus.failure, reason=reason
+    )
 
 PROXY_ADD_DURATION_SECONDS = Histogram(
     'proxy_add_duration_seconds',

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -75,6 +75,76 @@ def _quote_safe(s):
         return repr(s)
 
 
+class SpawnException(web.HTTPError):
+    """
+    An exception to raise when a policy failure prevents a spawn.
+
+    This is meant to help logging and metrics distinguish spawns that
+    should have been rejected due to e.g. invalid launch parameters
+    from spawns that fail due to unexpected errors that indicate possible
+    JupyterHub stability problems.
+
+    If a SpawnException is raised during spawn (including spawn hooks),
+    no traceback should be logged and the `status` shall be 'failure'.
+    The 'reason' label will be populated from the required reason keyword argument.
+
+
+    Args:
+        message (str, required):
+            The message that will be logged and returned to the user.
+        reason (str, required):
+            A short 'reason' label to categorize the failure.
+            This will be in the `reason` field for the spawn failure in metrics.
+        log_message (str):
+            The message which will be logged (not shown to the user),
+            if you want to log more detail than you show to the user.
+            Default: use message.
+        message_html (str):
+            An HTML-formatted message, for use in UI.
+            This allows you to display things like links in error message.
+            Default: use message, formatted as plain text
+            (will be escaped before displaying as HTML).
+        status_code (int):
+            HTTP status code that should be set for the error.
+            Default: 400.
+
+    Examples:
+
+    >>> raise SpawnException("invalid image", reason="image")
+    >>> raise SpawnException(
+            "Server is full",
+            reason="capacity",
+            message_html=f'Server is full. See <a href="{status_url}">status page</a> for more information',
+            status_code=503,
+        )
+
+    .. versionadded: 6.0
+    """
+
+    reason = ""
+    status_code = 400
+    message = ""
+    message_html = ""
+    log_message = ""
+
+    def __init__(
+        self, message, *, reason, log_message="", message_html="", status_code=400
+    ):
+        self.message = message
+        self.reason = reason
+        self.log_message = log_message or message
+        self.message_html = message_html
+        self.status_code = status_code
+        super().__init__(status_code, message, reason=reason)
+
+    # HTTPError interface
+    def get_message(self):
+        return self.log_message
+
+    def __str__(self):
+        return f"{self.status_code} {self.__class__.__name__}(reason={self.reason}): {self.log_message}"
+
+
 class Spawner(LoggingConfigurable):
     """Base class for spawning single-user notebook servers.
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -92,20 +92,20 @@ class SpawnException(web.HTTPError):
     Args:
         message (str, required):
             The message that will be logged and returned to the user.
-        reason (str, required):
+        reason (str, required, keyword-only):
             A short 'reason' label to categorize the failure.
             This will be in the `reason` field for the spawn failure in metrics.
             This must be a called with a named argument, e.g. `SpawnException("invalid image", reason="image")` and not `SpawnException("invalid image", "image")`
-        log_message (str):
+        log_message (str, keyword-only):
             The message which will be logged (not shown to the user),
             if you want to log more detail than you show to the user.
             Default: use message.
-        message_html (str):
+        message_html (str, keyword-only):
             An HTML-formatted message, for use in UI.
             This allows you to display things like links in error message.
             Default: use message, formatted as plain text
             (will be escaped before displaying as HTML).
-        status_code (int):
+        status_code (int, keyword-only):
             HTTP status code that should be set for the error.
             Default: 400.
 

--- a/jupyterhub/spawner.py
+++ b/jupyterhub/spawner.py
@@ -80,8 +80,8 @@ class SpawnException(web.HTTPError):
     An exception to raise when a policy failure prevents a spawn.
 
     This is meant to help logging and metrics distinguish spawns that
-    should have been rejected due to e.g. invalid launch parameters
-    from spawns that fail due to unexpected errors that indicate possible
+    should have been rejected due to policy failures, e.g. invalid launch parameters,
+    from spawns that error due to unexpected system errors that indicate possible
     JupyterHub stability problems.
 
     If a SpawnException is raised during spawn (including spawn hooks),
@@ -95,6 +95,7 @@ class SpawnException(web.HTTPError):
         reason (str, required):
             A short 'reason' label to categorize the failure.
             This will be in the `reason` field for the spawn failure in metrics.
+            This must be a called with a named argument, e.g. `SpawnException("invalid image", reason="image")` and not `SpawnException("invalid image", "image")`
         log_message (str):
             The message which will be logged (not shown to the user),
             if you want to log more detail than you show to the user.

--- a/jupyterhub/tests/conftest.py
+++ b/jupyterhub/tests/conftest.py
@@ -490,6 +490,15 @@ def bad_spawn(app):
 
 
 @fixture
+def custom_bad_spawn(app):
+    """Fixture enabling BadSpawner"""
+    with mock.patch.dict(
+        app.tornado_settings, {'spawner_class': mocking.CustomBadSpawner}
+    ):
+        yield
+
+
+@fixture
 def slow_bad_spawn(app):
     """Fixture enabling SlowBadSpawner"""
     with mock.patch.dict(

--- a/jupyterhub/tests/mocking.py
+++ b/jupyterhub/tests/mocking.py
@@ -38,12 +38,12 @@ from urllib.parse import urlparse
 from pamela import PAMError
 from sqlalchemy import event
 from tornado.httputil import url_concat
-from traitlets import Bool, Dict, Unicode, default
+from traitlets import Bool, Dict, Integer, Unicode, default
 
 from .. import metrics, orm, roles
 from ..app import JupyterHub
 from ..auth import PAMAuthenticator
-from ..spawner import SimpleLocalProcessSpawner
+from ..spawner import SimpleLocalProcessSpawner, SpawnException
 from ..utils import random_port, url_path_join, utcnow
 from .utils import AsyncSession, public_url, ssl_setup
 
@@ -143,6 +143,19 @@ class BadSpawner(MockSpawner):
 
     def start(self):
         raise RuntimeError("I don't work!")
+
+
+class CustomBadSpawner(MockSpawner):
+    """Spawner that fails immediately"""
+
+    status_code = Integer(418, config=True)
+    message = Unicode("custom message", config=True)
+    reason = Unicode("custom reason", config=True)
+
+    def start(self):
+        raise SpawnException(
+            self.message, reason=self.reason, status_code=self.status_code
+        )
 
 
 class SlowBadSpawner(MockSpawner):

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -22,6 +22,7 @@ import jupyterhub
 from .. import orm
 from ..apihandlers.base import PAGINATION_MEDIA_TYPE
 from ..objects import Server
+from ..spawner import SpawnException
 from ..utils import url_path_join as ujoin
 from ..utils import utcnow
 from .conftest import new_username
@@ -1259,19 +1260,46 @@ async def test_spawn_error_log(app, bad_spawn, caplog):
     def pre_spawn_http(spawner):
         raise HTTPError(418, "Teapot alert!")
 
+    def pre_spawn_custom(spawner):
+        raise SpawnException("Your fault", reason="custom", status_code=410)
+
+    def pre_spawn_custom_log(spawner):
+        raise SpawnException(
+            "Your fault 2", reason="custom2", status_code=411, log_message="Custom Log!"
+        )
+
     def pre_spawn_unhandled(spawner):
         raise ValueError("Not on my watch")
 
+    caplog.clear()
     with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": pre_spawn_http}):
         r = await api_request(app, 'users', name, 'server', method='post')
     assert r.status_code == 418
     assert "Traceback" not in caplog.text
     assert r.json() == {"status": 418, "message": "Teapot alert!"}
 
+    caplog.clear()
+    with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": pre_spawn_custom}):
+        r = await api_request(app, 'users', name, 'server', method='post')
+    assert r.status_code == 410
+    assert "Traceback" not in caplog.text
+    assert "Your fault" in caplog.text
+    assert r.json() == {"status": 410, "message": "Your fault"}
+
+    caplog.clear()
+    with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": pre_spawn_custom_log}):
+        r = await api_request(app, 'users', name, 'server', method='post')
+    assert r.status_code == 411
+    assert "Traceback" not in caplog.text
+    assert "Custom Log!" in caplog.text
+    assert "Your fault" not in caplog.text
+    assert r.json() == {"status": 411, "message": "Your fault 2"}
+
+    caplog.clear()
     with mock.patch.dict(app.config.Spawner, {"pre_spawn_hook": pre_spawn_unhandled}):
         r = await api_request(app, 'users', name, 'server', method='post')
     assert r.status_code == 500
-    assert r.json() == {"status": 500, "message": "error"}
+    assert r.json() == {"status": 500, "message": "Internal Server Error"}
     # unhandled error logs a traceback
     assert "Traceback" in caplog.text
     # unhandled error logs a traceback

--- a/jupyterhub/user.py
+++ b/jupyterhub/user.py
@@ -17,7 +17,7 @@ from .crypto import CryptKeeper, EncryptionUnavailable, InvalidToken, decrypt, e
 from .metrics import RUNNING_SERVERS, TOTAL_USERS
 from .objects import Server
 from .slugs import is_valid_display_name, is_valid_safe_slug
-from .spawner import LocalProcessSpawner
+from .spawner import LocalProcessSpawner, SpawnException
 from .utils import (
     AnyTimeoutError,
     _strict_dns_safe,
@@ -1058,6 +1058,8 @@ class User:
                     f"\n{start_timeout_message}"
                 )
                 e.reason = 'timeout'
+            elif isinstance(e, SpawnException):
+                self.log.error(f"Not starting {self.name}'s server {spawner.name}: {e}")
             elif isinstance(e, web.HTTPError):
                 # avoid logging noisy traceback on HTTPError,
                 # since this should be informative and will be relayed to the user


### PR DESCRIPTION
adds `jupyterhub.spawner.SpawnException`, and updates the server spawn prometheus metric for more fine-grained control

- prometheus metric gets separate `error` and `failure` status values, instead of just `failure`. `error` is for unhandled errors (like timeouts), where `failure` is for rejections, such as explicitly raised `HTTPError(400)` or the new `SpawnException`.
  - Built-in failures include exceeding quotas, already pending launches
  - Built-in errors include timeouts
- metric also gets a `reason` label to differentiate rejection reasons, so a deployment can categorize rejected launches better
- `SpawnException` has separate fields for http status, reason user-facing message, html message, and log message. Pretty much all of which were technically achievable  through our `.jupyterhub_message` attributes, but not as clean as a dedicated exception class
- SpawnException should never trigger a logged traceback

closes #5357 
