### PR TITLE
Require tornado 6.5

### DIFF
--- a/ci/oldest-dependencies/oldest-dependencies.txt
+++ b/ci/oldest-dependencies/oldest-dependencies.txt
@@ -1,11 +1,13 @@
 alembic==1.4
 certipy==0.1.2
 jinja2==2.11.0
+jupyter_events==0.11.0
 oauthlib==3.0
 pamela==1.1.0; sys_platform != 'win32'
 prometheus_client==0.5.0
 psutil==5.6.5; sys_platform == 'win32'
 pydantic==2
+pyopenssl==25.*
 SQLAlchemy==1.4.1
-tornado==6.1
+tornado==6.2
 traitlets==5.4

--- a/ci/oldest-dependencies/oldest-dependencies.txt
+++ b/ci/oldest-dependencies/oldest-dependencies.txt
@@ -9,5 +9,5 @@ psutil==5.6.5; sys_platform == 'win32'
 pydantic==2
 pyopenssl==25.*
 SQLAlchemy==1.4.1
-tornado==6.2
+tornado==6.5
 traitlets==5.4

--- a/ci/oldest-dependencies/requirements.old
+++ b/ci/oldest-dependencies/requirements.old
@@ -8,143 +8,196 @@ alembic==1.4.0
     # via -r oldest-dependencies.txt
 annotated-types==0.7.0
     # via pydantic
+anyio==3.7.1
+    # via jupyter-server
 argon2-cffi==25.1.0
-    # via notebook
+    # via
+    #   jupyter-server
+    #   notebook
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
-attrs==25.3.0
+arrow==1.4.0
+    # via isoduration
+asttokens==3.0.2
+    # via stack-data
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-backcall==0.2.0
-    # via ipython
 backports-asyncio-runner==1.2.0
     # via pytest-asyncio
-beautifulsoup4==4.14.2
-    # via -r requirements.in
-bleach==6.2.0
+beautifulsoup4==4.15.0
+    # via
+    #   -r requirements.in
+    #   nbconvert
+bleach==6.4.0
     # via nbconvert
-certifi==2025.8.3
+certifi==2026.6.17
     # via requests
 certipy==0.1.2
     # via -r oldest-dependencies.txt
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   argon2-cffi-bindings
     #   cryptography
-charset-normalizer==3.4.3
+charset-normalizer==3.4.9
     # via requests
-coverage[toml]==7.10.7
+comm==0.2.3
+    # via ipykernel
+coverage[toml]==7.15.2
     # via
     #   -r requirements.in
     #   pytest-cov
-cryptography==46.0.2
+cryptography==46.0.7
     # via pyopenssl
-debugpy==1.8.17
+debugpy==1.8.21
     # via ipykernel
-decorator==5.2.1
+decorator==5.3.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
 entrypoints==0.4
     # via
     #   jupyter-client
     #   nbconvert
-exceptiongroup==1.3.0
-    # via pytest
+exceptiongroup==1.3.1
+    # via
+    #   anyio
+    #   ipython
+    #   pytest
+executing==2.2.1
+    # via stack-data
 fastjsonschema==2.21.2
     # via nbformat
-filelock==3.19.1
-    # via virtualenv
-greenlet==3.2.4
+filelock==3.30.3
+    # via
+    #   python-discovery
+    #   virtualenv
+fqdn==1.5.1
+    # via jsonschema
+greenlet==3.5.3
     # via
     #   playwright
     #   sqlalchemy
-idna==3.10
-    # via requests
-iniconfig==2.1.0
+idna==3.18
+    # via
+    #   anyio
+    #   jsonschema
+    #   requests
+iniconfig==2.3.0
     # via pytest
-ipykernel==6.4.2
-    # via notebook
-ipython==7.34.0
+ipykernel==6.29.5
+    # via
+    #   nbclassic
+    #   notebook
+ipython==8.21.0
     # via ipykernel
 ipython-genutils==0.2.0
     # via
-    #   ipykernel
+    #   nbclassic
     #   notebook
-jedi==0.19.2
+isoduration==20.11.0
+    # via jsonschema
+jedi==0.20.0
     # via ipython
 jinja2==2.11.0
     # via
     #   -r oldest-dependencies.txt
+    #   jupyter-server
     #   nbconvert
     #   notebook
-jsonschema==4.25.1
-    # via nbformat
+jsonpointer==3.1.1
+    # via jsonschema
+jsonschema[format-nongpl]==4.26.0
+    # via
+    #   jupyter-events
+    #   nbformat
 jsonschema-specifications==2025.9.1
     # via jsonschema
-jupyter-client==7.2.0
+jupyter-client==7.3.4
     # via
     #   ipykernel
+    #   jupyter-server
     #   nbclient
     #   notebook
-jupyter-core==5.0.0
+jupyter-core==5.9.1
     # via
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
     #   nbconvert
     #   nbformat
     #   notebook
+jupyter-events==0.11.0
+    # via -r oldest-dependencies.txt
+jupyter-server==1.24.0
+    # via notebook-shim
 jupyterlab-pygments==0.3.0
     # via nbconvert
-mako==1.3.10
+lark==1.3.1
+    # via rfc3987-syntax
+mako==1.3.12
     # via alembic
 markupsafe==2.0.1
     # via
     #   -r requirements.in
     #   jinja2
     #   mako
-matplotlib-inline==0.1.7
+    #   nbconvert
+matplotlib-inline==0.2.2
     # via
     #   ipykernel
     #   ipython
 mistune==0.8.4
     # via nbconvert
-nbclient==0.5.11
-    # via nbconvert
-nbconvert==6.0.7
+nbclassic==1.3.3
     # via notebook
-nbformat==5.3.0
+nbclient==0.5.13
+    # via nbconvert
+nbconvert==6.4.5
     # via
+    #   jupyter-server
+    #   notebook
+nbformat==5.10.4
+    # via
+    #   jupyter-server
     #   nbclient
     #   nbconvert
     #   notebook
 nest-asyncio==1.6.0
     # via
+    #   ipykernel
     #   jupyter-client
+    #   nbclassic
     #   nbclient
-notebook==6.1.6
+    #   notebook
+notebook==6.5.7
     # via -r requirements.in
+notebook-shim==0.2.4
+    # via nbclassic
 oauthlib==3.0.0
     # via -r oldest-dependencies.txt
-packaging==25.0
-    # via pytest
+packaging==26.2
+    # via
+    #   ipykernel
+    #   jupyter-server
+    #   pytest
 pamela==1.1.0 ; sys_platform != "win32"
     # via -r oldest-dependencies.txt
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.5
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
-pickleshare==0.7.5
-    # via ipython
-platformdirs==4.4.0
+platformdirs==4.10.0
     # via
     #   jupyter-core
+    #   python-discovery
     #   virtualenv
-playwright==1.55.0
+playwright==1.61.0
     # via -r requirements.in
 pluggy==1.6.0
     # via
@@ -153,28 +206,35 @@ pluggy==1.6.0
 prometheus-client==0.5.0
     # via
     #   -r oldest-dependencies.txt
+    #   jupyter-server
     #   notebook
 prompt-toolkit==3.0.52
     # via ipython
+psutil==7.2.2
+    # via ipykernel
 ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-pycparser==2.23
+pure-eval==0.2.3
+    # via stack-data
+pycparser==3.0
     # via cffi
 pydantic==2.0
     # via -r oldest-dependencies.txt
 pydantic-core==2.0.1
     # via pydantic
-pyee==13.0.0
+pyee==13.0.1
     # via playwright
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   ipython
     #   nbconvert
     #   pytest
 pyopenssl==25.3.0
-    # via certipy
+    # via
+    #   -r oldest-dependencies.txt
+    #   certipy
 pytest==8.4.2
     # via
     #   -r requirements.in
@@ -182,53 +242,84 @@ pytest==8.4.2
     #   pytest-cov
 pytest-asyncio==1.1.1
     # via -r requirements.in
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   alembic
+    #   arrow
     #   jupyter-client
+python-discovery==1.4.4
+    # via virtualenv
 python-editor==1.0.4
     # via alembic
+python-json-logger==4.1.0
+    # via jupyter-events
+pyyaml==6.0.3
+    # via jupyter-events
 pyzmq==27.1.0
     # via
+    #   ipykernel
     #   jupyter-client
+    #   jupyter-server
     #   notebook
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+    #   jupyter-events
+requests==2.34.2
     # via requests-mock
 requests-mock==1.12.1
     # via -r requirements.in
-rpds-py==0.27.1
+rfc3339-validator==0.1.4
+    # via
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   jsonschema
+    #   jupyter-events
+rfc3987-syntax==1.1.0
+    # via jsonschema
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-send2trash==1.8.3
-    # via notebook
+send2trash==2.1.0
+    # via
+    #   jupyter-server
+    #   notebook
 six==1.17.0
-    # via python-dateutil
-soupsieve==2.8
+    # via
+    #   python-dateutil
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via anyio
+soupsieve==2.8.4
     # via beautifulsoup4
 sqlalchemy==1.4.1
     # via
     #   -r oldest-dependencies.txt
     #   alembic
-terminado==0.13.3
-    # via notebook
+stack-data==0.6.3
+    # via ipython
+terminado==0.18.1
+    # via
+    #   jupyter-server
+    #   notebook
 testpath==0.6.0
     # via nbconvert
-tomli==2.2.1
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
-tornado==6.1
+tornado==6.2
     # via
     #   -r oldest-dependencies.txt
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
     #   notebook
     #   terminado
 traitlets==5.4.0
@@ -238,12 +329,14 @@ traitlets==5.4.0
     #   ipython
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
     #   matplotlib-inline
     #   nbclient
     #   nbconvert
     #   nbformat
     #   notebook
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   beautifulsoup4
     #   cryptography
@@ -254,14 +347,19 @@ typing-extensions==4.15.0
     #   pyopenssl
     #   referencing
     #   virtualenv
-urllib3==2.5.0
+tzdata==2026.3
+    # via arrow
+uri-template==1.3.0
+    # via jsonschema
+urllib3==2.7.0
     # via requests
-virtualenv==20.34.0
+virtualenv==21.6.1
     # via -r requirements.in
-wcwidth==0.2.14
+wcwidth==0.8.2
     # via prompt-toolkit
+webcolors==25.10.0
+    # via jsonschema
 webencodings==0.5.1
     # via bleach
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+websocket-client==1.9.0
+    # via jupyter-server

--- a/ci/oldest-dependencies/requirements.old
+++ b/ci/oldest-dependencies/requirements.old
@@ -314,7 +314,7 @@ tomli==2.4.1
     # via
     #   coverage
     #   pytest
-tornado==6.2
+tornado==6.5
     # via
     #   -r oldest-dependencies.txt
     #   ipykernel

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -37,7 +37,7 @@ from urllib.parse import (
 
 import idna
 from sqlalchemy.exc import SQLAlchemyError
-from tornado import gen, ioloop, web
+from tornado import ioloop, web
 from tornado.httpclient import AsyncHTTPClient, HTTPError, HTTPRequest, HTTPResponse
 from tornado.log import app_log
 from tornado.netutil import Resolver

--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -278,8 +278,13 @@ def make_ssl_context(
     return ssl_context
 
 
-# AnyTimeoutError catches TimeoutErrors coming from asyncio, tornado, stdlib
-AnyTimeoutError = (gen.TimeoutError, asyncio.TimeoutError, TimeoutError)
+# AnyTimeoutError catches TimeoutErrors coming from asyncio, aiohttp, tornado, stdlib
+# with recent versions, these are all aliases for the stdlib TimeoutError
+# starting with Python 3.11, asyncio.TimeoutError is a deprecated alias for base TimeoutError
+if sys.version_info >= (3, 11):
+    AnyTimeoutError = (TimeoutError,)
+else:
+    AnyTimeoutError = (asyncio.TimeoutError, TimeoutError)
 
 
 async def exponential_backoff(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pydantic>=2
 python-dateutil
 requests
 SQLAlchemy>=1.4.1
-tornado>=6.1
+tornado>=6.2
 traitlets>=5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pydantic>=2
 python-dateutil
 requests
 SQLAlchemy>=1.4.1
-tornado>=6.2
+tornado>=6.5
 traitlets>=5.4


### PR DESCRIPTION
<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->
### Checklist

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

Extracted from #5447 which requires tornado 6.2 because #5464 actually requires tornado 6.5.

Mainly this simplifies some of our code related to TimeoutErrors because tornado 6.2 aliases its TimeoutError to `asyncio.TimeoutError`. Tornado 6.5 is required in #5464 to access the `HTTPError.get_message()` method.

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->
A tiny breaking change bumping the minimum tornado version to 6.5 from 6.1. No supported environments should see any effect. If anyone is stuck on outdated tornado, it doesn't make sense to upgrade jupyterhub.

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->
run the tests (check the `oldest-dependencies` test)

### What should a reviewer concentrate their feedback on?

checking the date of tornado 6.5 (May, 2025), and required Python (3.9)

### Other information

Needed for #5447 and #5464, but isolated as its own PR.