### PR TITLE
Populate auth state in the self API response

### DIFF
--- a/jupyterhub/apihandlers/users.py
+++ b/jupyterhub/apihandlers/users.py
@@ -62,6 +62,8 @@ class SelfAPIHandler(APIHandler):
             self.parsed_scopes = scopes.parse_scopes(self.expanded_scopes)
 
         model = get_model(user)
+        if 'auth_state' in model:
+            model['auth_state'] = await user.get_auth_state()
 
         # add session_id associated with token
         # added in 2.0

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -657,6 +657,23 @@ async def test_get_self(app):
     assert r.status_code == 403
 
 
+@mark.user
+async def test_get_self_auth_state(app, auth_state_enabled, create_user_with_scopes):
+    auth_state = {'access_token': 'secret'}
+    user = create_user_with_scopes('admin:auth_state!user')
+    await user.save_auth_state(auth_state)
+    token = user.new_api_token()
+
+    r = await api_request(
+        app,
+        'user',
+        headers={'Authorization': f'token {token}'},
+    )
+
+    r.raise_for_status()
+    assert r.json()['auth_state'] == auth_state
+
+
 async def test_get_self_service(app, mockservice):
     r = await api_request(
         app, "user", headers={"Authorization": f"token {mockservice.api_token}"}


### PR DESCRIPTION
Fixes #5103.

## Summary

- populate `auth_state` in the self API response when the token's scopes include it
- preserve the existing scope filter so unprivileged tokens do not load or expose auth state
- cover the scoped self-response path with a regression test

## Root cause

`SelfAPIHandler` used the synchronous user model directly. That model intentionally contains only an `auth_state` placeholder because loading encrypted auth state is asynchronous. The named-user endpoint replaces the placeholder before responding, but the self endpoint did not, so authorized callers always received `null`.

## Validation

- direct async handler regression for both scoped and unscoped models
- `python -m pytest jupyterhub/tests/test_api.py::test_get_self_auth_state --collect-only -q`
- `python -m compileall -q jupyterhub/apihandlers/users.py jupyterhub/tests/test_api.py`
- Black, isort, Ruff, and `git diff --check` on the changed files
