### PR TITLE
retry client connector error in proxy

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -27,7 +27,7 @@ from subprocess import Popen
 from urllib.parse import quote, unquote, urlparse
 from weakref import WeakKeyDictionary
 
-from aiohttp import ClientResponseError
+from aiohttp import ClientConnectorError, ClientResponseError
 from tornado.ioloop import PeriodicCallback
 from traitlets import (
     Any,
@@ -970,6 +970,11 @@ class ConfigurableHTTPProxy(Proxy):
                         headers={'Authorization': f'token {self.auth_token}'},
                         data=body,
                     )
+            except ClientConnectorError as e:
+                self.log.warning(
+                    f"api_request to the proxy failed with connection error {e}, retrying..."
+                )
+                return False  # a falsy return value make exponential_backoff retry
             except ClientResponseError as e:
                 # Retry on potentially transient errors in CHP, typically
                 # numbered 500 and up. Note that CHP isn't able to emit 429

--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -27,7 +27,7 @@ from subprocess import Popen
 from urllib.parse import quote, unquote, urlparse
 from weakref import WeakKeyDictionary
 
-from aiohttp import ClientConnectorError, ClientResponseError
+from aiohttp import ClientConnectionError, ClientResponseError
 from tornado.ioloop import PeriodicCallback
 from traitlets import (
     Any,
@@ -970,7 +970,7 @@ class ConfigurableHTTPProxy(Proxy):
                         headers={'Authorization': f'token {self.auth_token}'},
                         data=body,
                     )
-            except ClientConnectorError as e:
+            except ClientConnectionError as e:
                 self.log.warning(
                     f"api_request to the proxy failed with connection error {e}, retrying..."
                 )


### PR DESCRIPTION
already handled in wait_for_http_server

<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

fixes fatal error connecting to proxy if it hasn't started listening yet, because we only caught ClientResponseError
This is a regression in the aiohttp changes because the shape of the exception classes has changed from the tornado version.

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3960#issuecomment-5283794111

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

no

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->

start jupyterhub before a proxy and make sure it doesn't crash out right away

### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
You can use bullet points "-" if it helps.
-->

### Other information
<!--
Please provide any other information you think is relevant
-->
