### PR TITLE
make sure user_info is persisted

### DIFF
--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -942,6 +942,8 @@ class BaseHandler(RequestHandler):
         # Only set `admin` if the authenticator returned an explicit value.
         if admin is not None and admin != user.admin:
             user.admin = admin
+        if user_info is not None:
+            user.user_info = user_info
         # always ensure default roles ('user', 'admin' if admin) are assigned
         # after a successful login
         roles.assign_default_roles(self.db, entity=user)

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -431,6 +431,34 @@ async def test_auth_state_disabled(app, auth_state_unavailable):
     assert auth_state is None
 
 
+@pytest.mark.parametrize(
+    "user_info, ok",
+    [
+        pytest.param(None, None, id="None"),
+        pytest.param({"key": "value"}, True, id="dict"),
+        pytest.param({}, True, id="empty dict"),
+        pytest.param(object(), False, id="not JSONable"),
+    ],
+)
+async def test_auth_user_info(app, user, user_info, ok):
+    async def mock_authenticate(handler, data):
+        authenticated = {
+            "name": data["username"],
+            "user_info": user_info,
+        }
+        if user_info is not None:
+            authenticated["user_info"] = user_info
+        return authenticated
+
+    with mock.patch.object(app.authenticator, 'authenticate', mock_authenticate):
+        await app.login_user(user.name)
+    app.db.expire(user.orm_user)
+    if ok:
+        assert user.orm_user.user_info == user_info
+    else:
+        assert user.orm_user.user_info is None
+
+
 async def test_normalize_names():
     a = MockPAMAuthenticator(allow_all=True)
     authorized = await a.get_authenticated_user(

--- a/jupyterhub/tests/test_auth.py
+++ b/jupyterhub/tests/test_auth.py
@@ -444,7 +444,6 @@ async def test_auth_user_info(app, user, user_info, ok):
     async def mock_authenticate(handler, data):
         authenticated = {
             "name": data["username"],
-            "user_info": user_info,
         }
         if user_info is not None:
             authenticated["user_info"] = user_info


### PR DESCRIPTION
and add missing test coverage

<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

There was a missing step in actually assigning `user_info` to the orm.User  object so it gets persisted.

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

Fixes #5496 

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

no

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->

test coverage is in the PR

### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
You can use bullet points "-" if it helps.
-->

verifying test coverage

### Other information
<!--
Please provide any other information you think is relevant
-->

there were tests for this functionality, but they were a little to unit-testy, and only covered returning user_info from authenticate, not persisting it to the db.

