### PR TITLE
Add Authenticator.auth_refresh_strict

### DIFF
--- a/jupyterhub/auth.py
+++ b/jupyterhub/auth.py
@@ -88,6 +88,34 @@ class Authenticator(LoggingConfigurable):
         """,
     )
 
+    auth_refresh_strict = Bool(
+        False,
+        config=True,
+        help="""
+
+        When refresh_user would be called (refresh_pre_spawn, auth_refresh_age),
+        not all requests can be redirected to a login, such as:
+
+        - token-authenticated API requests
+        - admin spawn of other users' servers
+
+        If a user's auth state is stale and cannot be refreshed (e.g. missing or outdated oauth token),
+        these actions cannot be taken until the user logs in again.
+
+        Since auth state is unlikely to be invalid, forcing a refresh when it cannot be refreshed
+        is often counterproductive.
+        
+        However, if auth freshness is strictly required, this can be set to True,
+        in which case admin spawns for other users, or even API requests from users' own servers
+        will fail until the user completes a fresh login.
+
+        .. versionadded:: 6.0
+            Prior to 6.0, the behavior was the same as `Authenticator.auth_refresh_strict = True`.
+            6.0 adds this configuration and makes it False by default,
+            due to the problems seen when it is True.
+        """,
+    )
+
     refresh_pre_spawn = Bool(
         False,
         config=True,

--- a/jupyterhub/handlers/base.py
+++ b/jupyterhub/handlers/base.py
@@ -419,10 +419,37 @@ class BaseHandler(RequestHandler):
         auth_info = await self.authenticator.refresh_user(user, self)
 
         if not auth_info:
-            self.log.warning(
-                "User %s has stale auth info. Login is required to refresh.", user.name
-            )
-            return
+            # refresh failed, what do we do?
+            # if it's a cookie-authenticated, we can force a fresh login
+            # if it's token-authenticated OR the request is another user, we can't.
+            # In these cases, keep using the stale auth until the user makes a cookie-authenticated request.
+
+            if self._jupyterhub_user is user and (not self._token_authenticated):
+                self.log.warning(
+                    "User %s has stale auth info. Login is required to refresh.",
+                    user.name,
+                )
+                return None
+            else:
+                # cannot force login, avoid shutting down admin spawn or API access,
+                # which cannot meaningfully be refreshed
+                if self._token_authenticated:
+                    self.log.warning(
+                        "User %s has stale auth info. Cannot refresh on API requests.",
+                        user.name,
+                    )
+                if self._jupyterhub_user is not user:
+                    self.log.warning(
+                        "User %s has stale auth info. Request is made by %s, cannot refresh on cross-user requests.",
+                        user.name,
+                        self._jupyterhub_user.name,
+                    )
+
+                if self.authenticator.auth_refresh_strict:
+                    # strict refresh, don't allow
+                    return None
+                else:
+                    return user
 
         user._auth_refreshed = now
 
@@ -528,6 +555,9 @@ class BaseHandler(RequestHandler):
                 if user is None and self._accept_cookie_auth:
                     user = self.get_current_user_cookie()
                 if user and isinstance(user, User):
+                    # set self._jupyterhub_user so it can be checked in refresh_auth
+                    # it will be set again immediately after
+                    self._jupyterhub_user = user
                     user = await self.refresh_auth(user)
                 self._jupyterhub_user = user
             except Exception:

--- a/jupyterhub/tests/test_auth_expiry.py
+++ b/jupyterhub/tests/test_auth_expiry.py
@@ -45,6 +45,18 @@ def refresh_pre_stop(app):
     app.authenticator.refresh_pre_stop = False
 
 
+@pytest.fixture(params=[True, False])
+def auth_refresh_strict(request, app):
+    """parametrise auth_refresh_strict
+
+    for testing both enabled and disabled behavior
+    """
+    before = app.authenticator.auth_refresh_strict
+    app.authenticator.auth_refresh_strict = request.param
+    yield request.param
+    app.authenticator.auth_refresh_strict = before
+
+
 async def test_auth_refresh_at_login(app, user):
     # auth_refreshed starts unset:
     assert not user._auth_refreshed
@@ -107,16 +119,8 @@ async def test_auth_expired_page(app, user, disable_refresh):
     assert user._auth_refreshed == before
 
 
-@pytest.mark.parametrize(
-    "auth_refresh_strict, status",
-    [
-        (True, 403),
-        (False, 200),
-    ],
-)
-async def test_auth_expired_api(
-    app, user, disable_refresh, auth_refresh_strict, status
-):
+async def test_auth_expired_api(app, user, disable_refresh, auth_refresh_strict):
+
     cookies = await app.login_user(user.name)
     assert user._auth_refreshed
     user._auth_refreshed -= 10
@@ -127,17 +131,9 @@ async def test_auth_expired_api(
     assert user._auth_refreshed == before
     assert r.status_code == 200
 
-    # get a page with stale auth, triggers expiry
-    # can't do a regular mock.patch on traits, must patch the descriptor
-    with mock.patch.object(
-        app.authenticator.__class__,
-        "auth_refresh_strict",
-        new_callable=mock.PropertyMock,
-    ) as patched:
-        patched.return_value = auth_refresh_strict
-
-        user._auth_refreshed -= app.authenticator.auth_refresh_age
-        r = await api_request(app, 'users/' + user.name, name=user.name)
+    user._auth_refreshed -= app.authenticator.auth_refresh_age
+    r = await api_request(app, 'users/' + user.name, name=user.name)
+    status = 403 if auth_refresh_strict else 200
     # api requests can't do login redirects
     assert r.status_code == status
 
@@ -156,7 +152,9 @@ async def test_refresh_pre_spawn(app, user, refresh_pre_spawn):
     assert user._auth_refreshed > before
 
 
-async def test_refresh_pre_spawn_expired(app, user, refresh_pre_spawn, disable_refresh):
+async def test_refresh_pre_spawn_expired(
+    app, user, refresh_pre_spawn, disable_refresh, auth_refresh_strict
+):
     cookies = await app.login_user(user.name)
     assert user._auth_refreshed
     user._auth_refreshed -= 10
@@ -166,7 +164,10 @@ async def test_refresh_pre_spawn_expired(app, user, refresh_pre_spawn, disable_r
     r = await api_request(
         app, f'users/{user.name}/server', method='post', name=user.name
     )
-    assert r.status_code == 403
+    if auth_refresh_strict:
+        assert r.status_code == 403
+    else:
+        assert 200 <= r.status_code < 300
     assert user._auth_refreshed == before
 
 
@@ -187,7 +188,7 @@ async def test_refresh_pre_spawn_admin_request(
 
 
 async def test_refresh_pre_spawn_expired_admin_request(
-    app, user, admin_user, refresh_pre_spawn, disable_refresh
+    app, user, admin_user, refresh_pre_spawn, disable_refresh, auth_refresh_strict
 ):
     await app.login_user(user.name)
     await app.login_user(admin_user.name)
@@ -195,11 +196,17 @@ async def test_refresh_pre_spawn_expired_admin_request(
 
     # auth needs refresh but can't without a new login; spawn should fail
     user._auth_refreshed -= app.authenticator.auth_refresh_age
+    before = user._auth_refreshed
     r = await api_request(
         app, 'users', user.name, 'server', method='post', name=admin_user.name
     )
-    # api requests can't do login redirects
-    assert r.status_code == 403
+    # api requests can't do login redirects,
+    # but admin launches are still allowed unless auth_refresh_strict
+    if auth_refresh_strict:
+        assert r.status_code == 403
+    else:
+        assert 200 <= r.status_code < 300
+    assert user._auth_refreshed == before
 
 
 async def test_refresh_pre_stop(app, user, refresh_pre_stop):
@@ -223,7 +230,9 @@ async def test_refresh_pre_stop(app, user, refresh_pre_stop):
     assert user._auth_refreshed > before
 
 
-async def test_refresh_pre_stop_expired(app, user, refresh_pre_stop, disable_refresh):
+async def test_refresh_pre_stop_expired(
+    app, user, refresh_pre_stop, disable_refresh, auth_refresh_strict
+):
     cookies = await app.login_user(user.name)
     assert user._auth_refreshed
     user._auth_refreshed -= 10
@@ -239,7 +248,10 @@ async def test_refresh_pre_stop_expired(app, user, refresh_pre_stop, disable_ref
     r = await api_request(
         app, f'users/{user.name}/server', method='delete', name=user.name
     )
-    assert r.status_code == 403
+    if auth_refresh_strict:
+        assert r.status_code == 403
+    else:
+        assert 200 <= r.status_code < 300
     assert user._auth_refreshed == before
 
 

--- a/jupyterhub/tests/test_auth_expiry.py
+++ b/jupyterhub/tests/test_auth_expiry.py
@@ -107,7 +107,16 @@ async def test_auth_expired_page(app, user, disable_refresh):
     assert user._auth_refreshed == before
 
 
-async def test_auth_expired_api(app, user, disable_refresh):
+@pytest.mark.parametrize(
+    "auth_refresh_strict, status",
+    [
+        (True, 403),
+        (False, 200),
+    ],
+)
+async def test_auth_expired_api(
+    app, user, disable_refresh, auth_refresh_strict, status
+):
     cookies = await app.login_user(user.name)
     assert user._auth_refreshed
     user._auth_refreshed -= 10
@@ -119,10 +128,18 @@ async def test_auth_expired_api(app, user, disable_refresh):
     assert r.status_code == 200
 
     # get a page with stale auth, triggers expiry
-    user._auth_refreshed -= app.authenticator.auth_refresh_age
-    r = await api_request(app, 'users/' + user.name, name=user.name)
+    # can't do a regular mock.patch on traits, must patch the descriptor
+    with mock.patch.object(
+        app.authenticator.__class__,
+        "auth_refresh_strict",
+        new_callable=mock.PropertyMock,
+    ) as patched:
+        patched.return_value = auth_refresh_strict
+
+        user._auth_refreshed -= app.authenticator.auth_refresh_age
+        r = await api_request(app, 'users/' + user.name, name=user.name)
     # api requests can't do login redirects
-    assert r.status_code == 403
+    assert r.status_code == status
 
 
 async def test_refresh_pre_spawn(app, user, refresh_pre_spawn):


### PR DESCRIPTION
<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

opt-in to strict refresh auth enforcement

new default: do not trigger forced login when it can't work (token-authenticated api requests and auth as different user, e.g. admin spawn)

avoids breakage when auth is stale and cannot be refreshed

Background: refresh_user is meant to trigger a fresh login if auth state is stale. This only makes sense if the request triggering the refresh is a regular browser visit from the user being refreshed. Two categories of request:

1. API requests that cannot be redirected to login
2. requests authenticated as a different user (e.g. admin spawn)

_cannot_ trigger a fresh login. When these events occur:

- no API requests with tokens owned by the user can make requests (this includes checking auth for singleuser servers and activity updates for singleuser servers)
- admins cannot launch user servers
- there is no recourse available to admins to refresh auth other than asking the user to login again


### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

This is something of a redo of https://github.com/jupyterhub/jupyterhub/pull/4963 but a little more general.

Also related:

- https://github.com/jupyterhub/oauthenticator/pull/780
- https://github.com/jupyterhub/oauthenticator/issues/829
- https://github.com/jupyterhub/oauthenticator/pull/579
- https://github.com/jupyterhub/jupyterhub/pull/4947



### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

Not really, but it could be considered breaking that requests that were previously rejected due to stale auth (e.g. user activity requests from the user server) will not be rejected anymore. These requests have been spuriously rejected in a lot of situations after OAuthenticator 17.2 implemented refresh. Every time this has come up, the issue has been that it should have been accepted rather than rejected, so I don't consider this breaking.

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->

I still need to write a test

### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
You can use bullet points "-" if it helps.
-->

Whether this is the right thing to do, and/or if configuration should be expressed differently (e.g. separate strict setting for api requests and refresh_pre_spawn, add second timeout for enforcing refreshed auth, try to tackle this in OAuthenticator somehow)

### Other information
<!--
Please provide any other information you think is relevant
-->
