### PR TITLE
Fix ConfigurableHTTPProxy binding to hostname instead of wildcard address

### DIFF
--- a/jupyterhub/proxy.py
+++ b/jupyterhub/proxy.py
@@ -741,7 +741,7 @@ class ConfigurableHTTPProxy(Proxy):
         else:
             server_args = (
                 '--ip',
-                proxy_server.connect_addr,
+                proxy_server.ip,
                 '--port',
                 str(proxy_server.port),
             )
@@ -755,7 +755,7 @@ class ConfigurableHTTPProxy(Proxy):
         else:
             api_args = (
                 '--api-ip',
-                api_server.connect_addr,
+                api_server.ip,
                 '--api-port',
                 str(api_server.port),
             )

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -170,7 +170,7 @@ async def test_external_proxy(request):
 
 
 @pytest.mark.parametrize("bind_ip", ['0.0.0.0', '::', ''])
-async def test_proxy_wildcard_bind_ip(bind_ip):
+async def test_proxy_wildcard_bind_ip(bind_ip, tmp_path):
     """configurable-http-proxy must be launched with the configured bind
     address, not the address clients should use to connect to it.
 
@@ -180,6 +180,9 @@ async def test_proxy_wildcard_bind_ip(bind_ip):
         public_url=f'http://{fmt_ip_url(bind_ip)}:{random_port()}',
         api_url=f'http://{fmt_ip_url(bind_ip)}:{random_port()}',
         auth_token='test-token',
+        # isolate the pid file so parametrized runs (and other tests)
+        # can't collide on a leftover jupyterhub-proxy.pid in the cwd
+        pid_file=str(tmp_path / 'proxy.pid'),
         app=mock.Mock(subdomain_host='', internal_ssl=False),
     )
     proxy.hub = mock.Mock(url='http://127.0.0.1:8081')

--- a/jupyterhub/tests/test_proxy.py
+++ b/jupyterhub/tests/test_proxy.py
@@ -2,15 +2,19 @@
 
 import json
 import os
+import socket
 from contextlib import contextmanager
 from subprocess import Popen
+from unittest import mock
 from urllib.parse import quote, urlparse
 
 import pytest
 from traitlets import TraitError
 from traitlets.config import Config
 
-from ..utils import random_port
+from .. import proxy as proxymod
+from ..proxy import ConfigurableHTTPProxy
+from ..utils import fmt_ip_url, random_port
 from ..utils import url_path_join as ujoin
 from ..utils import wait_for_http_server
 from .mocking import MockHub
@@ -163,6 +167,45 @@ async def test_external_proxy(request):
     # check that the routes are correct
     routes = await app.proxy.get_all_routes()
     assert sorted(routes.keys()) == [app.hub.routespec, user_spec]
+
+
+@pytest.mark.parametrize("bind_ip", ['0.0.0.0', '::', ''])
+async def test_proxy_wildcard_bind_ip(bind_ip):
+    """configurable-http-proxy must be launched with the configured bind
+    address, not the address clients should use to connect to it.
+
+    Regression test for https://github.com/jupyterhub/jupyterhub/issues/5508
+    """
+    proxy = ConfigurableHTTPProxy(
+        public_url=f'http://{fmt_ip_url(bind_ip)}:{random_port()}',
+        api_url=f'http://{fmt_ip_url(bind_ip)}:{random_port()}',
+        auth_token='test-token',
+        app=mock.Mock(subdomain_host='', internal_ssl=False),
+    )
+    proxy.hub = mock.Mock(url='http://127.0.0.1:8081')
+
+    captured = {}
+
+    def mock_popen(cmd, **kwargs):
+        captured['cmd'] = cmd
+        proc = mock.Mock()
+        proc.pid = 1234
+        proc.poll.return_value = None
+        return proc
+
+    with (
+        mock.patch.object(proxymod, 'Popen', mock_popen),
+        mock.patch.object(
+            proxymod.Server, 'wait_up', mock.AsyncMock(return_value=True)
+        ),
+    ):
+        await proxy.start()
+
+    cmd = captured['cmd']
+    assert cmd[cmd.index('--ip') + 1] == bind_ip
+    assert cmd[cmd.index('--api-ip') + 1] == bind_ip
+    # must not have resolved the wildcard address to the local hostname
+    assert socket.gethostname() not in cmd
 
 
 @pytest.mark.parametrize("username", ['zoe', '50fia', '秀樹', '~TestJH', 'has@'])


### PR DESCRIPTION
## Summary

Fixes #5508.

`ConfigurableHTTPProxy.start()` launches `configurable-http-proxy` with
`--ip`/`--api-ip` set from `Server.connect_addr`. That property is meant
for *clients connecting to* the server, so for a wildcard bind address
(`0.0.0.0`, `::`, or `''`) it deliberately resolves to the local
hostname — correct for telling a client where to connect, wrong for
telling the proxy where to *bind*.

As a result, configuring a wildcard `JupyterHub.bind_url` (e.g.
`http://0.0.0.0:8000`) made the proxy listen only on whatever address
the machine's hostname resolves to (often a loopback alias like
`127.0.1.1`), instead of all interfaces.

This was introduced in #5397, which switched the TCP branch from
`public_server.ip`/`api_server.ip` to `proxy_server.connect_addr`/
`api_server.connect_addr` while adding Unix-socket support.

## Fix

Use `Server.ip` (the actual configured bind address) for the TCP
`--ip`/`--api-ip` arguments, keeping `connect_addr` only for the
Unix-socket branch it was introduced for.

## Testing

- Added `test_proxy_wildcard_bind_ip`, parametrized over `0.0.0.0`,
  `::`, and `''`, which mocks `Popen` to capture the actual command
  `ConfigurableHTTPProxy.start()` builds and asserts `--ip`/`--api-ip`
  match the configured bind address rather than `socket.gethostname()`.
- Confirmed the new test fails against the pre-fix code and passes
  after the fix, for all three wildcard forms.
- Ran the real `configurable-http-proxy` binary with each `--ip` value
  and inspected the actual listening socket: the pre-fix hostname value
  binds to a loopback-only address (reproducing the reported symptom
  exactly), while `0.0.0.0`/`''` after the fix bind to all interfaces.
- Full `test_proxy.py` + `test_objects.py` suite passes (40 passed, 2
  skipped, unrelated).
- `pre-commit run` (black, isort, flake8, pyupgrade, autoflake) passes
  on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)