### PR TITLE
Fix AttributeError on ClientOSError without os_error in wait_for_http_server

### DIFF
--- a/jupyterhub/utils.py
+++ b/jupyterhub/utils.py
@@ -337,7 +337,7 @@ async def wait_for_http_server(url, timeout=10, ssl_context=None):
             r = await fetch(url, raise_for_status=False, **request_args)
         except aiohttp.ClientOSError as e:
             # suppress expected "not there yet" errors
-            if e.os_error.errno not in {
+            if e.errno not in {
                 errno.ECONNABORTED,
                 errno.ECONNREFUSED,
                 errno.ECONNRESET,


### PR DESCRIPTION
## Summary

- `aiohttp.ClientOSError` does not always expose an `os_error` attribute — that property is only defined on its `ClientConnectorError` subclass. A bare `ClientOSError` can be raised directly on a mid-connection reset (e.g. when the Hub reaches a singleuser server through a NAT/port-forwarding layer, as `DockerSpawner` does via a Docker-published host port), and accessing `e.os_error.errno` in that case raises an unhandled `AttributeError` instead of the intended transient-error suppression, causing the Hub to treat the spawn as failed and tear down a container that was still starting up normally.
- `aiohttp.ClientOSError` itself subclasses `OSError`, and `ClientConnectorError.__init__` populates the standard `OSError` `errno`/`strerror` fields from the wrapped OS error, so `e.errno` is already available directly in both cases without going through `.os_error`.

Fixes #5514

## Test plan

- Reproduced the crash on a `DockerSpawner` deployment (Hub reaching the singleuser container through a Docker-published host port) where the container's startup window reliably raised a bare `ClientOSError` on connection reset, causing the traceback and premature container teardown described in #5514.
- Applied this one-line change and confirmed the server spawns successfully without the `AttributeError`, with the container allowed to finish starting normally.
